### PR TITLE
Modifying functionality for rocksdb.purge to use abstract method

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -25,18 +25,13 @@ import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
 import io.grpc.stub.StreamObserver;
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.text.DecimalFormat;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -96,14 +91,8 @@ public class RocksDBService extends AbstractFrontierService {
         LOG.info("RocksDB data stored in {} ", path);
 
         if (configuration.containsKey("rocksdb.purge")) {
-            try {
-                Files.walk(Paths.get(path))
-                        .sorted(Comparator.reverseOrder())
-                        .map(Path::toFile)
-                        .forEach(File::delete);
-            } catch (IOException e) {
-                LOG.error("Couldn't delete path {}", path);
-            }
+            createOrCleanDirectory(path);
+            LOG.info("Purged storage path {}", path);
         }
 
         if (configuration.containsKey("rocksdb.stats")) {


### PR DESCRIPTION
Analogously to PR #81 and issue #74 for the case of `ignite.purge`, the code for cleaning the storage directory for the flag `rocksdb.purge` is updated, so that it also uses the new abstract method `createOrCleanDirectory()`

Signed-off-by: Michael Dinzinger <michael.dinzinger@uni-passau.de>

Thanks for contributing to URL Frontier, your efforts are appreciated!

Developer Certificate of Origin
===============================

By contributing to URL Frontier, you accept and agree to the following terms and conditions (the *Developer Certificate of Origin*) for your present and future contributions submitted to URL Frontier. 
Please refer to the *Developer Certificate of Origin* section in [`CONTRIBUTING.md`](CONTRIBUTING.md) for details.

```
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

Before opening a PR, please check that: 

* You've squashed your commits into a single one
* You've described what the PR does or at least point to a related issue
* You've signed-ff your commits with 'git commit -s'


Thanks!
