### PR TITLE
Added ConcurrentOrdereredMap to avoid synchronization on GetQueues

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -37,7 +37,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -119,8 +118,8 @@ public abstract class AbstractFrontierService
     private List<String> nodes;
 
     // in memory map of metadata for each queue
-    private final Map<QueueWithinCrawl, QueueInterface> queues =
-            Collections.synchronizedMap(new LinkedHashMap<>());
+    private final ConcurrentInsertionOrderMap<QueueWithinCrawl, QueueInterface> queues =
+            new ConcurrentOrderedMap<>();
 
     protected final ExecutorService readExecutorService;
     protected final ExecutorService writeExecutorService;
@@ -147,7 +146,7 @@ public abstract class AbstractFrontierService
         LOG.info("Using {} threads for writing to queues", wthreadNum);
     }
 
-    public Map<QueueWithinCrawl, QueueInterface> getQueues() {
+    public ConcurrentInsertionOrderMap<QueueWithinCrawl, QueueInterface> getQueues() {
         return queues;
     }
 
@@ -209,14 +208,14 @@ public abstract class AbstractFrontierService
 
         Set<String> crawlIDs = new HashSet<>();
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                    getQueues().entrySet().iterator();
-            while (iterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                crawlIDs.add(e.getKey().getCrawlid());
-            }
+        Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
+                getQueues().entrySet().iterator();
+
+        while (iterator.hasNext()) {
+            Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+            crawlIDs.add(e.getKey().getCrawlid());
         }
+
         responseObserver.onNext(StringList.newBuilder().addAllValues(crawlIDs).build());
         responseObserver.onCompleted();
     }
@@ -234,21 +233,19 @@ public abstract class AbstractFrontierService
 
             final Set<QueueWithinCrawl> toDelete = new HashSet<>();
 
