### PR TITLE
Added storage of URL creation date and purgeURLs method

### DIFF
--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -87,6 +87,9 @@ service URLFrontier {
      
      /** Count URLs currently in the frontier **/
      rpc CountURLs(CountUrlParams) returns (Long) {}
+     
+     /** Deletes URLs from a frontier which are older than N days **/
+     rpc PurgeURLs(PurgeUrlParams) returns (Long) {}
 }
 
 /** 
@@ -221,6 +224,10 @@ oneof item {
   }
   /** Identifier specified by the client, if missing, the URL is returned **/
   string ID = 3;
+  /** Creation date of the URLInfo 
+  Expressed in seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+  **/
+  uint64 creation_date = 4;
 }
 
 message AckMessage {
@@ -344,3 +351,13 @@ message CountUrlParams {
   // only for the current local instance (default is false)
   optional bool local = 5;
 }
+
+message PurgeUrlParams {
+  /** ID for the queue **/
+  string key = 1;
+  // crawl ID
+  string crawlID = 2;
+  // Nb of days
+  uint32 days = 3;
+}
+

--- a/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
@@ -26,7 +26,8 @@ import picocli.CommandLine.Option;
             SetLogLevel.class,
             SetCrawlLimit.class,
             GetURLStatus.class,
-            CountURLs.class
+            CountURLs.class,
+            PurgeURLs.class
         },
         description = "Interacts with a URL Frontier from the command line")
 public class Client {

--- a/client/src/main/java/crawlercommons/urlfrontier/client/PurgeURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PurgeURLs.java
@@ -19,14 +19,14 @@ public class PurgeURLs implements Runnable {
             names = {"-k", "--key"},
             defaultValue = "",
             paramLabel = "STRING",
-            description = "key of the queue to get the URL count for")
+            description = "key of the queue to from where to delete URLs")
     private String key;
 
     @Option(
             names = {"-c", "--crawlID"},
             defaultValue = "DEFAULT",
             paramLabel = "STRING",
-            description = "crawl to get the URL count for")
+            description = "crawl from where to delete URLs")
     private String crawl;
 
     @Option(

--- a/client/src/main/java/crawlercommons/urlfrontier/client/PurgeURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PurgeURLs.java
@@ -1,0 +1,63 @@
+package crawlercommons.urlfrontier.client;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier;
+import crawlercommons.urlfrontier.Urlfrontier.Long;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(name = "PurgeURLs", description = "Purge old URLs in a Frontier")
+public class PurgeURLs implements Runnable {
+
+    @ParentCommand private Client parent;
+
+    @Option(
+            names = {"-k", "--key"},
+            defaultValue = "",
+            paramLabel = "STRING",
+            description = "key of the queue to get the URL count for")
+    private String key;
+
+    @Option(
+            names = {"-c", "--crawlID"},
+            defaultValue = "DEFAULT",
+            paramLabel = "STRING",
+            description = "crawl to get the URL count for")
+    private String crawl;
+
+    @Option(
+            names = {"-d", "--days"},
+            defaultValue = "",
+            paramLabel = "NUM",
+            description = "Number of days after which we want to delete URLs",
+            required = true)
+    private int days;
+
+    @Override
+    public void run() {
+        ManagedChannel channel =
+                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
+                        .usePlaintext()
+                        .build();
+
+        URLFrontierBlockingStub blockingFrontier = URLFrontierGrpc.newBlockingStub(channel);
+
+        Urlfrontier.PurgeUrlParams.Builder builder = Urlfrontier.PurgeUrlParams.newBuilder();
+
+        if (key.length() > 0) {
+            builder.setKey(key);
+        }
+
+        builder.setCrawlID(crawl);
+        builder.setDays(days);
+
+        Long s = blockingFrontier.purgeURLs(builder.build());
+        System.out.println("Purged " + s.getValue() + " URLs in frontier");
+
+        channel.shutdownNow();
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -6,6 +6,7 @@ package crawlercommons.urlfrontier.service;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import crawlercommons.urlfrontier.CrawlID;
+import crawlercommons.urlfrontier.Urlfrontier;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Builder;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
@@ -18,6 +19,7 @@ import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.LogLevelParams;
+import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.QueueList;
 import crawlercommons.urlfrontier.Urlfrontier.Stats;
@@ -32,6 +34,7 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractFrontierService
@@ -973,13 +977,18 @@ public abstract class AbstractFrontierService
      * @return
      */
     public static URLItem buildURLItem(
-            URLItem.Builder builder, KnownURLItem.Builder kbuilder, URLInfo info, long refetch) {
+            URLItem.Builder builder,
+            KnownURLItem.Builder kbuilder,
+            URLInfo info,
+            long refetch,
+            long creationDate) {
         builder.clear();
         kbuilder.clear();
 
         kbuilder.setInfo(info);
         kbuilder.setRefetchableFromDate(refetch);
         builder.setKnown(kbuilder.build());
+        builder.setCreationDate(creationDate);
 
         return builder.build();
     }
@@ -1054,8 +1063,76 @@ public abstract class AbstractFrontierService
     private boolean filterURL(URLItem cur, String text, boolean ignoreCase) {
 
         String curURL = cur.getKnown().getInfo().getUrl();
-        return ignoreCase
-                ? StringUtils.containsIgnoreCase(curURL, text)
-                : StringUtils.contains(curURL, text);
+        return ignoreCase ? Strings.CI.contains(curURL, text) : Strings.CS.contains(curURL, text);
     }
+
+    @Override
+    public void purgeURLs(
+            PurgeUrlParams request,
+            StreamObserver<crawlercommons.urlfrontier.Urlfrontier.Long> responseObserver) {
+
+        final String key = request.getKey();
+        final String normalisedCrawlID = CrawlID.normaliseCrawlID(request.getCrawlID());
+        int days = request.getDays();
+
+        LOG.info(
+                "Received request to purge URLs [crawlId={}, key={}, days={}]",
+                normalisedCrawlID,
+                key,
+                days);
+
+        long deletedCount = 0;
+
+        // Cutoff date  = now - number of days we want to keep
+        Instant cutoff = Instant.now().minus(Period.ofDays(days));
+
+        synchronized (getQueues()) {
+            Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
+                    getQueues().entrySetView().iterator();
+
+            while (qiterator.hasNext()) {
+                Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
+
+                // check that it is within the right crawlID
+                if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
+                    continue;
+                }
+
+                // check that it is within the right key/queue
+                if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
+                    continue;
+                }
+
+                try (CloseableIterator<URLItem> urliter = urlIterator(e)) {
+                    List<URLItem> toDelete = new ArrayList<>();
+
+                    while (urliter.hasNext()) {
+                        URLItem cur = urliter.next();
+
+                        if (Instant.ofEpochSecond(cur.getCreationDate()).isBefore(cutoff)) {
+                            // Add to deletion list (should not delete while iterating URLItem in
+                            // queue)
+                            toDelete.add(cur);
+                            deletedCount++;
+                        }
+                    }
+
+                    toDelete.stream().forEach(x -> deleteURLItem(x));
+
+                } catch (Exception e1) {
+                    LOG.warn(e1.getMessage(), e1);
+                }
+            }
+        }
+
+        responseObserver.onNext(Urlfrontier.Long.newBuilder().setValue(deletedCount).build());
+        responseObserver.onCompleted();
+    }
+
+    /**
+     * Deletes a single URLItem
+     *
+     * @param item
+     */
+    public abstract void deleteURLItem(URLItem item);
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -35,10 +35,6 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
     private Map<String, Long> creationDates = new HashMap<>();
 
-    // Used for testPurge when enabled
-    @SuppressWarnings("unused")
-    private static final Instant oldCreatDt = Instant.ofEpochSecond(489243020L);
-
     public MemoryFrontierService(final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
     }
@@ -135,7 +131,6 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 queue = new URLQueue(iu);
                 getQueues().put(qk, queue);
                 creationDates.put(iu.url, Instant.now().getEpochSecond());
-                // creationDates.put(iu.url, oldCreatDt.getEpochSecond());
 
                 // If known and nextFetchDate, set to completed
                 if (!discovered && iu.nextFetchDate == 0) {
@@ -166,8 +161,6 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 queue.addToCompleted(iu.url);
             } else {
                 creationDates.put(iu.url, Instant.now().getEpochSecond());
-                // creationDates.put(iu.url, oldCreatDt.getEpochSecond());
-
                 queue.add(iu);
             }
         }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -16,6 +16,7 @@ import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
 import io.grpc.stub.StreamObserver;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -31,6 +32,12 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(MemoryFrontierService.class);
