### PR TITLE
Fix iterators in case we have removed an entry

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -23,19 +23,23 @@ public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
     /** Remove & returns the first entry according to insertion order */
     Entry<K, V> pollFirstEntry();
 
-    /** Returns a set containing the keys in this map. Remove is not supported by the iterator */
+    /**
+     * Returns a set containing the keys in this map. The iterator returned by this set is weakly
+     * consistent. Remove is not supported by the iterator
+     */
     @Override
     Set<K> keySet();
 
     /**
-     * Returns a set containing the mappings in this map. Remove is not supported by the iterator
+     * Returns a set containing the mappings in this map. The iterator returned by this set is
+     * weakly consistent. Remove is not supported by the iterator
      */
     @Override
     Set<Map.Entry<K, V>> entrySet();
 
     /**
-     * Returns a collection containing the values in this map. Remove is not supported by the
-     * iterator
+     * Returns a collection containing the values in this map. The iterator returned by this
+     * collection is weakly consistent. Remove is not supported by the iterator
      */
     @Override
     Collection<V> values();

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -195,8 +195,16 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
                     public Map.Entry<K, V> next() {
                         Entry<Long, K> nextEntry = orderedIterator.next();
                         K key = nextEntry.getValue();
-                        V value = valueMap.get(key).value;
-                        return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                        if (valueMap.containsKey(key)) {
+                            V value = valueMap.get(key).value;
+                            return new AbstractMap.SimpleImmutableEntry<>(key, value);
+                        } else {
+                            if (orderedIterator.hasNext()) {
+                                return next();
+                            } else {
+                                return null;
+                            }
+                        }
                     }
                 };
             }
@@ -406,7 +414,16 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
                     @Override
                     public V next() {
                         K key = orderedIterator.next().getValue();
-                        return valueMap.get(key).value;
+
+                        if (valueMap.containsKey(key)) {
+                            return valueMap.get(key).value;
+                        } else {
+                            if (orderedIterator.hasNext()) {
+                                return next();
+                            } else {
+                                return null;
+                            }
+                        }
                     }
                 };
             }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -169,11 +169,13 @@ class ConcurrentOrderedMapTest {
     void testEntrySet() {
         map.put("key1", "value1");
         map.put("key2", "value2");
+        map.put("key3", "value3");
 
         Set<Map.Entry<String, String>> entries = map.entrySet();
-        assertEquals(2, entries.size());
+        assertEquals(3, entries.size());
         assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("key1", "value1")));
         assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("key2", "value2")));
+        assertTrue(entries.contains(new AbstractMap.SimpleEntry<>("key3", "value3")));
     }
 
     @Test
@@ -253,5 +255,73 @@ class ConcurrentOrderedMapTest {
         int[] count = {0};
         map.forEach((k, v) -> count[0]++);
         assertEquals(2, count[0]);
+    }
+
+    @Test
+    void testEntrySetIterator() {
+        for (int i = 0; i < 10; i++) {
+            map.put("key" + i, "value" + i);
+        }
+
+        map.remove("key5");
+
+        // key5 will be at the end
+        map.put("key5", null);
+
+        Iterator<Map.Entry<String, String>> iterator = map.entrySet().iterator();
+
+        // Removes key0
+        map.pollFirstEntry();
+
+        while (iterator.hasNext()) {
+            Map.Entry<String, String> entry = iterator.next();
+            String key = entry.getKey();
+            String value = entry.getValue();
+
+            // Remove while iterating
+            if ("key2".equals(key)) {
+                map.remove("key6");
+            }
+
+            assertTrue(key.startsWith("key"));
+            if ("key5".equals(key)) {
+                assertNull(value);
+            } else {
+                assertTrue(value.startsWith("value"));
+            }
+        }
+    }
+
+    @Test
+    void testKeySetIterator() {
+        for (int i = 0; i < 10; i++) {
+            map.put("key" + i, "value" + i);
+        }
+
+        map.remove("key5");
+
+        // key5 will be at the end
+        map.put("key5", null);
+
+        map.remove("key6");
+
+        Iterator<String> iterator = map.keySet().iterator();
+
+        // Removes key0
+        map.pollFirstEntry();
+
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            System.out.println("Key: " + key);
+
+            assertTrue(key.startsWith("key"));
+            if ("key0".equals(key)) {
+                assertNull(map.get(key));
+            } else if ("key5".equals(key)) {
+                assertNull(map.get(key));
+            } else {
+                assertTrue(map.get(key).startsWith("value"));
+            }
+        }
     }
 }


### PR DESCRIPTION
Fix iterators in case we have removed an entry

(see issue #119 )

This can typically happen while iterating and we swap elements between the head and the tail of the queue The iterator on the insertion order map is weakly consistent, but accesses to the valuemap must be checked.