-            synchronized (getQueues()) {
-                Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                        getQueues().entrySet().iterator();
-                while (iterator.hasNext()) {
-                    Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                    QueueWithinCrawl qwc = e.getKey();
-                    if (qwc.getCrawlid().equals(normalisedCrawlID)) {
-                        toDelete.add(qwc);
-                    }
+            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
+                    getQueues().entrySet().iterator();
+            while (iterator.hasNext()) {
+                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+                QueueWithinCrawl qwc = e.getKey();
+                if (qwc.getCrawlid().equals(normalisedCrawlID)) {
+                    toDelete.add(qwc);
                 }
+            }
 
-                for (QueueWithinCrawl quid : toDelete) {
-                    QueueInterface q = getQueues().remove(quid);
-                    total += q.countActive();
-                }
+            for (QueueWithinCrawl quid : toDelete) {
+                QueueInterface q = getQueues().remove(quid);
+                total += q.countActive();
             }
         }
         responseObserver.onNext(
@@ -334,33 +331,32 @@ public abstract class AbstractFrontierService
 
         crawlercommons.urlfrontier.Urlfrontier.QueueList.Builder list = QueueList.newBuilder();
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                    getQueues().entrySet().iterator();
+        Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
+                getQueues().entrySet().iterator();
 
-            while (iterator.hasNext() && sent <= maxQueues) {
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                pos++;
+        while (iterator.hasNext() && sent <= maxQueues) {
+            Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+            pos++;
 
-                // check that it is within the right crawlID
-                if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
-                    continue;
-                }
+            // check that it is within the right crawlID
+            if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
+                continue;
+            }
 
-                // check that it isn't blocked
-                if (!include_inactive && e.getValue().getBlockedUntil() >= now) {
-                    continue;
-                }
+            // check that it isn't blocked
+            if (!include_inactive && e.getValue().getBlockedUntil() >= now) {
+                continue;
+            }
 
-                // ignore the nextfetchdate
-                if (include_inactive || e.getValue().countActive() > 0) {
-                    if (pos >= start) {
-                        list.addValues(e.getKey().getQueue());
-                        sent++;
-                    }
+            // ignore the nextfetchdate
+            if (include_inactive || e.getValue().countActive() > 0) {
+                if (pos >= start) {
+                    list.addValues(e.getKey().getQueue());
+                    sent++;
                 }
             }
         }
+
         responseObserver.onNext(list.build());
         responseObserver.onCompleted();
     }
@@ -451,16 +447,14 @@ public abstract class AbstractFrontierService
         // all the queues within the crawlID
         else {
 
-            synchronized (getQueues()) {
-                // check that the queues belong to the crawlid specified
-                Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                        getQueues().entrySet().iterator();
-                while (iterator.hasNext()) {
-                    Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                    QueueWithinCrawl qwc = e.getKey();
-                    if (qwc.getCrawlid().equals(normalisedCrawlID)) {
-                        _queues.add(e.getValue());
-                    }
+            // check that the queues belong to the crawlid specified
+            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
+                    getQueues().entrySet().iterator();
+            while (iterator.hasNext()) {
+                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+                QueueWithinCrawl qwc = e.getKey();
+                if (qwc.getCrawlid().equals(normalisedCrawlID)) {
+                    _queues.add(e.getValue());
                 }
             }
         }
@@ -469,18 +463,16 @@ public abstract class AbstractFrontierService
 
         long now = Instant.now().getEpochSecond();
 
-        synchronized (getQueues()) {
-            for (QueueInterface q : _queues) {
-                final int inProcForQ = q.getInProcess(now);
-                final int activeForQ = q.countActive();
-                if (inProcForQ > 0 || activeForQ > 0) {
-                    activeQueues++;
-                }
-                inProc += inProcForQ;
-                numQueues++;
-                size += activeForQ;
-                completed += q.getCountCompleted();
+        for (QueueInterface q : _queues) {
+            final int inProcForQ = q.getInProcess(now);
+            final int activeForQ = q.countActive();
+            if (inProcForQ > 0 || activeForQ > 0) {
+                activeQueues++;
             }
+            inProc += inProcForQ;
+            numQueues++;
+            size += activeForQ;
+            completed += q.getCountCompleted();
         }
 
         // put count completed as custom stats for now
@@ -646,23 +638,20 @@ public abstract class AbstractFrontierService
             final QueueInterface currentQueue;
             final QueueWithinCrawl currentCrawlQueue;
 
-            synchronized (getQueues()) {
-                Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                        getQueues().entrySet().iterator();
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                currentQueue = e.getValue();
-                currentCrawlQueue = e.getKey();
+            Entry<QueueWithinCrawl, QueueInterface> e = getQueues().firstEntry();
+            currentQueue = e.getValue();
+            currentCrawlQueue = e.getKey();
 
-                // to make sure we don't loop over the ones we already processed
-                if (firstCrawlQueue == null) {
-                    firstCrawlQueue = currentCrawlQueue;
-                } else if (firstCrawlQueue.equals(currentCrawlQueue)) {
-                    break;
-                }
-                // We remove the entry and put it at the end of the map
-                iterator.remove();
-                getQueues().put(currentCrawlQueue, currentQueue);
+            // to make sure we don't loop over the ones we already processed
+            if (firstCrawlQueue == null) {
+                firstCrawlQueue = currentCrawlQueue;
+            } else if (firstCrawlQueue.equals(currentCrawlQueue)) {
+                break;
             }
+
+            // We remove the entry and put it at the end of the map
+            Entry<QueueWithinCrawl, QueueInterface> first = getQueues().pollFirstEntry();
+            getQueues().put(first.getKey(), first.getValue());
 
             // if a crawlID has been specified make sure it matches
             if (crawlID != null && !currentCrawlQueue.getCrawlid().equals(crawlID)) {
@@ -875,19 +864,18 @@ public abstract class AbstractFrontierService
 
     public void setCrawlLimit(CrawlLimitParams params, StreamObserver<Empty> responseObserver) {
         QueueWithinCrawl searchKey = new QueueWithinCrawl(params.getKey(), params.getCrawlID());
-        synchronized (getQueues()) {
-            QueueInterface qi = getQueues().get(searchKey);
-            if (qi != null) {
-                qi.setCrawlLimit(params.getLimit());
-            } else {
-                LOG.error(
-                        "Queue with key: {} and CrawlId: {} was not found.",
-                        searchKey.getQueue(),
-                        searchKey.getCrawlid());
-                responseObserver.onError(
-                        new RuntimeException("CrawlId and Queue combination is not found."));
-                return;
-            }
+
+        QueueInterface qi = getQueues().get(searchKey);
+        if (qi != null) {
+            qi.setCrawlLimit(params.getLimit());
+        } else {
+            LOG.error(
+                    "Queue with key: {} and CrawlId: {} was not found.",
+                    searchKey.getQueue(),
+                    searchKey.getCrawlid());
+            responseObserver.onError(
+                    new RuntimeException("CrawlId and Queue combination is not found."));
+            return;
         }
 
         responseObserver.onCompleted();
@@ -927,43 +915,41 @@ public abstract class AbstractFrontierService
         long pos = -1; // Current position in the list of (filtered) URLs
         long sentCount = 0;
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                    getQueues().entrySet().iterator();
+        Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
+                getQueues().entrySet().iterator();
 
-            while (qiterator.hasNext() && sentCount < maxURLs) {
-                Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
+        while (qiterator.hasNext() && sentCount < maxURLs) {
+            Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
 
-                // check that it is within the right crawlID
-                if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
-                    continue;
-                }
+            // check that it is within the right crawlID
+            if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
+                continue;
+            }
 
-                // check that it is within the right key/queue
-                if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
-                    continue;
-                }
+            // check that it is within the right key/queue
+            if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
+                continue;
+            }
 
-                CloseableIterator<URLItem> urliter = urlIterator(e);
+            CloseableIterator<URLItem> urliter = urlIterator(e);
 
-                while (urliter.hasNext() && sentCount < maxURLs) {
-                    URLItem cur = urliter.next();
+            while (urliter.hasNext() && sentCount < maxURLs) {
+                URLItem cur = urliter.next();
 
-                    if (!doFilter || filterURL(cur, filter, ignoreCase)) {
-                        pos++;
+                if (!doFilter || filterURL(cur, filter, ignoreCase)) {
+                    pos++;
 
-                        if (pos >= start && sentCount < maxURLs) {
-                            sentCount++;
-                            responseObserver.onNext(cur);
-                        }
+                    if (pos >= start && sentCount < maxURLs) {
+                        sentCount++;
+                        responseObserver.onNext(cur);
                     }
                 }
+            }
 
-                try {
-                    urliter.close();
-                } catch (IOException e1) {
-                    LOG.warn("Error closing URLIterator", e1);
-                }
+            try {
+                urliter.close();
+            } catch (IOException e1) {
+                LOG.warn("Error closing URLIterator", e1);
             }
         }
 
@@ -1022,38 +1008,36 @@ public abstract class AbstractFrontierService
 
         long totalCount = 0;
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                    getQueues().entrySet().iterator();
+        Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
+                getQueues().entrySet().iterator();
 
-            while (qiterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
+        while (qiterator.hasNext()) {
+            Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
 
-                // check that it is within the right crawlID
-                if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
-                    continue;
+            // check that it is within the right crawlID
+            if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
+                continue;
+            }
+
+            // check that it is within the right key/queue
+            if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
+                continue;
+            }
+
+            CloseableIterator<URLItem> urliter = urlIterator(e);
+
+            while (urliter.hasNext()) {
+                URLItem cur = urliter.next();
+
+                if (!doFilter || filterURL(cur, filter, ignoreCase)) {
+                    totalCount++;
                 }
+            }
 
-                // check that it is within the right key/queue
-                if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
-                    continue;
-                }
-
-                CloseableIterator<URLItem> urliter = urlIterator(e);
-
-                while (urliter.hasNext()) {
-                    URLItem cur = urliter.next();
-
-                    if (!doFilter || filterURL(cur, filter, ignoreCase)) {
-                        totalCount++;
-                    }
-                }
-
-                try {
-                    urliter.close();
-                } catch (Exception e1) {
-                    LOG.warn("Error closing URLIterator", e1);
-                }
+            try {
+                urliter.close();
+            } catch (Exception e1) {
+                LOG.warn("Error closing URLIterator", e1);
             }
         }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -1,0 +1,39 @@
+package crawlercommons.urlfrontier.service;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Interface for a Concurrent Map which preserves insertion order and allows to retrieve its first
+ * element.
+ *
+ * @param <K>
+ * @param <V>
+ */
+public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
+
+    /** Returns the first entry according to insertion order */
+    Entry<K, V> firstEntry();
+
+    /** Remove & returns the first entry according to insertion order */
+    Entry<K, V> pollFirstEntry();
+
+    /** Returns a set containing the keys in this map. Remove is not supported by the iterator */
+    @Override
+    Set<K> keySet();
+
+    /**
+     * Returns a set containing the mappings in this map. Remove is not supported by the iterator
+     */
+    @Override
+    Set<Map.Entry<K, V>> entrySet();
+
+    /**
+     * Returns a collection containing the values in this map. Remove is not supported by the
+     * iterator
+     */
+    @Override
+    Collection<V> values();
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-FileCopyrightText: 2025 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
 package crawlercommons.urlfrontier.service;
 
 import java.util.Collection;

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-FileCopyrightText: 2025 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
 package crawlercommons.urlfrontier.service;
 
 import com.google.common.util.concurrent.Striped;

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -1,0 +1,417 @@
+package crawlercommons.urlfrontier.service;
+
+import com.google.common.util.concurrent.Striped;
+import java.util.AbstractCollection;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Concurrent version of LinkedHashMap Design goal is the same as for ConcurrentHashMap: Maintain
+ * concurrent readability (typically method get(), but also iterators and related methods) while
+ * minimizing update contention.
+ *
+ * <p>This implementation is based on ConcurrentSkipListMap for order preservation and Guava Striped
+ * locks for concurrency.
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ */
+public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K, V> {
+
+    // Main storage for key-value pairs
+    private final ConcurrentHashMap<K, ValueEntry> valueMap;
+
+    // Tracks insertion order using a concurrent skip list map
+    private final ConcurrentSkipListMap<Long, K> insertionOrderMap;
+
+    // Atomic counter to track insertion order
+    private final AtomicLong insertionCounter;
+
+    private static final int DEFAULT_CONCURRENCY = 32;
+    private static final int DEFAULT_SIZE = DEFAULT_CONCURRENCY * 16;
+
+    private final Striped<Lock> striped;
+
+    class ValueEntry {
+        public ValueEntry(V v, long o) {
+            this.value = v;
+            this.order = o;
+        }
+
+        V value;
+        long order;
+    }
+
+    public ConcurrentOrderedMap() {
+        this(DEFAULT_CONCURRENCY);
+    }
+
+    private final ReentrantLock globalLock = new ReentrantLock();
+
+    public ConcurrentOrderedMap(int stripes) {
+        this.valueMap = new ConcurrentHashMap<>(DEFAULT_SIZE, 0.75f, stripes);
+        this.insertionOrderMap = new ConcurrentSkipListMap<>();
+        this.insertionCounter = new AtomicLong(0);
+        this.striped = Striped.lock(stripes);
+    }
+
+    private Lock getStripe(Object key) {
+        return striped.get(Objects.hashCode(key));
+    }
+
+    private void lockAllStripes() {
+        globalLock.lock();
+        try {
+            // Lock each stripe
+            for (int i = 0; i < striped.size(); i++) {
+                striped.get(i).lock();
+            }
+        } finally {
+            globalLock.unlock();
+        }
+    }
+
+    private void unlockAllStripes() {
+        // Unlock each stripe
+        for (int i = 0; i < striped.size(); i++) {
+            striped.get(i).unlock();
+        }
+    }
+
+    @Override
+    public V put(K key, V value) {
+
+        Lock stripe = getStripe(key);
+        stripe.lock();
+
+        try {
+            // Check if key already exists
+            ValueEntry ventry = valueMap.get(key);
+            V oldValue = null;
+            if (ventry != null) {
+                oldValue = ventry.value;
+                ventry.value = value;
+            } else {
+                long newOrder = insertionCounter.getAndIncrement();
+                insertionOrderMap.put(newOrder, key);
+                valueMap.put(key, new ValueEntry(value, newOrder));
+            }
+
+            return oldValue;
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    public V get(Object key) {
+
+        ValueEntry ventry = valueMap.get(key);
+        return (ventry != null) ? ventry.value : null;
+    }
+
+    @Override
+    public V remove(Object key) {
+
+        Lock stripe = getStripe(key);
+        stripe.lock();
+
+        try {
+            ValueEntry removed = valueMap.remove(key);
+
+            // Remove from insertion order map if value existed
+            if (removed != null) {
+                insertionOrderMap.remove(removed.order);
+            }
+
+            return (removed != null) ? removed.value : null;
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    /**
+     * Insertion order is preserved.
+     *
+     * @return a linked hash set will all keys
+     */
+    public Set<K> keySet() {
+        return new AbstractSet<>() {
+            @Override
+            public Iterator<K> iterator() {
+                return new Iterator<>() {
+                    final Iterator<Entry<Long, K>> orderedIterator =
+                            insertionOrderMap.entrySet().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return orderedIterator.hasNext();
+                    }
+
+                    @Override
+                    public K next() {
+                        return orderedIterator.next().getValue();
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                // Don't use size on CSLM as it's not in O(1) but rather O(n) and may be inacurate
+                return valueMap.size();
+            }
+        };
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+        return new AbstractSet<Map.Entry<K, V>>() {
+            @Override
+            public Iterator<Map.Entry<K, V>> iterator() {
+                return new Iterator<Map.Entry<K, V>>() {
+                    final Iterator<Entry<Long, K>> orderedIterator =
+                            insertionOrderMap.entrySet().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return orderedIterator.hasNext();
+                    }
+
+                    @Override
+                    public Map.Entry<K, V> next() {
+                        Entry<Long, K> nextEntry = orderedIterator.next();
+                        K key = nextEntry.getValue();
+                        V value = valueMap.get(key).value;
+                        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return valueMap.size();
+            }
+        };
+    }
+
+    @Override
+    public int size() {
+
+        return valueMap.size();
+    }
+
+    @Override
+    public void clear() {
+        lockAllStripes();
+
+        try {
+            valueMap.clear();
+            insertionOrderMap.clear();
+            insertionCounter.set(0);
+        } finally {
+            unlockAllStripes();
+        }
+    }
+
+    // Additional methods for more advanced concurrent operations
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+
+        Lock stripe = getStripe(key);
+        stripe.lock();
+        try {
+            if (valueMap.containsKey(key)) {
+                ValueEntry ventry = valueMap.get(key);
+                if (ventry != null && Objects.equals(ventry.value, oldValue)) {
+                    ventry.value = newValue;
+
+                    return true;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        Lock stripe = getStripe(key);
+        stripe.lock();
+
+        try {
+            if (!valueMap.containsKey(key)) {
+                return this.put(key, value);
+            } else {
+                return valueMap.get(key).value;
+            }
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+
+        Lock stripe = getStripe(key);
+        stripe.lock();
+
+        try {
+            if (valueMap.containsKey(key) && Objects.equals(valueMap.get(key).value, value)) {
+                remove(key);
+                return true;
+            } else {
+                return false;
+            }
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    public V replace(K key, V value) {
+
+        Lock stripe = getStripe(key);
+        stripe.lock();
+        try {
+            if (valueMap.containsKey(key)) {
+                return put(key, value);
+            } else {
+                return null;
+            }
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    /*
+     * Returns the first entry according to insertion order
+     */
+    public Entry<K, V> firstEntry() {
+        Entry<Long, K> first = insertionOrderMap.firstEntry();
+
+        if (first != null) {
+            K key = first.getValue();
+
+            return new AbstractMap.SimpleImmutableEntry<>(key, valueMap.get(key).value);
+        } else {
+            return null;
+        }
+    }
+
+    /*
+     * Remove & Returns the first entry according to insertion order
+     */
+    public Entry<K, V> pollFirstEntry() {
+
+        Entry<Long, K> firstEntry = insertionOrderMap.firstEntry();
+        if (firstEntry == null) {
+            return null;
+        }
+
+        K key = firstEntry.getValue();
+        Lock stripe = getStripe(key);
+        stripe.lock();
+        try {
+
+            // Removes the first key from the order queue
+            insertionOrderMap.pollFirstEntry();
+            if (key != null) {
+                // Get the value and remove the entry from the map
+                V value = valueMap.get(key).value;
+                valueMap.remove(key);
+
+                return new AbstractMap.SimpleImmutableEntry<>(key, value);
+            } else {
+                return null;
+            }
+        } finally {
+            stripe.unlock();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+
+        return valueMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+
+        return valueMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+
+        return valueMap.values().stream().anyMatch(v -> Objects.equals(value, v.value));
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+
+        // Lock everything here, instead of lock per key, to evaluate
+        lockAllStripes();
+        try {
+            for (Entry<? extends K, ? extends V> entry : m.entrySet()) {
+                K key = entry.getKey();
+
+                // Check if key already exists
+                ValueEntry ventry = valueMap.get(key);
+                if (ventry != null) {
+                    ventry.value = entry.getValue();
+                } else {
+                    long newOrder = insertionCounter.getAndIncrement();
+                    insertionOrderMap.put(newOrder, key);
+                    valueMap.put(key, new ValueEntry(entry.getValue(), newOrder));
+                }
+            }
+        } finally {
+            unlockAllStripes();
+        }
+    }
+
+    @Override
+    public Collection<V> values() {
+        return new AbstractCollection<>() {
+            @Override
+            public Iterator<V> iterator() {
+                return new Iterator<>() {
+                    final Iterator<Entry<Long, K>> orderedIterator =
+                            insertionOrderMap.entrySet().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return orderedIterator.hasNext();
+                    }
+
+                    @Override
+                    public V next() {
+                        K key = orderedIterator.next().getValue();
+                        return valueMap.get(key).value;
+                    }
+                };
+            }
+
+            @Override
+            public int size() {
+                return valueMap.size();
+            }
+        };
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -386,14 +386,13 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
             }
         }
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                    getQueues().entrySet().iterator();
-            while (iterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                crawlIDs.add(e.getKey().getCrawlid());
-            }
+        Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
+                getQueues().entrySet().iterator();
+        while (iterator.hasNext()) {
+            Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+            crawlIDs.add(e.getKey().getCrawlid());
         }
+
         responseObserver.onNext(StringList.newBuilder().addAllValues(crawlIDs).build());
         responseObserver.onCompleted();
     }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -122,34 +122,33 @@ public class MemoryFrontierService extends AbstractFrontierService {
         QueueWithinCrawl qk = QueueWithinCrawl.get(key, iu.crawlID);
 
         // get the priority queue or create one
-        synchronized (getQueues()) {
-            URLQueue queue = (URLQueue) getQueues().get(qk);
-            if (queue == null) {
-                getQueues().put(qk, new URLQueue(iu));
-                return Status.OK;
-            }
+        URLQueue queue = (URLQueue) getQueues().get(qk);
+        if (queue == null) {
+            getQueues().put(qk, new URLQueue(iu));
+            return Status.OK;
+        }
 
-            // check whether the URL already exists
-            if (queue.contains(iu)) {
-                if (discovered) {
-                    putURLs_alreadyknown_count.inc();
-                    // we already discovered it - so no need for it
-                    return Status.SKIPPED;
-                } else {
-                    // overwrite the existing version
-                    queue.remove(iu);
-                }
-            }
-
-            // add the new item
-            // unless it is an update and it's nextFetchDate is 0 == NEVER
-            if (!discovered && iu.nextFetchDate == 0) {
-                putURLs_completed_count.inc();
-                queue.addToCompleted(iu.url);
+        // check whether the URL already exists
+        if (queue.contains(iu)) {
+            if (discovered) {
+                putURLs_alreadyknown_count.inc();
+                // we already discovered it - so no need for it
+                return Status.SKIPPED;
             } else {
-                queue.add(iu);
+                // overwrite the existing version
+                queue.remove(iu);
             }
         }
+
+        // add the new item
+        // unless it is an update and it's nextFetchDate is 0 == NEVER
+        if (!discovered && iu.nextFetchDate == 0) {
+            putURLs_completed_count.inc();
+            queue.addToCompleted(iu.url);
+        } else {
+            queue.add(iu);
+        }
+
         return Status.OK;
     }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
@@ -9,6 +9,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.CloseableIterator;
+import crawlercommons.urlfrontier.service.ConcurrentInsertionOrderMap;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -83,7 +84,7 @@ public class ShardedRocksDBService extends DistributedFrontierService {
     }
 
     @Override
-    public Map<QueueWithinCrawl, QueueInterface> getQueues() {
+    public ConcurrentInsertionOrderMap<QueueWithinCrawl, QueueInterface> getQueues() {
         return instance.getQueues();
     }
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
 package crawlercommons.urlfrontier.service;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-FileCopyrightText: 2025 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -1,0 +1,254 @@
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ConcurrentOrderedMapTest {
+
+    private ConcurrentOrderedMap<String, String> map;
+
+    @BeforeEach
+    void setUp() {
+        map = new ConcurrentOrderedMap<>();
+    }
+
+    @Test
+    void testPutAndGet() {
+        map.put("key1", "value1");
+        assertEquals("value1", map.get("key1"), "Value should be retrieved correctly");
+
+        map.put("key2", "value2");
+        assertEquals("value2", map.get("key2"), "Value should be retrieved correctly");
+    }
+
+    @Test
+    void testContainsKey() {
+        // Add a key-value pair to the map
+        map.put("key1", "value1");
+
+        // Check if the map contains the key
+        boolean contains = map.containsKey("key1");
+        assertTrue(contains);
+
+        contains = map.containsKey("key2");
+        assertFalse(contains);
+    }
+
+    @Test
+    void testContainsValue() {
+        // Add a key-value pair to the map
+        map.put("key1", "value1");
+
+        // Check if the map contains the key
+        boolean contains = map.containsValue("value1");
+        assertTrue(contains);
+
+        contains = map.containsValue("value2");
+        assertFalse(contains);
+    }
+
+    @Test
+    void testRemove() {
+        map.put("key1", "value1");
+        map.remove("key1");
+        assertNull(map.get("key1"), "Key should be removed from the map");
+
+        assertEquals(0, map.size(), "Size of the map should be zero after removal");
+    }
+
+    @Test
+    void testConcurrentOperations() {
+        int numThreads = 10;
+        int numIterations = 100;
+
+        Thread[] threads = new Thread[numThreads];
+
+        for (int i = 0; i < numThreads; i++) {
+            threads[i] =
+                    new Thread(
+                            () -> {
+                                for (int j = 0; j < numIterations; j++) {
+                                    String key = "key" + j;
+                                    String value = "value" + j;
+                                    map.put(key, value);
+                                    assertEquals(
+                                            value,
+                                            map.get(key),
+                                            "Value should be retrieved correctly");
+
+                                    // Remove the key after adding
+                                    map.remove(key);
+                                }
+                            });
+        }
+
+        for (Thread thread : threads) {
+            thread.start();
+        }
+
+        for (Thread thread : threads) {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+
+        assertEquals(0, map.size(), "Size of the map should be zero after concurrent operations");
+    }
+
+    @Test
+    void testOrderAndSize() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+
+        assertEquals(3, map.size(), "Size of the map should be 3");
+
+        Iterator<String> iterator = map.keySet().iterator();
+        assertEquals("key1", iterator.next());
+        assertEquals("key2", iterator.next());
+        assertEquals("key3", iterator.next());
+    }
+
+    @Test
+    void testFirstEntry() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+
+        assertEquals("key1", map.firstEntry().getKey());
+        assertEquals("key1", map.pollFirstEntry().getKey());
+        assertEquals("key2", map.firstEntry().getKey());
+    }
+
+    @Test
+    void testPutExistingKey() {
+        // Add a key-value pair to the map
+        map.put("key1", "value1");
+
+        // Overwrite the existing key with a new value
+        map.put("key1", "new_value1");
+
+        // Retrieve the updated value
+        String value = map.get("key1");
+        assertEquals("new_value1", value);
+    }
+
+    void testPutIfAbsent() {
+        map.putIfAbsent("key1", "value1");
+        assertEquals("value1", map.get("key1"), "Value should be retrieved correctly");
+
+        String ret = map.putIfAbsent("key1", "value2");
+        assertEquals("value1", ret);
+    }
+
+    @Test
+    void testClear() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        assertEquals(2, map.size());
+
+        map.clear();
+        assertEquals(0, map.size());
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    void testEntrySet() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        Set<Map.Entry<String, String>> entries = map.entrySet();
+        assertEquals(2, entries.size());
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("key1", "value1")));
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("key2", "value2")));
+    }
+
+    @Test
+    void testKeySet() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        Set<String> keys = map.keySet();
+        assertEquals(2, keys.size());
+        assertTrue(keys.contains("key1"));
+        assertTrue(keys.contains("key2"));
+    }
+
+    @Test
+    void testValues() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        Collection<String> values = map.values();
+        assertEquals(2, values.size());
+        assertTrue(values.contains("value1"));
+        assertTrue(values.contains("value2"));
+    }
+
+    @Test
+    void testIsEmpty() {
+        assertTrue(map.isEmpty());
+
+        map.put("key1", "value1");
+        assertFalse(map.isEmpty());
+
+        map.clear();
+        assertTrue(map.isEmpty());
+    }
+
+    @Test
+    void testPutAll() {
+        Map<String, String> otherMap = Map.of("key1", "value1", "key2", "value2");
+        map.putAll(otherMap);
+
+        assertEquals(2, map.size());
+        assertEquals("value1", map.get("key1"));
+        assertEquals("value2", map.get("key2"));
+    }
+
+    @Test
+    void testCompute() {
+        map.put("key1", "value1");
+        map.compute("key1", (k, v) -> v + " updated");
+        assertEquals("value1 updated", map.get("key1"));
+
+        map.compute("key2", (k, v) -> "new_value");
+        assertEquals("new_value", map.get("key2"));
+    }
+
+    @Test
+    void testRemoveWithValues() {
+        map.put("key1", "value1");
+        assertTrue(map.remove("key1", "value1"));
+        assertFalse(map.containsKey("key1"));
+    }
+
+    @Test
+    void testReplaceAll() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        map.replaceAll((k, v) -> v + "_updated");
+        assertEquals("value1_updated", map.get("key1"));
+    }
+
+    @Test
+    void testForEach() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+
+        int[] count = {0};
+        map.forEach((k, v) -> count[0]++);
+        assertEquals(2, count[0]);
+    }
+}


### PR DESCRIPTION
The purpose of this PR is to avoid the synchronization on the internal queue map.
(Avoid synchronized blocks around GetQueues calls)

The synchronized(getQueues()) call causes contention during long queue traversals which are very likely to occur during calls to countURLs & ListURLs.

This change is based on the ConcurrentOrdereredMap class which uses Guava striped Locks to provide fine
fine-grained locking and internal ConcurrentHashMap and ConcurrentSkipListMap for maintaining insertion order.
 