### PR TITLE
Added CloseableIterator interface

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -938,7 +938,7 @@ public abstract class AbstractFrontierService
                     continue;
                 }
 
-                Iterator<URLItem> urliter = urlIterator(e);
+                CloseableIterator<URLItem> urliter = urlIterator(e);
 
                 while (urliter.hasNext()) {
                     totalCount++;
@@ -951,17 +951,24 @@ public abstract class AbstractFrontierService
                         break;
                     }
                 }
+
+                try {
+                    urliter.close();
+                } catch (IOException e1) {
+                    LOG.warn("Error closing URLIterator", e1);
+                }
             }
         }
 
         responseObserver.onCompleted();
     }
 
-    protected Iterator<URLItem> urlIterator(Entry<QueueWithinCrawl, QueueInterface> qentry) {
+    protected CloseableIterator<URLItem> urlIterator(
+            Entry<QueueWithinCrawl, QueueInterface> qentry) {
         return urlIterator(qentry, 0L, Long.MAX_VALUE);
     }
 
-    protected abstract Iterator<URLItem> urlIterator(
+    protected abstract CloseableIterator<URLItem> urlIterator(
             Entry<QueueWithinCrawl, QueueInterface> qentry, long start, long max);
 
     /**

--- a/service/src/main/java/crawlercommons/urlfrontier/service/CloseableIterator.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/CloseableIterator.java
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import java.io.Closeable;
+import java.util.Iterator;
+
+/**
+ * Adds close to the Iterator Needed when we need to close resources used by the Iterator (e.g. The
+ * RocksDBIterator in case of RocksDb implementation).
+ *
+ * @param <T>
+ */
+public interface CloseableIterator<T> extends Closeable, Iterator<T> {}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -11,6 +11,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.AbstractFrontierService;
+import crawlercommons.urlfrontier.service.CloseableIterator;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -224,12 +225,12 @@ public class MemoryFrontierService extends AbstractFrontierService {
         }
     }
 
-    public Iterator<URLItem> urlIterator(
+    public CloseableIterator<URLItem> urlIterator(
             Entry<QueueWithinCrawl, QueueInterface> qentry, long start, long maxURLs) {
         return new MemoryURLItemIterator(qentry, start, maxURLs);
     }
 
-    class MemoryURLItemIterator implements Iterator<URLItem> {
+    class MemoryURLItemIterator implements CloseableIterator<URLItem> {
 
         private final org.slf4j.Logger LOG = LoggerFactory.getLogger(MemoryURLItemIterator.class);
 
@@ -297,6 +298,11 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 }
             }
             return null; // shouldn't happen
+        }
+
+        @Override
+        public void close() {
+            // No need to close anything here
         }
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -12,6 +12,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.AbstractFrontierService;
+import crawlercommons.urlfrontier.service.CloseableIterator;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -26,7 +27,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -856,12 +856,12 @@ public class RocksDBService extends AbstractFrontierService {
         }
     }
 
-    public Iterator<URLItem> urlIterator(
+    public CloseableIterator<URLItem> urlIterator(
             Entry<QueueWithinCrawl, QueueInterface> qentry, long start, long maxURLs) {
         return new RocksDBURLItemIterator(qentry, start, maxURLs);
     }
 
-    class RocksDBURLItemIterator implements Iterator<URLItem> {
+    class RocksDBURLItemIterator implements CloseableIterator<URLItem> {
 
         private final org.slf4j.Logger LOG = LoggerFactory.getLogger(RocksDBURLItemIterator.class);
 
@@ -960,7 +960,7 @@ public class RocksDBService extends AbstractFrontierService {
                     final int pos2 = schedulingKey.indexOf('_', pos1 + 1);
                     final int pos3 = schedulingKey.indexOf('_', pos2 + 1);
 
-                    fromEpoch = Long.parseLong(schedulingKey.substring(pos2 + 1, pos3));
+                    fromEpoch = Long.parseLong(schedulingKey, pos2 + 1, pos3, 10);
 
                     try {
                         info = URLInfo.parseFrom(scheduled);
@@ -997,6 +997,11 @@ public class RocksDBService extends AbstractFrontierService {
             }
 
             return null; // Shouldn't happen
+        }
+
+        @Override
+        public void close() {
+            this.rocksIterator.close();
         }
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -300,7 +300,7 @@ public class RocksDBService extends AbstractFrontierService {
                 }
 
                 // too early for it?
-                long scheduled = Long.parseLong(currentKey.substring(pos2 + 1, pos3));
+                long scheduled = Long.parseLong(currentKey, pos2 + 1, pos3, 10);
                 if (scheduled > now) {
                     // they are sorted by date no need to go further
                     return alreadySent;
@@ -823,7 +823,7 @@ public class RocksDBService extends AbstractFrontierService {
                     final int pos2 = currentKey.indexOf('_', pos + 1);
                     final int pos3 = currentKey.indexOf('_', pos2 + 1);
 
-                    fromEpoch = Long.parseLong(currentKey.substring(pos2 + 1, pos3));
+                    fromEpoch = Long.parseLong(currentKey, pos2 + 1, pos3, 10);
 
                     try {
                         info =

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
@@ -8,6 +8,7 @@ import crawlercommons.urlfrontier.Urlfrontier.ListUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
+import crawlercommons.urlfrontier.service.CloseableIterator;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -15,7 +16,6 @@ import crawlercommons.urlfrontier.service.cluster.DistributedFrontierService;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -101,7 +101,7 @@ public class ShardedRocksDBService extends DistributedFrontierService {
 
     @Override
     // TODO Implementation of urlIterator for ShardedRocksDB
-    protected Iterator<URLItem> urlIterator(
+    protected CloseableIterator<URLItem> urlIterator(
             Entry<QueueWithinCrawl, QueueInterface> qentry, long start, long max) {
         throw new UnsupportedOperationException(
                 "Feature not implemented for ShardedRocksDB backend");


### PR DESCRIPTION
Added  close to the Iterator Needed when we need to close resources used by the Iterator 
(e.g. The RocksDBIterator in case of RocksDb implementation).