+
+    private Map<String, Long> creationDates = new HashMap<>();
+
+    // Used for testPurge when enabled
+    @SuppressWarnings("unused")
+    private static final Instant oldCreatDt = Instant.ofEpochSecond(489243020L);
 
     public MemoryFrontierService(final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
@@ -125,7 +132,18 @@ public class MemoryFrontierService extends AbstractFrontierService {
         synchronized (getQueues()) {
             URLQueue queue = (URLQueue) getQueues().get(qk);
             if (queue == null) {
-                getQueues().put(qk, new URLQueue(iu));
+                queue = new URLQueue(iu);
+                getQueues().put(qk, queue);
+                creationDates.put(iu.url, Instant.now().getEpochSecond());
+                // creationDates.put(iu.url, oldCreatDt.getEpochSecond());
+
+                // If known and nextFetchDate, set to completed
+                if (!discovered && iu.nextFetchDate == 0) {
+                    queue.remove(iu);
+                    putURLs_completed_count.inc();
+                    queue.addToCompleted(iu.url);
+                }
+
                 return Status.OK;
             }
 
@@ -147,6 +165,9 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 putURLs_completed_count.inc();
                 queue.addToCompleted(iu.url);
             } else {
+                creationDates.put(iu.url, Instant.now().getEpochSecond());
+                // creationDates.put(iu.url, oldCreatDt.getEpochSecond());
+
                 queue.add(iu);
             }
         }
@@ -192,7 +213,8 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
         if (queue.isCompleted(url)) {
             found = true;
-            responseObserver.onNext(buildURLItem(builder, knownBuilder, info, 0));
+            long creatDt = creationDates.get(url);
+            responseObserver.onNext(buildURLItem(builder, knownBuilder, info, 0, creatDt));
         } else {
             Iterator<InternalURL> iter = queue.iterator();
 
@@ -212,6 +234,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
                     }
 
                     builder.setKnown(knownBuilder.build());
+                    builder.setCreationDate(creationDates.get(url));
                     found = true;
                     responseObserver.onNext(builder.build());
                     break;
@@ -277,7 +300,8 @@ public class MemoryFrontierService extends AbstractFrontierService {
                                 .build();
                 if (pos >= start) {
                     sent++;
-                    return buildURLItem(builder, knownBuilder, info, 0);
+                    long creatDt = creationDates.get(curcomplete);
+                    return buildURLItem(builder, knownBuilder, info, 0, creatDt);
                 } else {
                     return next();
                 }
@@ -289,7 +313,9 @@ public class MemoryFrontierService extends AbstractFrontierService {
                         URLInfo info = item.toURLInfo(qentry.getKey());
                         if (pos >= start) {
                             sent++;
-                            return buildURLItem(builder, knownBuilder, info, item.nextFetchDate);
+                            long creatDt = creationDates.get(item.url);
+                            return buildURLItem(
+                                    builder, knownBuilder, info, item.nextFetchDate, creatDt);
                         } else {
                             return next();
                         }
@@ -304,6 +330,33 @@ public class MemoryFrontierService extends AbstractFrontierService {
         @Override
         public void close() {
             // No need to close anything here
+        }
+    }
+
+    @Override
+    public void deleteURLItem(URLItem e) {
+        // Get URLInfo
+        URLInfo info;
+        if (e.hasDiscovered()) {
+            info = e.getDiscovered().getInfo();
+        } else {
+            info = e.getKnown().getInfo();
+        }
+
+        Object[] parsed = InternalURL.from(e);
+        InternalURL iu = (InternalURL) parsed[2];
+
+        final QueueWithinCrawl qwc = QueueWithinCrawl.get(info.getKey(), info.getCrawlID());
+        synchronized (getQueues()) {
+            URLQueue queue = (URLQueue) getQueues().get(qwc);
+
+            if (queue.isCompleted(info.getUrl())) {
+                queue.getCompleted().remove(info.getUrl());
+                creationDates.remove(info.getUrl());
+            } else if (queue.contains(iu)) {
+                queue.remove(iu);
+                creationDates.remove(info.getUrl());
+            }
         }
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
@@ -4,7 +4,6 @@
 package crawlercommons.urlfrontier.service.memory;
 
 import crawlercommons.urlfrontier.service.QueueInterface;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
@@ -119,9 +118,9 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
     }
 
     /**
-     * @return The unmodifiable set of completed URLs
+     * @return The set of completed URLs
      */
     public Set<String> getCompleted() {
-        return Collections.unmodifiableSet(completed);
+        return completed;
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/QueueMetadata.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/QueueMetadata.java
@@ -131,6 +131,10 @@ public class QueueMetadata implements QueueInterface {
         completed.incrementAndGet();
     }
 
+    public void decrementCompleted() {
+        completed.decrementAndGet();
+    }
+
     @Override
     public int countActive() {
         return active.get();

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -56,6 +56,10 @@ public class RocksDBService extends AbstractFrontierService {
 
     private static final DecimalFormat DF = new DecimalFormat("0000000000");
 
+    // Used for testPurge when enabled
+    @SuppressWarnings("unused")
+    private static final Instant oldCreatDt = Instant.ofEpochSecond(489243020L);
+
     static {
         RocksDB.loadLibrary();
     }
@@ -117,7 +121,8 @@ public class RocksDBService extends AbstractFrontierService {
                     Arrays.asList(
                             new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpts),
                             new ColumnFamilyDescriptor("queues".getBytes(), cfOpts),
-                            new ColumnFamilyDescriptor("queueInfos".getBytes(), cfOpts));
+                            new ColumnFamilyDescriptor("queueInfos".getBytes(), cfOpts),
+                            new ColumnFamilyDescriptor("creationDates".getBytes(), cfOpts));
 
             long start = System.currentTimeMillis();
 
@@ -346,6 +351,7 @@ public class RocksDBService extends AbstractFrontierService {
 
         long nextFetchDate;
         boolean discovered = true;
+        boolean brandNew = true; // Can be either discovered or known
         URLInfo info;
 
         putURLs_urls_count.inc();
@@ -359,7 +365,7 @@ public class RocksDBService extends AbstractFrontierService {
             KnownURLItem known = value.getKnown();
             info = known.getInfo();
             nextFetchDate = known.getRefetchableFromDate();
-            discovered = Boolean.FALSE;
+            discovered = false;
         }
 
         String Qkey = info.getKey();
@@ -429,6 +435,7 @@ public class RocksDBService extends AbstractFrontierService {
                     if (isClosing()) {
                         return Status.FAIL;
                     }
+                    brandNew = false;
                     writeBatch.delete(columnFamilyHandleList.get(1), schedulingKey);
                     // remove from queue metadata
                     queueMD.removeFromProcessed(url);
@@ -464,6 +471,19 @@ public class RocksDBService extends AbstractFrontierService {
 
                 // update the link to its queue
                 writeBatch.put(columnFamilyHandleList.get(0), existenceKey, schedulingKey);
+
+                // Keep creation date in a separate column family
+                // This is updated only for brand new items and not read during sendURLsForQueue
+                // (we need it for both discovered and completed URLs, if we want to clean old URLs
+                // later)
+                if (brandNew) {
+                    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+                    buffer.putLong(Instant.now().getEpochSecond());
+                    // NOSONAR
+                    // buffer.putLong(oldCreatDt.getEpochSecond());
+
+                    writeBatch.put(columnFamilyHandleList.get(3), existenceKey, buffer.array());
+                }
 
                 // batch the updates - this way the scheduling and main tables will always be in
                 // sync
@@ -778,10 +798,12 @@ public class RocksDBService extends AbstractFrontierService {
         // processed
         rocksDB.deleteRange(columnFamilyHandleList.get(1), prefix, endKey);
         rocksDB.deleteRange(columnFamilyHandleList.get(0), prefix, endKey);
+        rocksDB.deleteRange(columnFamilyHandleList.get(3), prefix, endKey);
 
         if (includeEndKey) {
             rocksDB.deleteRange(columnFamilyHandleList.get(1), endKey, endKey);
             rocksDB.delete(columnFamilyHandleList.get(0), endKey);
+            rocksDB.deleteRange(columnFamilyHandleList.get(3), endKey, endKey);
         }
     }
 
@@ -856,7 +878,18 @@ public class RocksDBService extends AbstractFrontierService {
         }
 
         if (found) {
-            responseObserver.onNext(buildURLItem(builder, knownbuilder, info, fromEpoch));
+            // Get the creation date
+            long creatDt = 0L;
+
+            try {
+                byte[] baCreatDt = rocksDB.get(columnFamilyHandleList.get(3), existenceKey);
+                creatDt = ByteBuffer.wrap(baCreatDt).getLong();
+            } catch (RocksDBException e) {
+                LOG.error("Cannot read creation date ", e);
+                responseObserver.onError(io.grpc.Status.fromThrowable(e).asRuntimeException());
+            }
+
+            responseObserver.onNext(buildURLItem(builder, knownbuilder, info, fromEpoch, creatDt));
             responseObserver.onCompleted();
         } else {
             responseObserver.onError(io.grpc.Status.NOT_FOUND.asRuntimeException());
@@ -952,8 +985,10 @@ public class RocksDBService extends AbstractFrontierService {
                 LOG.debug("current key {}, schedulingKey={}", currentKey, schedulingKey);
 
                 byte[] scheduled = null;
+                byte[] created = null;
                 try {
                     scheduled = rocksDB.get(columnFamilyHandleList.get(1), rocksIterator.value());
+                    created = rocksDB.get(columnFamilyHandleList.get(3), rocksIterator.key());
                 } catch (RocksDBException e) {
                     LOG.error(e.getMessage(), e);
                 }
@@ -1000,7 +1035,8 @@ public class RocksDBService extends AbstractFrontierService {
                     hasNext = rocksIterator.isValid();
                 }
 
-                return buildURLItem(builder, knownBuilder, info, fromEpoch);
+                ByteBuffer lCreated = ByteBuffer.wrap(created);
+                return buildURLItem(builder, knownBuilder, info, fromEpoch, lCreated.getLong());
             }
 
             return null; // Shouldn't happen
@@ -1014,5 +1050,40 @@ public class RocksDBService extends AbstractFrontierService {
 
     private static Lock lockFor(String compositeKey) {
         return STRIPED_LOCKS.get(compositeKey);
+    }
+
+    @Override
+    public void deleteURLItem(URLItem e) {
+
+        // Get URLInfo
+        URLInfo info;
+        if (e.hasDiscovered()) {
+            info = e.getDiscovered().getInfo();
+        } else {
+            info = e.getKnown().getInfo();
+        }
+
+        // Compute existence key
+        final QueueWithinCrawl qk = QueueWithinCrawl.get(info.getKey(), info.getCrawlID());
+        final String existenceKeyString = (qk.toString() + "_" + info.getUrl());
+        byte[] key = existenceKeyString.getBytes(StandardCharsets.UTF_8);
+
+        synchronized (getQueues()) {
+            try {
+                // Delete scheduling entry if exists
+                byte[] schedulingKey = rocksDB.get(columnFamilyHandleList.get(0), key);
+                if (schedulingKey != null) {
+                    rocksDB.delete(columnFamilyHandleList.get(1), schedulingKey);
+                }
+
+                // Delete the creation date
+                rocksDB.delete(columnFamilyHandleList.get(3), key);
+
+                // Delete the existence key
+                rocksDB.delete(columnFamilyHandleList.get(0), key);
+            } catch (RocksDBException e1) {
+                LOG.error(e1.getMessage());
+            }
+        }
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -56,10 +56,6 @@ public class RocksDBService extends AbstractFrontierService {
 
     private static final DecimalFormat DF = new DecimalFormat("0000000000");
 
-    // Used for testPurge when enabled
-    @SuppressWarnings("unused")
-    private static final Instant oldCreatDt = Instant.ofEpochSecond(489243020L);
-
     static {
         RocksDB.loadLibrary();
     }
@@ -479,8 +475,6 @@ public class RocksDBService extends AbstractFrontierService {
                 if (brandNew) {
                     ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
                     buffer.putLong(Instant.now().getEpochSecond());
-                    // NOSONAR
-                    // buffer.putLong(oldCreatDt.getEpochSecond());
 
                     writeBatch.put(columnFamilyHandleList.get(3), existenceKey, buffer.array());
                 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -1066,8 +1066,19 @@ public class RocksDBService extends AbstractFrontierService {
             try {
                 // Delete scheduling entry if exists
                 byte[] schedulingKey = rocksDB.get(columnFamilyHandleList.get(0), key);
-                if (schedulingKey != null) {
+
+                // check the value - if it is an empty byte array it means that the URL has been
+                // processed and is not scheduled
+                // otherwise it is scheduled
+                boolean completed = schedulingKey.length == 0;
+
+                QueueMetadata queueMD = (QueueMetadata) getQueues().get(qk);
+
+                if (!completed) {
                     rocksDB.delete(columnFamilyHandleList.get(1), schedulingKey);
+                    queueMD.decrementActive();
+                } else {
+                    queueMD.decrementCompleted();
                 }
 
                 // Delete the creation date

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
@@ -107,4 +107,11 @@ public class ShardedRocksDBService extends DistributedFrontierService {
         throw new UnsupportedOperationException(
                 "Feature not implemented for ShardedRocksDB backend");
     }
+
+    @Override
+    // TODO Implementation of deleteURLItem for ShardedRocksDB
+    public void deleteURLItem(URLItem item) {
+        throw new UnsupportedOperationException(
+                "Feature not implemented for ShardedRocksDB backend");
+    }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceTest.java
@@ -6,20 +6,27 @@ package crawlercommons.urlfrontier.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import crawlercommons.urlfrontier.Urlfrontier;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.CountUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.ListUrlParams;
+import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.StringList;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
 import io.grpc.stub.StreamObserver;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -65,6 +72,9 @@ class MemoryFrontierServiceTest {
                         if (value.hasKnown()) {
                             discovered.incrementAndGet();
                             assertTrue(value.getKnown().getRefetchableFromDate() > 0);
+
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -110,6 +120,9 @@ class MemoryFrontierServiceTest {
                         if (value.hasKnown()) {
                             fetched.incrementAndGet();
                             assertEquals(0, value.getKnown().getRefetchableFromDate());
+
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -171,10 +184,9 @@ class MemoryFrontierServiceTest {
     }
 
     private void logURLItem(URLItem item) {
-        if (item.hasDiscovered()) {
-            LOG.info(item.getDiscovered().toString());
-        } else if (item.hasKnown()) {
-            LOG.info(item.getKnown().toString());
+
+        if (item.hasDiscovered() || item.hasKnown()) {
+            LOG.info(item.toString());
         } else {
             LOG.error("Unknown URLItem type");
         }
@@ -207,6 +219,9 @@ class MemoryFrontierServiceTest {
                         if (value.hasKnown()) {
                             fetched.incrementAndGet();
                             assertTrue(value.getKnown().getRefetchableFromDate() > 0);
+
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -264,7 +279,7 @@ class MemoryFrontierServiceTest {
                 };
 
         memoryFrontierService.listURLs(params, statusObserver);
-        assertEquals(4, count.get());
+        assertEquals(5, count.get());
     }
 
     @Test
@@ -291,6 +306,9 @@ class MemoryFrontierServiceTest {
 
                         if (value.hasKnown()) {
                             fetched.incrementAndGet();
+
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -328,8 +346,8 @@ class MemoryFrontierServiceTest {
             }
         }
 
-        assertEquals(2, nbQueues);
-        assertEquals(4, nbUrls);
+        assertEquals(3, nbQueues);
+        assertEquals(5, nbUrls);
     }
 
     @Test
@@ -354,8 +372,8 @@ class MemoryFrontierServiceTest {
             }
         }
 
-        assertEquals(1, nbQueues);
-        assertEquals(3, nbUrls);
+        assertEquals(2, nbQueues);
+        assertEquals(4, nbUrls);
     }
 
     @Test
@@ -484,12 +502,11 @@ class MemoryFrontierServiceTest {
                 };
 
         memoryFrontierService.listURLs(params, statusObserver);
-        assertEquals(1, count.get());
+        assertEquals(2, count.get());
     }
 
     @Test
-    @Order(99)
-    // Must be last test
+    @Order(97)
     void testNoRescheduleCompleted() {
 
         String crawlId = "crawl_id";
@@ -615,5 +632,112 @@ class MemoryFrontierServiceTest {
                 };
 
         memoryFrontierService.getURLStatus(request, statusObserver2);
+    }
+
+    @Test
+    @Order(98)
+    void testDeleteURLItem() {
+
+        URLInfo info5 =
+                URLInfo.newBuilder()
+                        .setUrl("https://www.delete.me/tobedeleted")
+                        .setCrawlID("crawl_id")
+                        .setKey("delete_queue")
+                        .build();
+
+        crawlercommons.urlfrontier.Urlfrontier.URLItem.Builder builder5 = URLItem.newBuilder();
+        KnownURLItem deleteItem =
+                KnownURLItem.newBuilder()
+                        .setInfo(info5)
+                        .setRefetchableFromDate(Instant.now().getEpochSecond() + 3600)
+                        .build();
+
+        builder5.setKnown(deleteItem);
+        builder5.setID("crawl_id" + "_" + "https://www.delete.me/tobedeleted");
+
+        memoryFrontierService.deleteURLItem(builder5.build());
+
+        CountUrlParams countParams = CountUrlParams.newBuilder().setCrawlID("crawl_id").build();
+        final AtomicLong count = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> countObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        memoryFrontierService.countURLs(countParams, countObserver);
+        assertEquals(4L, count.get());
+    }
+
+    @Test
+    @Order(99)
+    @Disabled
+    // Must hardcode creation date in service before testing that
+    // Test works with creation date set as Unix Epoch 489243020L (3/Jul/1985) and guaranteed to
+    // work until 2040
+    void testPurge() {
+
+        PurgeUrlParams purgeParams1 =
+                PurgeUrlParams.newBuilder().setCrawlID("crawl_id").setDays(20000).build();
+
+        final AtomicLong count1 = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> purgeObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count1.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        memoryFrontierService.purgeURLs(purgeParams1, purgeObserver);
+        assertEquals(0L, count1.get());
+
+        PurgeUrlParams purgeParams2 =
+                PurgeUrlParams.newBuilder().setCrawlID("crawl_id").setDays(365).build();
+
+        final AtomicLong count2 = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> countObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count2.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        memoryFrontierService.purgeURLs(purgeParams2, countObserver);
+
+        // Should be 4 as we have deleted 1 in previous test
+        // all test must run as service it is the same service instance for all tests (unlike
+        // RocksDBServiceTest)
+        assertEquals(4L, count2.get());
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -15,6 +15,7 @@ import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.ListUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
+import crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams;
 import crawlercommons.urlfrontier.Urlfrontier.StringList;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
@@ -33,8 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
@@ -49,21 +49,17 @@ class RocksDBServiceTest {
 
     private static final String ROCKSDB_PATH = "./target/rocksdb";
 
-    RocksDBService rocksDBService;
-
-    @AfterEach
-    void shutdown() throws IOException {
-        rocksDBService.close();
-    }
+    static RocksDBService rocksDBService;
 
     @AfterAll
-    static void cleanup() {
+    static void cleanup() throws IOException {
+        rocksDBService.close();
         LOG.info("Cleaning up directory {}", ROCKSDB_PATH);
         FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
     }
 
-    @BeforeEach
-    void setup() {
+    @BeforeAll
+    static void setup() {
 
         Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.path", ROCKSDB_PATH);
@@ -934,6 +930,7 @@ class RocksDBServiceTest {
                 };
 
         rocksDBService.purgeURLs(purgeParams1, purgeObserver);
+        // Nothing should be deleted
         assertEquals(0L, count1.get());
 
         PurgeUrlParams purgeParams2 =
@@ -957,8 +954,40 @@ class RocksDBServiceTest {
                     public void onCompleted() {}
                 };
 
+        // Get total nb of URLs before the purge
+        // (Nb may vary depending on previous test(s) executed)
+        long c1 = ServiceTestUtil.countAllURLs(rocksDBService);
+
         rocksDBService.purgeURLs(purgeParams2, countObserver);
 
-        assertEquals(5L, count2.get());
+        // Get total nb of URLs after the purge (should be 0)
+        long c2 = ServiceTestUtil.countAllURLs(rocksDBService);
+        assertEquals(0L, c2);
+
+        // Check we deleted the right nb of URLs
+        assertEquals(c1, count2.get());
+
+        // Check that queue stats are properly updated
+        StreamObserver<Urlfrontier.Stats> statsObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Stats value) {
+                        assertEquals(0L, value.getSize());
+                        assertEquals(0L, value.getCountsOrDefault("completed", 0L));
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        QueueWithinCrawlParams qwcp =
+                QueueWithinCrawlParams.newBuilder().setCrawlID("crawl_id").build();
+        rocksDBService.getStats(qwcp, statsObserver);
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -10,9 +10,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import crawlercommons.urlfrontier.Urlfrontier;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.CountUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.ListUrlParams;
+import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.StringList;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
@@ -21,16 +23,19 @@ import crawlercommons.urlfrontier.service.rocksdb.RocksDBService;
 import io.grpc.stub.StreamObserver;
 import java.io.File;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -93,6 +98,8 @@ class RocksDBServiceTest {
                             assertEquals(crawlId, value.getKnown().getInfo().getCrawlID());
                             assertEquals(key, value.getKnown().getInfo().getKey());
                             assertTrue(value.getKnown().getRefetchableFromDate() > 0);
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -142,6 +149,8 @@ class RocksDBServiceTest {
                             assertEquals(crawlId, value.getKnown().getInfo().getCrawlID());
                             assertEquals(key, value.getKnown().getInfo().getKey());
                             assertEquals(0, value.getKnown().getRefetchableFromDate());
+                            // Check creation date is not null
+                            assertTrue(value.getCreationDate() > 0);
                         }
                         count.incrementAndGet();
                     }
@@ -206,10 +215,8 @@ class RocksDBServiceTest {
     }
 
     private void logURLItem(URLItem item) {
-        if (item.hasDiscovered()) {
-            LOG.info(item.getDiscovered().toString());
-        } else if (item.hasKnown()) {
-            LOG.info(item.getKnown().toString());
+        if (item.hasDiscovered() || item.hasKnown()) {
+            LOG.info(item.toString());
         } else {
             LOG.error("Unknown URLItem type");
         }
@@ -236,6 +243,9 @@ class RocksDBServiceTest {
                     public void onNext(URLItem value) {
                         // receives confirmation that the value has been received
                         logURLItem(value);
+
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
 
                         // Internally, MemoryFrontierService does not make a distinction
                         // between discovered and known which have to be re-fetched
@@ -281,6 +291,9 @@ class RocksDBServiceTest {
                         // receives confirmation that the value has been received
                         logURLItem(value);
 
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
+
                         if (value.hasKnown()) {
                             fetched.incrementAndGet();
                         }
@@ -299,7 +312,7 @@ class RocksDBServiceTest {
                 };
 
         rocksDBService.listURLs(params, statusObserver);
-        assertEquals(4, count.get());
+        assertEquals(5, count.get());
     }
 
     @Test
@@ -324,6 +337,9 @@ class RocksDBServiceTest {
                         // receives confirmation that the value has been received
                         logURLItem(value);
 
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
+
                         if (value.hasKnown()) {
                             fetched.incrementAndGet();
                         }
@@ -347,7 +363,7 @@ class RocksDBServiceTest {
 
     @Test
     @Order(7)
-    void testMemoryIterator() {
+    void testUrlIterator() {
         int nbQueues = 0;
         int nbUrls = 0;
 
@@ -357,18 +373,20 @@ class RocksDBServiceTest {
             Iterator<URLItem> iter = rocksDBService.urlIterator(cur, 0, 100);
             while (iter.hasNext()) {
                 URLItem item = iter.next();
+                // Check creation date is not null
+                assertTrue(item.getCreationDate() > 0);
                 System.out.println(item.toString());
                 nbUrls++;
             }
         }
 
-        assertEquals(2, nbQueues);
-        assertEquals(4, nbUrls);
+        assertEquals(3, nbQueues);
+        assertEquals(5, nbUrls);
     }
 
     @Test
     @Order(8)
-    void testMemoryIteratorSingleQueue() {
+    void testUrlIteratorSingleQueue() {
         int nbQueues = 0;
         int nbUrls = 0;
 
@@ -382,13 +400,15 @@ class RocksDBServiceTest {
             Iterator<URLItem> iter = rocksDBService.urlIterator(cur, 0, 100);
             while (iter.hasNext()) {
                 URLItem item = iter.next();
+                // Check creation date is not null
+                assertTrue(item.getCreationDate() > 0);
                 System.out.println(item.toString());
                 nbUrls++;
             }
         }
 
-        assertEquals(1, nbQueues);
-        assertEquals(3, nbUrls);
+        assertEquals(2, nbQueues);
+        assertEquals(4, nbUrls);
     }
 
     @Test
@@ -496,7 +516,7 @@ class RocksDBServiceTest {
     }
 
     @Test
-    @Order(98)
+    @Order(90)
     void testNoRescheduleCompleted() {
 
         String crawlId = "crawl_id";
@@ -513,6 +533,9 @@ class RocksDBServiceTest {
                     public void onNext(URLItem value) {
                         // receives confirmation that the value has been received
                         logURLItem(value);
+
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
 
                         // Internally, MemoryFrontierService does not make a distinction
                         // between discovered and known which have to be re-fetched
@@ -606,6 +629,9 @@ class RocksDBServiceTest {
                         // receives confirmation that the value has been received
                         logURLItem(value);
 
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
+
                         // Internally, MemoryFrontierService does not make a distinction
                         // between discovered and known which have to be re-fetched
                         if (value.hasKnown()) {
@@ -628,7 +654,7 @@ class RocksDBServiceTest {
     }
 
     @Test
-    @Order(99)
+    @Order(91)
     void testRescheduleCompleted() {
 
         String crawlId = "crawl_id";
@@ -646,6 +672,9 @@ class RocksDBServiceTest {
                     public void onNext(URLItem value) {
                         // receives confirmation that the value has been received
                         logURLItem(value);
+
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
 
                         // Internally, MemoryFrontierService does not make a distinction
                         // between discovered and known which have to be re-fetched
@@ -805,6 +834,9 @@ class RocksDBServiceTest {
                         // receives confirmation that the value has been received
                         logURLItem(value);
 
+                        // Check creation date is not null
+                        assertTrue(value.getCreationDate() > 0);
+
                         // Internally, MemoryFrontierService does not make a distinction
                         // between discovered and known which have to be re-fetched
                         if (value.hasKnown()) {
@@ -824,5 +856,109 @@ class RocksDBServiceTest {
                 };
 
         rocksDBService.getURLStatus(request, statusObserver2);
+    }
+
+    @Test
+    @Order(92)
+    void testDeleteURLItem() {
+
+        URLInfo info5 =
+                URLInfo.newBuilder()
+                        .setUrl("https://www.delete.me/tobedeleted")
+                        .setCrawlID("crawl_id")
+                        .setKey("delete_queue")
+                        .build();
+
+        crawlercommons.urlfrontier.Urlfrontier.URLItem.Builder builder5 = URLItem.newBuilder();
+        KnownURLItem deleteItem =
+                KnownURLItem.newBuilder()
+                        .setInfo(info5)
+                        .setRefetchableFromDate(Instant.now().getEpochSecond() + 3600)
+                        .build();
+
+        builder5.setKnown(deleteItem);
+        builder5.setID("crawl_id" + "_" + "https://www.delete.me/tobedeleted");
+
+        rocksDBService.deleteURLItem(builder5.build());
+
+        CountUrlParams countParams = CountUrlParams.newBuilder().setCrawlID("crawl_id").build();
+        final AtomicLong count = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> countObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        rocksDBService.countURLs(countParams, countObserver);
+        assertEquals(4L, count.get());
+    }
+
+    @Test
+    @Order(99)
+    @Disabled
+    // Must hardcode creation date in service before testing that
+    // Test works with creation date set as Unix Epoch 489243020L (3/Jul/1985) and guaranteed to
+    // work until 2040
+    void testPurge() {
+
+        PurgeUrlParams purgeParams1 =
+                PurgeUrlParams.newBuilder().setCrawlID("crawl_id").setDays(20000).build();
+
+        final AtomicLong count1 = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> purgeObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count1.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        rocksDBService.purgeURLs(purgeParams1, purgeObserver);
+        assertEquals(0L, count1.get());
+
+        PurgeUrlParams purgeParams2 =
+                PurgeUrlParams.newBuilder().setCrawlID("crawl_id").setDays(365).build();
+
+        final AtomicLong count2 = new AtomicLong(0L);
+        StreamObserver<Urlfrontier.Long> countObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        count2.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        rocksDBService.purgeURLs(purgeParams2, countObserver);
+
+        assertEquals(5L, count2.get());
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
@@ -27,6 +27,8 @@ public class ServiceTestUtil {
         String key3 = "queue_mysite";
         String url4 = "https://www.mysite.com/secondqueue";
         String key4 = "another_queue";
+        String url5 = "https://www.delete.me/tobedeleted";
+        String key5 = "delete_queue";
 
         final AtomicBoolean completed = new AtomicBoolean(false);
         final AtomicInteger acked = new AtomicInteger(0);
@@ -152,6 +154,21 @@ public class ServiceTestUtil {
         builder4.setID(crawlId + "_" + url4);
 
         streamObserver.onNext(builder4.build());
+        sent++;
+
+        URLInfo info5 = URLInfo.newBuilder().setUrl(url5).setCrawlID(crawlId).setKey(key5).build();
+
+        crawlercommons.urlfrontier.Urlfrontier.URLItem.Builder builder5 = URLItem.newBuilder();
+        KnownURLItem deleteItem =
+                KnownURLItem.newBuilder()
+                        .setInfo(info5)
+                        .setRefetchableFromDate(Instant.now().getEpochSecond() + 3600)
+                        .build();
+
+        builder5.setKnown(deleteItem);
+        builder5.setID(crawlId + "_" + url5);
+
+        streamObserver.onNext(builder5.build());
         sent++;
 
         streamObserver.onCompleted();

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
@@ -3,6 +3,9 @@
 
 package crawlercommons.urlfrontier.service;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
+import crawlercommons.urlfrontier.Urlfrontier;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
@@ -13,6 +16,7 @@ import io.grpc.stub.StreamObserver;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ServiceTestUtil {
 
@@ -181,5 +185,42 @@ public class ServiceTestUtil {
                 Thread.currentThread().interrupt();
             }
         }
+    }
+
+    /**
+     * Returns the total number of URLs in the service (all crawls & queues)
+     *
+     * @param service
+     * @return
+     */
+    public static long countAllURLs(AbstractFrontierService service) {
+
+        final AtomicLong ret = new AtomicLong(0L);
+
+        StreamObserver<Urlfrontier.Long> responseObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {
+                        ret.set(value.getValue());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        fail();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        Urlfrontier.CountUrlParams.Builder builder = Urlfrontier.CountUrlParams.newBuilder();
+        builder.setCrawlID("crawl_id");
+        builder.setLocal(true);
+
+        service.countURLs(builder.build(), responseObserver);
+
+        return ret.get();
     }
 }


### PR DESCRIPTION
With this PR, we now store the creation of each URL in the frontier so that old URLs can be purged from the frontier after a given retention period. This is achieved by calling the new **purgeURLs** method from the API.

