### PR TITLE
Maintain dynamic count of URLs per crawl ID

### DIFF
--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -87,6 +87,11 @@ service URLFrontier {
      
      /** Count URLs currently in the frontier **/
      rpc CountURLs(CountUrlParams) returns (Long) {}
+     
+     /** Return the crawl-wide total number of URLs ever added to the frontier.
+         This is a cumulative count and does not decrease when URLs are removed from the frontier.
+      **/
+     rpc GetCrawlStats(GetCrawlStatsParams) returns (GetCrawlStatsResponse) {}
 }
 
 /** 
@@ -344,3 +349,16 @@ message CountUrlParams {
   // only for the current local instance (default is false)
   optional bool local = 5;
 }
+
+message GetCrawlStatsParams {
+  // crawl ID
+  string crawlID = 1;
+}
+
+message GetCrawlStatsResponse {
+  // Total number of URLs ever added to the frontier for this crawl
+  Long totalURL = 1;
+  // Total number of URLs ever completed (fetched) for this crawl
+  Long completedURL = 2;
+}
+

--- a/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
@@ -26,7 +26,8 @@ import picocli.CommandLine.Option;
             SetLogLevel.class,
             SetCrawlLimit.class,
             GetURLStatus.class,
-            CountURLs.class
+            CountURLs.class,
+            GetCrawlStats.class
         },
         description = "Interacts with a URL Frontier from the command line")
 public class Client {

--- a/client/src/main/java/crawlercommons/urlfrontier/client/GetCrawlStats.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/GetCrawlStats.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2
+
+package crawlercommons.urlfrontier.client;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier;
+import crawlercommons.urlfrontier.Urlfrontier.GetCrawlStatsResponse;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "GetCrawlStats",
+        description = "Prints out the total number of URLs for a given crawl")
+public class GetCrawlStats implements Runnable {
+
+    @ParentCommand private Client parent;
+
+    @Option(
+            names = {"-c", "--crawlID"},
+            required = true,
+            defaultValue = "DEFAULT",
+            paramLabel = "STRING",
+            description = "crawl to get the total URL count for")
+    private String crawl;
+
+    @Override
+    public void run() {
+        ManagedChannel channel =
+                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
+                        .usePlaintext()
+                        .build();
+
+        URLFrontierBlockingStub blockingFrontier = URLFrontierGrpc.newBlockingStub(channel);
+        Urlfrontier.GetCrawlStatsParams.Builder builder =
+                Urlfrontier.GetCrawlStatsParams.newBuilder();
+
+        builder.setCrawlID(crawl);
+        GetCrawlStatsResponse s = blockingFrontier.getCrawlStats(builder.build());
+
+        System.out.println(
+                "Crawl statistics: "
+                        + s.getCompletedURL()
+                        + " completed, "
+                        + s.getTotalURL()
+                        + " total URLs");
+
+        channel.shutdownNow();
+    }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -16,7 +16,7 @@
 
 	<properties>
 		<prometheus.version>0.16.0</prometheus.version>
-		<rocksdb.version>9.7.3</rocksdb.version>
+		<rocksdb.version>9.7.4</rocksdb.version>
 		<logback.version>1.5.17</logback.version>
 		<mockito.version>5.13.0</mockito.version>
 		<commons.io.version>2.20.0</commons.io.version>

--- a/service/src/main/java/crawlercommons/urlfrontier/service/CrawlStats.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/CrawlStats.java
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.commons.lang3.mutable.MutableLong;
+import org.slf4j.LoggerFactory;
+
+public class CrawlStats {
+
+    private static final org.slf4j.Logger LOG =
+            LoggerFactory.getLogger(MemoryFrontierService.class);
+
+    // Nb of URLs per crawlID
+    private final ConcurrentMap<String, MutableLong> urlCountMap = new ConcurrentHashMap<>();
+
+    // Nb of completed URLs per crawlID
+    private final ConcurrentMap<String, MutableLong> completedUrlCountMap =
+            new ConcurrentHashMap<>();
+
+    /**
+     * Increment the total URL count for a given crawlID
+     *
+     * @param crawlID
+     * @return
+     */
+    public long incTotalURLCount(String crawlId) {
+
+        // Using compute to atomically initialize or increment
+        MutableLong res =
+                urlCountMap.compute(
+                        crawlId,
+                        (k, v) -> {
+                            if (v == null) {
+                                return new MutableLong(1);
+                            } else {
+                                v.increment();
+                                return v;
+                            }
+                        });
+
+        return res.longValue();
+    }
+
+    /**
+     * Increment the completed URL count for a given crawlID
+     *
+     * @param crawlID
+     * @return
+     */
+    public long incCompletedURLCount(String crawlId) {
+
+        // Using compute to atomically initialize or increment
+        MutableLong res =
+                completedUrlCountMap.compute(
+                        crawlId,
+                        (k, v) -> {
+                            if (v == null) {
+                                return new MutableLong(1);
+                            } else {
+                                v.increment();
+                                return v;
+                            }
+                        });
+
+        return res.longValue();
+    }
+
+    /**
+     * Get the total URL count for a given crawlID
+     *
+     * @param crawlID
+     * @return
+     */
+    public long getTotalURLCount(String crawlID) {
+        MutableLong count = urlCountMap.get(crawlID);
+        if (count != null) {
+            return count.longValue();
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Get the total URL count for a given crawlID
+     *
+     * @param crawlID
+     * @return
+     */
+    public long getCompletedURLCount(String crawlID) {
+        MutableLong count = completedUrlCountMap.get(crawlID);
+        if (count != null) {
+            return count.longValue();
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Delete stats for a given crawlID
+     *
+     * @param crawlID
+     */
+    public void delete(String crawlID) {
+        urlCountMap.remove(crawlID);
+        completedUrlCountMap.remove(crawlID);
+    }
+
+    /** Log stats for all crawlIDs */
+    public void logStats() {
+        for (String crawlID : urlCountMap.keySet()) {
+            long total = getTotalURLCount(crawlID);
+            long completed = getCompletedURLCount(crawlID);
+            LOG.info("CrawlID: {}, Total URLs: {}, Completed URLs: {}", crawlID, total, completed);
+        }
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -6,7 +6,7 @@ package crawlercommons.urlfrontier.service;
 import crawlercommons.urlfrontier.service.rocksdb.RocksDBService;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
-import io.grpc.protobuf.services.ProtoReflectionService;
+import io.grpc.protobuf.services.ProtoReflectionServiceV1;
 import io.prometheus.client.exporter.HTTPServer;
 import io.prometheus.client.hotspot.DefaultExports;
 import java.io.Closeable;
@@ -178,7 +178,7 @@ public class URLFrontierServer implements Callable<Integer> {
         ServerBuilder builder = ServerBuilder.forPort(port).addService(service);
 
         if (enableReflection) {
-            builder.addService(ProtoReflectionService.newInstance());
+            builder.addService(ProtoReflectionServiceV1.newInstance());
         }
 
         this.server = builder.build();

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -126,6 +126,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
             URLQueue queue = (URLQueue) getQueues().get(qk);
             if (queue == null) {
                 getQueues().put(qk, new URLQueue(iu));
+                crawlStats.incTotalURLCount(iu.crawlID);
                 return Status.OK;
             }
 
@@ -146,8 +147,12 @@ public class MemoryFrontierService extends AbstractFrontierService {
             if (!discovered && iu.nextFetchDate == 0) {
                 putURLs_completed_count.inc();
                 queue.addToCompleted(iu.url);
+                crawlStats.incCompletedURLCount(iu.crawlID);
             } else {
                 queue.add(iu);
+
+                // Increment the URL count only if it's a new URL being added to the queue
+                crawlStats.incTotalURLCount(iu.crawlID);
             }
         }
 


### PR DESCRIPTION
This PR introduces a new API call: **GetCrawlStats** which will return the number of completed and total URLs per crawl.

