### PR TITLE
Avoid synchronization on GetQueues

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentLinkedHashMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentLinkedHashMap.java
@@ -179,8 +179,8 @@ public class ConcurrentLinkedHashMap<K, V> implements Map<K, V> {
         ConcurrentLinkedHashMap<Integer, String> clhMap = new ConcurrentLinkedHashMap<>();
 
         // Simulate concurrent puts
-        ExecutorService executor = Executors.newFixedThreadPool(4);
-        for (int i = 1; i <= 10; i++) {
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        for (int i = 1; i <= 20; i++) {
             final int key = i;
             executor.submit(() -> clhMap.put(key, "Value" + key));
         }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentLinkedHashMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentLinkedHashMap.java
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Concurrent version of LinkedHashMap Design goal is the same as for ConcurrentHashMap: Maintain
+ * concurrent readability (typically method get(), but also iterators and related methods) while
+ * minimizing update contention
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ */
+public class ConcurrentLinkedHashMap<K, V> implements Map<K, V> {
+
+    private final ConcurrentHashMap<K, V> map;
+    private final ConcurrentLinkedQueue<K> order;
+    private final ReentrantLock lock; // To maintain consistency between map and order
+    private final AtomicInteger size;
+
+    public ConcurrentLinkedHashMap() {
+        this.map = new ConcurrentHashMap<>();
+        this.order = new ConcurrentLinkedQueue<>();
+        this.lock = new ReentrantLock();
+        this.size = new AtomicInteger(0);
+    }
+
+    @Override
+    public int size() {
+        return size.get();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return size.get() == 0;
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return map.get(key);
+    }
+
+    /**
+     * Associates the specified value with the specified key in this map. Maintains insertion order
+     * if the key is new.
+     */
+    @Override
+    public V put(K key, V value) {
+        V previous;
+        lock.lock();
+        try {
+            previous = map.put(key, value);
+            if (previous == null) {
+                order.add(key);
+                size.incrementAndGet();
+            }
+        } finally {
+            lock.unlock();
+        }
+        return previous;
+    }
+
+    /**
+     * Removes the mapping for a key from this map if it is present. Also removes the key from the
+     * insertion order queue.
+     */
+    @Override
+    public V remove(Object key) {
+        V removedValue;
+        lock.lock();
+        try {
+            removedValue = map.remove(key);
+            if (removedValue != null) {
+                order.remove(key);
+                size.decrementAndGet();
+            }
+        } finally {
+            lock.unlock();
+        }
+        return removedValue;
+    }
+
+    /**
+     * Copies all of the mappings from the specified map to this map. Maintains insertion order
+     * based on the iteration order of the specified map.
+     */
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        lock.lock();
+        try {
+            for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+                K key = entry.getKey();
+                V value = entry.getValue();
+                if (map.put(key, value) == null) {
+                    order.add(key);
+                    size.incrementAndGet();
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Removes all of the mappings from this map and clears the insertion order. */
+    @Override
+    public void clear() {
+        lock.lock();
+        try {
+            map.clear();
+            order.clear();
+            size.set(0);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /** Returns a Set view of the keys contained in this map in insertion order. */
+    @Override
+    public Set<K> keySet() {
+        return new LinkedHashSet<>(order);
+    }
+
+    /** Returns a Collection view of the values contained in this map in insertion order. */
+    @Override
+    public Collection<V> values() {
+        List<V> values = new ArrayList<>();
+        for (K key : order) {
+            V value = map.get(key);
+            if (value != null) {
+                values.add(value);
+            }
+        }
+        return values;
+    }
+
+    /** Returns a Set view of the mappings contained in this map in insertion order. */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        LinkedHashSet<Entry<K, V>> entries = new LinkedHashSet<>();
+        for (K key : order) {
+            V value = map.get(key);
+            if (value != null) {
+                entries.add(new AbstractMap.SimpleImmutableEntry<>(key, value));
+            }
+        }
+        return entries;
+    }
+
+    // Optional: Override additional Map default methods for better performance or
+    // additional behaviors.
+
+    // Example usage:
+    public static void main(String[] args) throws InterruptedException {
+        ConcurrentLinkedHashMap<Integer, String> clhMap = new ConcurrentLinkedHashMap<>();
+
+        // Simulate concurrent puts
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        for (int i = 1; i <= 10; i++) {
+            final int key = i;
+            executor.submit(() -> clhMap.put(key, "Value" + key));
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+
+        // Iterate in insertion order
+        for (Map.Entry<Integer, String> entry : clhMap.entrySet()) {
+            System.out.println(entry.getKey() + " => " + entry.getValue());
+        }
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -1,0 +1,168 @@
+package crawlercommons.urlfrontier.service;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.StampedLock;
+import java.util.stream.Collectors;
+
+/**
+ * Concurrent version of LinkedHashMap Design goal is the same as for ConcurrentHashMap: Maintain
+ * concurrent readability (typically method get(), but also iterators and related methods) while
+ * minimizing update contention
+ *
+ * <p>This implementation is based on StampedLock.
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ */
+public class ConcurrentOrderedMap<K, V> extends AbstractMap<K, V> {
+    // Main storage for key-value pairs
+    private final ConcurrentHashMap<K, V> valueMap;
+
+    // Tracks insertion order using a concurrent skip list map
+    private final ConcurrentSkipListMap<Long, K> insertionOrderMap;
+
+    // Atomic counter to track insertion order
+    private final AtomicLong insertionCounter;
+
+    // Stamped lock for read-write operations
+    private final StampedLock lock;
+
+    public ConcurrentOrderedMap() {
+        this.valueMap = new ConcurrentHashMap<>();
+        this.insertionOrderMap = new ConcurrentSkipListMap<>();
+        this.insertionCounter = new AtomicLong(0);
+        this.lock = new StampedLock();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        long stamp = lock.writeLock();
+        try {
+            // Check if key already exists
+            V oldValue = valueMap.get(key);
+
+            // Remove old insertion order if key exists
+            if (oldValue != null) {
+                insertionOrderMap.entrySet().removeIf(entry -> entry.getValue().equals(key));
+            }
+
+            // Add to value map and track insertion order
+            valueMap.put(key, value);
+            insertionOrderMap.put(insertionCounter.getAndIncrement(), key);
+
+            return oldValue;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public V get(Object key) {
+        return valueMap.get(key);
+    }
+
+    @Override
+    public V remove(Object key) {
+        long stamp = lock.writeLock();
+        try {
+            V removedValue = valueMap.remove(key);
+
+            // Remove from insertion order map if value existed
+            if (removedValue != null) {
+                insertionOrderMap.entrySet().removeIf(entry -> entry.getValue().equals(key));
+            }
+
+            return removedValue;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        // Return entries in insertion order
+        long stamp = lock.tryOptimisticRead();
+
+        Set<Entry<K, V>> orderedEntries =
+                insertionOrderMap.values().stream()
+                        .map(key -> new SimpleEntry<>(key, valueMap.get(key)))
+                        .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        // Validate the read to ensure no concurrent modifications
+        if (!lock.validate(stamp)) {
+            stamp = lock.readLock();
+            try {
+                orderedEntries =
+                        insertionOrderMap.values().stream()
+                                .map(key -> new SimpleEntry<>(key, valueMap.get(key)))
+                                .collect(Collectors.toCollection(LinkedHashSet::new));
+            } finally {
+                lock.unlockRead(stamp);
+            }
+        }
+
+        return orderedEntries;
+    }
+
+    @Override
+    public int size() {
+        return valueMap.size();
+    }
+
+    @Override
+    public void clear() {
+        long stamp = lock.writeLock();
+        try {
+            valueMap.clear();
+            insertionOrderMap.clear();
+            insertionCounter.set(0);
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    // Additional methods for more advanced concurrent operations
+    public boolean replace(K key, V oldValue, V newValue) {
+        long stamp = lock.writeLock();
+        try {
+            if (valueMap.replace(key, oldValue, newValue)) {
+                // Remove old insertion order entry and add new one
+                insertionOrderMap.entrySet().removeIf(entry -> entry.getValue().equals(key));
+                insertionOrderMap.put(insertionCounter.getAndIncrement(), key);
+                return true;
+            }
+            return false;
+        } finally {
+            lock.unlockWrite(stamp);
+        }
+    }
+
+    // Example usage:
+    public static void main(String[] args) throws InterruptedException {
+        ConcurrentLinkedHashMap<Integer, String> clhMap = new ConcurrentLinkedHashMap<>();
+
+        // Simulate concurrent puts
+        ExecutorService executor = Executors.newFixedThreadPool(10);
+        for (int i = 1; i <= 20; i++) {
+            final int key = i;
+            executor.submit(() -> clhMap.put(key, "Value" + key));
+        }
+
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+
+        // Iterate in insertion order
+        for (Map.Entry<Integer, String> entry : clhMap.entrySet()) {
+            System.out.println(entry.getKey() + " => " + entry.getValue());
+        }
+    }
+}


### PR DESCRIPTION

The purpose of this PR is to avoid the synchronization on the internal queue map.

The synchronized(getQueues()) call causes contention during long queue traversals which are very likely to occur during calls to countURLs & ListURLs.

This change is based on the ConcurrentOrdereredMap class which uses StampLock to provide fine
fine-grained locking over the concurrent map.

(alternative in ConcurrentLinkedHashMap based on ReentrantLock, need to compare under stress tests)


Signed-off-by: Laurent Klock <Laurent.Klock@arhs-cube.com>
