### PR TITLE
Distributed service: route SetDelay and BlockQueueUntil to the owner node

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -15,12 +15,14 @@ import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
+import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
 import crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Empty;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.LogLevelParams;
 import crawlercommons.urlfrontier.Urlfrontier.Pagination;
+import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.QueueList;
 import crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams;
 import crawlercommons.urlfrontier.Urlfrontier.Stats;
@@ -40,6 +42,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -64,6 +67,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     protected boolean clusterMode = false;
 
+    /** Maximum time granted to a forwarded control call before failing the caller. */
+    static final int FORWARD_DEADLINE_SECONDS = 30;
+
     private final CacheLoader<String, ManagedChannel> channelLoader =
             new CacheLoader<String, ManagedChannel>() {
                 @Override
@@ -85,6 +91,130 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     private URLFrontierBlockingStub getFrontier(String target) {
         return URLFrontierGrpc.newBlockingStub(channelCache.getUnchecked(target));
+    }
+
+    /**
+     * Identifies the partition (index in the sorted node list) owning a queue. Must stay
+     * bit-for-bit identical to the historical inline computation in putURLs: changing it (e.g. to
+     * floorMod) would silently remap existing queues without migration.
+     */
+    static int partitionFor(QueueWithinCrawl qwc, List<String> nodes) {
+        return Math.abs(qwc.toString().hashCode() % nodes.size());
+    }
+
+    @FunctionalInterface
+    interface LocalEmptyCall {
+        void invoke(StreamObserver<Empty> observer);
+    }
+
+    @FunctionalInterface
+    interface RemoteEmptyCall {
+        void invoke(URLFrontierStub stub, StreamObserver<Empty> observer);
+    }
+
+    private URLFrontierStub getAsyncFrontier(String target) {
+        return URLFrontierGrpc.newStub(channelCache.getUnchecked(target))
+                .withDeadlineAfter(FORWARD_DEADLINE_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Runs the call on the node owning the queue: locally when this node is the owner, otherwise
+     * forwarded once to the owner with a deadline. Exactly one terminal event reaches the response
+     * observer.
+     */
+    private void routeToOwner(
+            QueueWithinCrawl qwc,
+            LocalEmptyCall localCall,
+            RemoteEmptyCall remoteCall,
+            StreamObserver<Empty> responseObserver) {
+        final List<String> nodes = List.copyOf(getNodes());
+        final int localNodeIndex = nodes.indexOf(address);
+        if (localNodeIndex == -1) {
+            throw new RuntimeException(
+                    "Found conf 'nodes' but current node's address not in the list");
+        }
+        final int partition = partitionFor(qwc, nodes);
+        if (partition == localNodeIndex) {
+            localCall.invoke(responseObserver);
+        } else {
+            final EmptyAggregator aggregator = new EmptyAggregator(1, responseObserver);
+            remoteCall.invoke(getAsyncFrontier(nodes.get(partition)), aggregator.newChild());
+        }
+    }
+
+    /**
+     * Applies the call locally first, then forwards it to every other node with a deadline, so a
+     * fast remote failure can never unblock the caller before the local application has completed.
+     * Success is reported only when all nodes responded; the first failure is reported instead. The
+     * operation is not atomic: some nodes may have applied it when an error is returned. Repeating
+     * the same assignment is idempotent in the absence of concurrent newer writes.
+     */
+    private void broadcastAll(
+            LocalEmptyCall localCall,
+            RemoteEmptyCall remoteCall,
+            StreamObserver<Empty> responseObserver) {
+        final List<String> nodes = List.copyOf(getNodes());
+        if (nodes.indexOf(address) == -1) {
+            throw new RuntimeException(
+                    "Found conf 'nodes' but current node's address not in the list");
+        }
+        final EmptyAggregator aggregator = new EmptyAggregator(nodes.size(), responseObserver);
+        localCall.invoke(aggregator.newChild());
+        for (String node : nodes) {
+            if (node.equals(address)) {
+                continue;
+            }
+            remoteCall.invoke(getAsyncFrontier(node), aggregator.newChild());
+        }
+    }
+
+    /**
+     * In cluster mode, a keyed request with local=false is routed to the node owning the queue; a
+     * keyless one (default delay) is applied on every node. local=true always stays local.
+     */
+    @Override
+    public void setDelay(QueueDelayParams request, StreamObserver<Empty> responseObserver) {
+        if (request.getLocal() || !clusterMode || isClosing()) {
+            super.setDelay(request, responseObserver);
+            return;
+        }
+        final QueueDelayParams localParams =
+                QueueDelayParams.newBuilder(request).setLocal(true).build();
+        if (request.getKey().isEmpty()) {
+            broadcastAll(
+                    observer -> super.setDelay(localParams, observer),
+                    (stub, observer) -> stub.setDelay(localParams, observer),
+                    responseObserver);
+        } else {
+            final QueueWithinCrawl qwc =
+                    QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
+            routeToOwner(
+                    qwc,
+                    observer -> super.setDelay(localParams, observer),
+                    (stub, observer) -> stub.setDelay(localParams, observer),
+                    responseObserver);
+        }
+    }
+
+    /**
+     * In cluster mode, a keyed request with local=false is routed to the node owning the queue. An
+     * empty key keeps the historical local no-op instead of being routed to an artificial owner.
+     * local=true always stays local.
+     */
+    @Override
+    public void blockQueueUntil(BlockQueueParams request, StreamObserver<Empty> responseObserver) {
+        if (request.getLocal() || !clusterMode || isClosing() || request.getKey().isEmpty()) {
+            super.blockQueueUntil(request, responseObserver);
+            return;
+        }
+        final QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
+        final BlockQueueParams localParams =
+                BlockQueueParams.newBuilder(request).setLocal(true).build();
+        routeToOwner(
+                qwc,
+                observer -> super.blockQueueUntil(localParams, observer),
+                (stub, observer) -> stub.blockQueueUntil(localParams, observer),
+                responseObserver);
     }
 
     /** Create or return an existing stream to an external Frontier * */
@@ -493,7 +623,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 final QueueWithinCrawl qk = QueueWithinCrawl.get(Qkey, crawlID);
 
                 // work out which node should receive the item
-                int partition = Math.abs(qk.toString().hashCode() % getNodes().size());
+                int partition = partitionFor(qk, getNodes());
 
                 // is it the local node?
                 int localNodeIndex = getNodes().indexOf(address);

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/EmptyAggregator.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/EmptyAggregator.java
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import crawlercommons.urlfrontier.Urlfrontier.Empty;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Aggregates the responses of N unary Empty calls into a single terminal event on the downstream
+ * observer: onNext + onCompleted once all N children have completed, or onError on the first child
+ * error. Guarantees exactly one terminal event; late child callbacks after termination are ignored.
+ */
+class EmptyAggregator {
+
+    private final StreamObserver<Empty> downstream;
+    private final AtomicInteger pending;
+    private final AtomicBoolean terminated = new AtomicBoolean(false);
+
+    EmptyAggregator(int expected, StreamObserver<Empty> downstream) {
+        this.downstream = downstream;
+        this.pending = new AtomicInteger(expected);
+        if (expected <= 0 && terminated.compareAndSet(false, true)) {
+            downstream.onNext(Empty.getDefaultInstance());
+            downstream.onCompleted();
+        }
+    }
+
+    StreamObserver<Empty> newChild() {
+        return new StreamObserver<Empty>() {
+            @Override
+            public void onNext(Empty value) {
+                // unary Empty payload carries no information
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                if (terminated.compareAndSet(false, true)) {
+                    downstream.onError(Status.fromThrowable(t).asRuntimeException());
+                }
+            }
+
+            @Override
+            public void onCompleted() {
+                if (pending.decrementAndGet() == 0 && terminated.compareAndSet(false, true)) {
+                    downstream.onNext(Empty.getDefaultInstance());
+                    downstream.onCompleted();
+                }
+            }
+        };
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.PriorityQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -33,7 +34,9 @@ public class MemoryFrontierService extends AbstractFrontierService {
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(MemoryFrontierService.class);
 
-    private Map<String, Long> creationDates = new HashMap<>();
+    // written by the putURLs worker threads, read without synchronization by
+    // getURLStatus and the URL iterators
+    private Map<String, Long> creationDates = new ConcurrentHashMap<>();
 
     public MemoryFrontierService(final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
@@ -154,13 +157,14 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 }
             }
 
+            creationDates.put(iu.url, Instant.now().getEpochSecond());
+
             // add the new item
             // unless it is an update and it's nextFetchDate is 0 == NEVER
             if (!discovered && iu.nextFetchDate == 0) {
                 putURLs_completed_count.inc();
                 queue.addToCompleted(iu.url);
             } else {
-                creationDates.put(iu.url, Instant.now().getEpochSecond());
                 queue.add(iu);
             }
         }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -1,0 +1,402 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Two sharded RocksDB services behind real gRPC servers. Tests are ordered: routing behaviour
+ * first, node-failure behaviour last (node B is shut down and stays down).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class DistributedFrontierServiceTest {
+
+    private static final int PORT_A = 7301;
+    private static final int PORT_B = 7302;
+    private static final List<String> NODES = List.of("localhost:" + PORT_A, "localhost:" + PORT_B);
+    private static final String PATH_A = "./target/rocksdb-shard-a";
+    private static final String PATH_B = "./target/rocksdb-shard-b";
+
+    static ShardedRocksDBService serviceA;
+    static ShardedRocksDBService serviceB;
+    static Server serverA;
+    static Server serverB;
+    static ManagedChannel channelA;
+    static URLFrontierBlockingStub stubA;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        FileUtils.deleteQuietly(new File(PATH_A));
+        FileUtils.deleteQuietly(new File(PATH_B));
+        serviceA = newService(PATH_A, PORT_A);
+        serviceB = newService(PATH_B, PORT_B);
+        serverA = ServerBuilder.forPort(PORT_A).addService(serviceA).build().start();
+        serverB = ServerBuilder.forPort(PORT_B).addService(serviceB).build().start();
+        channelA = ManagedChannelBuilder.forTarget("localhost:" + PORT_A).usePlaintext().build();
+        stubA = URLFrontierGrpc.newBlockingStub(channelA);
+    }
+
+    private static ShardedRocksDBService newService(String path, int port) {
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", path);
+        conf.put("nodes", String.join(",", NODES));
+        return new ShardedRocksDBService(conf, "localhost", port);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (channelA != null) {
+            try {
+                channelA.shutdownNow();
+                channelA.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        for (Server server : new Server[] {serverA, serverB}) {
+            if (server == null || server.isTerminated()) {
+                continue;
+            }
+            try {
+                server.shutdownNow();
+                server.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        try {
+            if (serviceA != null) {
+                serviceA.close();
+            }
+        } finally {
+            try {
+                if (serviceB != null) {
+                    serviceB.close();
+                }
+            } finally {
+                FileUtils.deleteQuietly(new File(PATH_A));
+                FileUtils.deleteQuietly(new File(PATH_B));
+            }
+        }
+    }
+
+    /** Finds a key owned by the wanted partition, distinct per label. */
+    private static String keyOwnedBy(int partition, String label) {
+        for (int i = 0; i < 10_000; i++) {
+            String key = label + "-" + i + ".test";
+            if (DistributedFrontierService.partitionFor(QueueWithinCrawl.get(key, "DEFAULT"), NODES)
+                    == partition) {
+                return key;
+            }
+        }
+        throw new IllegalStateException("no key found for partition " + partition);
+    }
+
+    /**
+     * Creates a queue by sending a URL through node A's gRPC putURLs endpoint; the distributed
+     * service routes it to the owner. Never call service.putURLs directly: it casts the observer to
+     * ServerCallStreamObserver.
+     */
+    private static void createQueue(String key, String crawlId) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<URLItem> input =
+                URLFrontierGrpc.newStub(channelA)
+                        .putURLs(
+                                new StreamObserver<AckMessage>() {
+                                    @Override
+                                    public void onNext(AckMessage value) {}
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        latch.countDown();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        latch.countDown();
+                                    }
+                                });
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://" + key + "/page")
+                        .setKey(key)
+                        .setCrawlID(crawlId)
+                        .build();
+        input.onNext(
+                URLItem.newBuilder()
+                        .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                        .build());
+        input.onCompleted();
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "putURLs did not complete in time");
+    }
+
+    @Test
+    @Order(1)
+    void smokePutUrlsCreatesQueueOnOwnerOnly() throws Exception {
+        String key = keyOwnedBy(1, "smoke");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+        assertNotNull(serviceB.getQueues().get(qwc), "queue must exist on the owner (node B)");
+        assertNull(serviceA.getQueues().get(qwc), "queue must not exist on the non-owner");
+    }
+
+    @Test
+    @Order(2)
+    void keyedSetDelayLocalFalseReachesOwner() throws Exception {
+        String key = keyOwnedBy(1, "delay");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+
+        // sent to the NON-owner node A with local=false
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(123)
+                        .setLocal(false)
+                        .build());
+
+        assertEquals(
+                123,
+                serviceB.getQueues().get(qwc).getDelay(),
+                "owner queue must receive the delay (silent no-op on master)");
+        assertNull(serviceA.getQueues().get(qwc), "no queue must be created on the non-owner");
+    }
+
+    @Test
+    @Order(3)
+    void keylessSetDelayLocalFalseSetsDefaultOnEveryNode() {
+        stubA.setDelay(
+                QueueDelayParams.newBuilder().setDelayRequestable(77).setLocal(false).build());
+
+        assertEquals(77, serviceA.getDefaultDelayForQueues());
+        assertEquals(77, serviceB.getDefaultDelayForQueues());
+    }
+
+    @Test
+    @Order(4)
+    void keyedSetDelayLocalTrueNeverLeavesTheNode() throws Exception {
+        String key = keyOwnedBy(1, "delaylocal");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(555)
+                        .setLocal(true)
+                        .build());
+
+        assertNotEquals(
+                555,
+                serviceB.getQueues().get(qwc).getDelay(),
+                "local=true on the non-owner must not touch the owner queue");
+    }
+
+    @Test
+    @Order(5)
+    void keyedBlockQueueUntilLocalFalseReachesOwner() throws Exception {
+        String key = keyOwnedBy(1, "block");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+        long until = Instant.now().getEpochSecond() + 3600;
+
+        stubA.blockQueueUntil(
+                BlockQueueParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setTime(until)
+                        .setLocal(false)
+                        .build());
+
+        assertEquals(
+                until,
+                serviceB.getQueues().get(qwc).getBlockedUntil(),
+                "owner queue must be blocked (silent no-op on master)");
+    }
+
+    @Test
+    @Order(6)
+    void emptyKeyBlockQueueUntilIsLocalNoOp() {
+        // must not compute an artificial owner nor fail: historical local no-op preserved
+        assertDoesNotThrow(
+                () ->
+                        stubA.blockQueueUntil(
+                                BlockQueueParams.newBuilder()
+                                        .setTime(9_999_999_999L)
+                                        .setLocal(false)
+                                        .build()));
+        assertNull(
+                serviceA.getQueues().get(QueueWithinCrawl.get("", "DEFAULT")),
+                "no artificial queue must be created anywhere");
+        assertNull(serviceB.getQueues().get(QueueWithinCrawl.get("", "DEFAULT")));
+    }
+
+    @Test
+    @Order(7)
+    void emptyCrawlIdIsNormalisedAcrossRouting() throws Exception {
+        // QueueWithinCrawl.get normalises "" to DEFAULT, so the partition matches keyOwnedBy
+        String key = keyOwnedBy(1, "normalise");
+        createQueue(key, "");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "");
+
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("")
+                        .setDelayRequestable(42)
+                        .setLocal(false)
+                        .build());
+
+        assertEquals(42, serviceB.getQueues().get(qwc).getDelay());
+    }
+
+    @Test
+    @Order(8)
+    void queueAbsentOnOwnerIsSilentSuccess() {
+        String key = keyOwnedBy(1, "absent");
+        // no createQueue on purpose: same success/no-op as AbstractFrontierService today
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(55)
+                        .setLocal(false)
+                        .build());
+        assertNull(serviceB.getQueues().get(QueueWithinCrawl.get(key, "DEFAULT")));
+    }
+
+    @Test
+    @Order(9)
+    void repeatedAssignmentIsIdempotent() throws Exception {
+        String key = keyOwnedBy(1, "idem");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+        QueueDelayParams params =
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(88)
+                        .setLocal(false)
+                        .build();
+
+        stubA.setDelay(params);
+        stubA.setDelay(params);
+
+        assertEquals(88, serviceB.getQueues().get(qwc).getDelay());
+    }
+
+    @Test
+    @Order(20)
+    void ownerUnreachableSurfacesError() throws Exception {
+        serverB.shutdownNow();
+        serverB.awaitTermination(5, TimeUnit.SECONDS);
+
+        String key = keyOwnedBy(1, "down");
+        assertThrows(
+                StatusRuntimeException.class,
+                () ->
+                        stubA.withDeadlineAfter(
+                                        DistributedFrontierService.FORWARD_DEADLINE_SECONDS + 10,
+                                        TimeUnit.SECONDS)
+                                .setDelay(
+                                        QueueDelayParams.newBuilder()
+                                                .setKey(key)
+                                                .setCrawlID("DEFAULT")
+                                                .setDelayRequestable(11)
+                                                .setLocal(false)
+                                                .build()),
+                "forward to a dead owner must fail, not silently no-op");
+    }
+
+    @Test
+    @Order(21)
+    void partialBroadcastFailureSurfacesErrorButLocalApplies() {
+        assertThrows(
+                StatusRuntimeException.class,
+                () ->
+                        stubA.setDelay(
+                                QueueDelayParams.newBuilder()
+                                        .setDelayRequestable(99)
+                                        .setLocal(false)
+                                        .build()));
+        // documented partial application: the reachable node applied the value
+        assertEquals(99, serviceA.getDefaultDelayForQueues());
+    }
+
+    @Test
+    @Order(22)
+    void localTrueUnaffectedByDeadNode() throws Exception {
+        String key = keyOwnedBy(0, "localalive");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(33)
+                        .setLocal(true)
+                        .build());
+
+        assertEquals(33, serviceA.getQueues().get(qwc).getDelay());
+    }
+
+    @Test
+    @Order(23)
+    void keyedLocalFalseOwnedLocallyWorksWithDeadNode() throws Exception {
+        String key = keyOwnedBy(0, "ownerlocal");
+        createQueue(key, "DEFAULT");
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+
+        stubA.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(44)
+                        .setLocal(false)
+                        .build());
+
+        assertEquals(44, serviceA.getQueues().get(qwc).getDelay());
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/EmptyAggregatorTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/EmptyAggregatorTest.java
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.Urlfrontier.Empty;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class EmptyAggregatorTest {
+
+    private static final class RecordingObserver implements StreamObserver<Empty> {
+        final List<String> events = new ArrayList<>();
+
+        @Override
+        public void onNext(Empty value) {
+            events.add("next");
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            events.add("error");
+        }
+
+        @Override
+        public void onCompleted() {
+            events.add("completed");
+        }
+    }
+
+    @Test
+    void allChildrenCompletedProducesSingleSuccess() {
+        RecordingObserver downstream = new RecordingObserver();
+        EmptyAggregator aggregator = new EmptyAggregator(3, downstream);
+        StreamObserver<Empty> c1 = aggregator.newChild();
+        StreamObserver<Empty> c2 = aggregator.newChild();
+        StreamObserver<Empty> c3 = aggregator.newChild();
+
+        c1.onCompleted();
+        c2.onCompleted();
+        assertTrue(downstream.events.isEmpty(), "no terminal event before all children complete");
+        c3.onCompleted();
+
+        assertEquals(List.of("next", "completed"), downstream.events);
+    }
+
+    @Test
+    void firstErrorWinsAndLaterCompletionsAreIgnored() {
+        RecordingObserver downstream = new RecordingObserver();
+        EmptyAggregator aggregator = new EmptyAggregator(2, downstream);
+        StreamObserver<Empty> c1 = aggregator.newChild();
+        StreamObserver<Empty> c2 = aggregator.newChild();
+
+        c1.onError(new RuntimeException("boom"));
+        c2.onCompleted();
+
+        assertEquals(List.of("error"), downstream.events);
+    }
+
+    @Test
+    void lateErrorAfterCompletionIsIgnored() {
+        RecordingObserver downstream = new RecordingObserver();
+        EmptyAggregator aggregator = new EmptyAggregator(1, downstream);
+        StreamObserver<Empty> c1 = aggregator.newChild();
+
+        c1.onCompleted();
+        c1.onError(new RuntimeException("late"));
+
+        assertEquals(List.of("next", "completed"), downstream.events);
+    }
+
+    @Test
+    void doubleErrorProducesSingleTerminalEvent() {
+        RecordingObserver downstream = new RecordingObserver();
+        EmptyAggregator aggregator = new EmptyAggregator(2, downstream);
+
+        aggregator.newChild().onError(new RuntimeException("a"));
+        aggregator.newChild().onError(new RuntimeException("b"));
+
+        assertEquals(List.of("error"), downstream.events);
+    }
+
+    @Test
+    void zeroExpectedCompletesImmediately() {
+        RecordingObserver downstream = new RecordingObserver();
+        new EmptyAggregator(0, downstream);
+
+        assertEquals(List.of("next", "completed"), downstream.events);
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/PartitionForTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/PartitionForTest.java
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PartitionForTest {
+
+    private static final List<String> THREE_NODES =
+            List.of("node1:7071", "node2:7071", "node3:7071");
+
+    @Test
+    void matchesLegacyPutUrlsFormula() {
+        QueueWithinCrawl qwc = QueueWithinCrawl.get("example.com", "DEFAULT");
+        assertEquals(
+                Math.abs(qwc.toString().hashCode() % THREE_NODES.size()),
+                DistributedFrontierService.partitionFor(qwc, THREE_NODES));
+    }
+
+    @Test
+    void negativeHashKeepsLegacyMapping() {
+        // with 2 nodes abs and floorMod coincide; 3 nodes tell them apart:
+        // abs(-2 % 3) = 2 while floorMod(-2, 3) = 1
+        QueueWithinCrawl negative = null;
+        for (int i = 0; i < 10_000; i++) {
+            QueueWithinCrawl candidate = QueueWithinCrawl.get("host-" + i + ".com", "DEFAULT");
+            if (candidate.toString().hashCode() % THREE_NODES.size() < 0) {
+                negative = candidate;
+                break;
+            }
+        }
+        assertNotNull(negative, "no negative-hash key found in search space");
+        int hash = negative.toString().hashCode();
+        assertEquals(
+                Math.abs(hash % 3), DistributedFrontierService.partitionFor(negative, THREE_NODES));
+        assertNotEquals(
+                Math.floorMod(hash, 3),
+                DistributedFrontierService.partitionFor(negative, THREE_NODES));
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/** A sharded service configured with a single node must behave exactly like before the fix. */
+class SingleNodeShardedServiceTest {
+
+    private static final int PORT = 7401;
+    private static final String PATH = "./target/rocksdb-single";
+
+    static ShardedRocksDBService service;
+    static Server server;
+    static ManagedChannel channel;
+    static URLFrontierBlockingStub stub;
+
+    @BeforeAll
+    static void setup() throws IOException {
+        FileUtils.deleteQuietly(new File(PATH));
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", PATH);
+        conf.put("nodes", "localhost:" + PORT);
+        service = new ShardedRocksDBService(conf, "localhost", PORT);
+        server = ServerBuilder.forPort(PORT).addService(service).build().start();
+        channel = ManagedChannelBuilder.forTarget("localhost:" + PORT).usePlaintext().build();
+        stub = URLFrontierGrpc.newBlockingStub(channel);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (channel != null) {
+            try {
+                channel.shutdownNow();
+                channel.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        if (server != null && !server.isTerminated()) {
+            try {
+                server.shutdownNow();
+                server.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        try {
+            if (service != null) {
+                service.close();
+            }
+        } finally {
+            FileUtils.deleteQuietly(new File(PATH));
+        }
+    }
+
+    @Test
+    void keyedSetDelayLocalFalseAppliedLocally() throws Exception {
+        assertFalse(service.clusterMode, "single-node config must not enable cluster mode");
+        String key = "single.test";
+        CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<URLItem> input =
+                URLFrontierGrpc.newStub(channel)
+                        .putURLs(
+                                new StreamObserver<AckMessage>() {
+                                    @Override
+                                    public void onNext(AckMessage value) {}
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        latch.countDown();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        latch.countDown();
+                                    }
+                                });
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://" + key + "/page")
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .build();
+        input.onNext(
+                URLItem.newBuilder()
+                        .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                        .build());
+        input.onCompleted();
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "putURLs did not complete in time");
+
+        stub.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setDelayRequestable(66)
+                        .setLocal(false)
+                        .build());
+
+        assertEquals(66, service.getQueues().get(QueueWithinCrawl.get(key, "DEFAULT")).getDelay());
+    }
+}


### PR DESCRIPTION
Fixes #146.

In a sharded deployment, `BlockQueueUntil` and `SetDelay` only updated the local queue map: a request sent with `local=false` to a node that does not own the queue completed successfully without changing anything. This PR routes those calls in `DistributedFrontierService`.

### Routing semantics

| Operation | local=true | local=false |
|---|---|---|
| BlockQueueUntil (keyed) | local | owner node |
| SetDelay (keyed) | local | owner node |
| SetDelay (keyless) | local | applied locally + forwarded to every other node |

- The owner is computed with the exact same partition function as `putURLs` (extracted as `partitionFor`, bit-for-bit identical — covered by a test that would fail under e.g. `floorMod`, which would silently remap existing queues).
- Forwarded copies carry `local=true`, which acts as the loop breaker; a keyed call whose owner is remote is **not** also applied locally.
- An empty-key `BlockQueueUntil` keeps the historical local no-op instead of being routed to an artificial owner.
- Forwards use the async stub with an explicit 30s deadline; a shared `EmptyAggregator` guarantees exactly one terminal event per call (all-complete → success, first failure → error).
- No protobuf change: both request messages already carry the `local` flag.

### Caveats (by design, documented in the Javadoc)

- The keyless broadcast is not atomic: some nodes may have applied the value when an error is returned. Repeating the same assignment is idempotent in the absence of concurrent newer writes.
- Rolling upgrade: old ingress nodes retain the previous local-only behaviour until upgraded; a new ingress forwarding to an old owner works, since the forwarded `local=true` path is already handled by the old code.
- These remain admin RPCs that assume a protected endpoint and trusted cluster membership (inter-node channels are plaintext today); a keyless call fans out O(N) RPCs.

### Also included

A pre-existing race in `MemoryFrontierService`, introduced by #143 and exposed by the new distributed tests: a completed URL added to an existing queue was not recorded in `creationDates`, so `GetURLStatus` and the URL iterators failed with a `NullPointerException` depending on write-thread scheduling. `creationDates` is also read without synchronization and is now a `ConcurrentHashMap`. Kept in this PR because it is tiny and stabilises the test suite; happy to split it out if preferred.

### Tests

- `PartitionForTest`: locks the partition mapping bit-for-bit (3-node negative-hash case distinguishes `Math.abs` from `floorMod`).
- `EmptyAggregatorTest`: single-terminal-event contract, late/double callbacks, zero-children completion.
- `DistributedFrontierServiceTest`: two `ShardedRocksDBService` instances behind real gRPC servers — silent no-op repro for both RPCs (red on master), keyless fan-out, `local=true` isolation, crawlID normalisation, absent queue, idempotent repeat, and node-failure modes (dead owner surfaces an error, partial broadcast surfaces an error while the reachable node applies, locally-owned keys unaffected).
- `SingleNodeShardedServiceTest`: single-node configuration keeps the previous behaviour (`clusterMode` off).

`mvn verify` on the service module: 71/71 green.

### Follow-up

`setActive` has the same class of gap (the `Active` message carries `local`, no distributed override) and is a natural first reuse of `broadcastAll` — tracked in #149.