### PR TITLE
Making the metrics variables for GetURLs protected

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -66,19 +66,19 @@ public abstract class AbstractFrontierService
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(AbstractFrontierService.class);
 
-    private static final Counter getURLs_calls =
+    protected static final Counter getURLs_calls =
             Counter.build()
                     .name("frontier_getURLs_calls_total")
                     .help("Number of times getURLs has been called.")
                     .register();
 
-    private static final Counter getURLs_urls_count =
+    protected static final Counter getURLs_urls_count =
             Counter.build()
                     .name("frontier_getURLs_total")
                     .help("Number of URLs returned.")
                     .register();
 
-    private static final Summary getURLs_Latency =
+    protected static final Summary getURLs_Latency =
             Summary.build()
                     .name("frontier_getURLs_latency_seconds")
                     .help("getURLs latency in seconds.")


### PR DESCRIPTION
Hello,

in an service implementation, which inherits from the abstract implementation of the FrontierService in this repository, we want to override the GetURLs method. Besides that, we want to use furtheron use the Prometheus metrics, which help to monitor the Frontier service and, among others, the number and latency of GetURLs calls. Therefore, it is necessary to make the three corresponding variables in AbstractFrontierService.java protected instead of private.
Thank you!