### PR TITLE
Distributed service: cluster-wide SetActive and aggregated GetActive

### DIFF
--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -54,10 +54,12 @@ service URLFrontier {
       **/
      rpc BlockQueueUntil(BlockQueueParams) returns (Empty) {}
           
-     /** De/activate the crawl. GetURLs will not return anything until SetActive is set to true. PutURLs will still take incoming data. **/
+     /** De/activate the frontier. GetURLs will not return anything until SetActive is set to true. PutURLs will still take incoming data.
+      The state belongs to the frontier node, not to a specific crawl; with local set to false the change is applied to every node in the cluster. **/
      rpc SetActive(Active) returns (Empty) {}
 
-     /** Returns true if the crawl is active, false if it has been deactivated with SetActive(Boolean) **/
+     /** Returns true if the frontier is active, false if it has been deactivated with SetActive.
+      With local set to false, returns true only if every node in the cluster is active. **/
      rpc GetActive(Local) returns (Boolean) {}
      
      /** Set a delay from a given queue.

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -111,7 +111,9 @@ public abstract class AbstractFrontierService
                     .help("Number of completed URLs")
                     .register();
 
-    private boolean active = true;
+    // written by setActive on gRPC handler threads, read by getURLs on other
+    // threads: volatile for visibility (JVM-level only, not distributed ordering)
+    private volatile boolean active = true;
 
     private int defaultDelayForQueues = 1;
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -17,6 +17,7 @@ import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
 import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
+import crawlercommons.urlfrontier.Urlfrontier.Boolean;
 import crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Empty;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
@@ -34,6 +35,7 @@ import crawlercommons.urlfrontier.service.AbstractFrontierService;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
+import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
@@ -236,6 +238,56 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 observer -> super.setActive(localParams, observer),
                 (stub, observer) -> stub.setActive(localParams, observer),
                 responseObserver);
+    }
+
+    /**
+     * In cluster mode, local=false returns the AND of every node's state: true only if all nodes
+     * are active. A mixed state returns false and logs a warning. This is not an atomic snapshot:
+     * it aggregates the states observed while querying the nodes, under a single shared deadline.
+     * An unreachable node surfaces an error rather than a fabricated false. local=true returns the
+     * state of this node only.
+     */
+    @Override
+    public void getActive(Local request, StreamObserver<Boolean> responseObserver) {
+        if (request.getLocal() || !clusterMode) {
+            super.getActive(request, responseObserver);
+            return;
+        }
+        final List<String> nodes = List.copyOf(getNodes());
+        if (nodes.indexOf(address) == -1) {
+            throw new RuntimeException(
+                    "Found conf 'nodes' but current node's address not in the list");
+        }
+        // one deadline for the whole aggregation, not per node
+        final Deadline deadline = Deadline.after(FORWARD_DEADLINE_SECONDS, TimeUnit.SECONDS);
+        final Local localRequest = Local.newBuilder().setLocal(true).build();
+        final boolean localState = isActive();
+        boolean allActive = localState;
+        boolean sawActive = localState;
+        boolean sawInactive = !localState;
+        try {
+            for (String node : nodes) {
+                if (node.equals(address)) {
+                    continue;
+                }
+                // &= evaluates the right-hand side regardless: every node is
+                // queried, an unreachable one fails the call instead of being
+                // silently folded into a false
+                final boolean nodeActive =
+                        getFrontier(node).withDeadline(deadline).getActive(localRequest).getState();
+                allActive &= nodeActive;
+                sawActive |= nodeActive;
+                sawInactive |= !nodeActive;
+            }
+        } catch (StatusRuntimeException e) {
+            responseObserver.onError(e);
+            return;
+        }
+        if (sawActive && sawInactive) {
+            LOG.warn("URLFrontier nodes report divergent active states");
+        }
+        responseObserver.onNext(Boolean.newBuilder().setState(allActive).build());
+        responseObserver.onCompleted();
     }
 
     /** Create or return an existing stream to an external Frontier * */

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -15,6 +15,7 @@ import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
+import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
 import crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Empty;
@@ -214,6 +215,26 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 qwc,
                 observer -> super.blockQueueUntil(localParams, observer),
                 (stub, observer) -> stub.blockQueueUntil(localParams, observer),
+                responseObserver);
+    }
+
+    /**
+     * In cluster mode, a request with local=false is applied locally and broadcast to every other
+     * node. Concurrent setActive calls are not globally ordered: conflicting broadcasts may leave
+     * nodes divergent even when each call reports success. local=true stays local. Unlike the other
+     * overrides there is no isClosing() guard, because the base method changes the flag even while
+     * closing.
+     */
+    @Override
+    public void setActive(Active request, StreamObserver<Empty> responseObserver) {
+        if (request.getLocal() || !clusterMode) {
+            super.setActive(request, responseObserver);
+            return;
+        }
+        final Active localParams = Active.newBuilder(request).setLocal(true).build();
+        broadcastAll(
+                observer -> super.setActive(localParams, observer),
+                (stub, observer) -> stub.setActive(localParams, observer),
                 responseObserver);
     }
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -368,6 +368,27 @@ class DistributedFrontierServiceTest {
     }
 
     @Test
+    @Order(12)
+    void getActiveLocalFalseIsFalseOnMixedState() {
+        try {
+            // deactivate B only, bypassing the broadcast
+            stubB.setActive(Active.newBuilder().setState(false).setLocal(true).build());
+
+            assertFalse(
+                    stubA.getActive(LOCAL_FALSE).getState(),
+                    "mixed cluster state must report inactive");
+        } finally {
+            stubB.setActive(Active.newBuilder().setState(true).setLocal(true).build());
+        }
+    }
+
+    @Test
+    @Order(13)
+    void getActiveLocalFalseIsTrueWhenAllNodesActive() {
+        assertTrue(stubA.getActive(LOCAL_FALSE).getState());
+    }
+
+    @Test
     @Order(20)
     void ownerUnreachableSurfacesError() throws Exception {
         serverB.shutdownNow();
@@ -439,5 +460,26 @@ class DistributedFrontierServiceTest {
                         .build());
 
         assertEquals(44, serviceA.getQueues().get(qwc).getDelay());
+    }
+
+    @Test
+    @Order(24)
+    void getActiveLocalFalseErrorsWhenNodeUnreachable() {
+        // an unreachable node must surface an error, never a fabricated false
+        assertThrows(StatusRuntimeException.class, () -> stubA.getActive(LOCAL_FALSE));
+    }
+
+    @Test
+    @Order(25)
+    void getActiveDoesNotShortCircuitOnLocalInactive() {
+        try {
+            stubA.setActive(Active.newBuilder().setState(false).setLocal(true).build());
+
+            // a short-circuiting implementation would return false here without
+            // querying the dead node; the contract requires an error instead
+            assertThrows(StatusRuntimeException.class, () -> stubA.getActive(LOCAL_FALSE));
+        } finally {
+            stubA.setActive(Active.newBuilder().setState(true).setLocal(true).build());
+        }
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -5,6 +5,7 @@ package crawlercommons.urlfrontier.service.cluster;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -14,8 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import crawlercommons.urlfrontier.URLFrontierGrpc;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
@@ -55,13 +58,17 @@ class DistributedFrontierServiceTest {
     private static final List<String> NODES = List.of("localhost:" + PORT_A, "localhost:" + PORT_B);
     private static final String PATH_A = "./target/rocksdb-shard-a";
     private static final String PATH_B = "./target/rocksdb-shard-b";
+    private static final Local LOCAL_TRUE = Local.newBuilder().setLocal(true).build();
+    private static final Local LOCAL_FALSE = Local.newBuilder().setLocal(false).build();
 
     static ShardedRocksDBService serviceA;
     static ShardedRocksDBService serviceB;
     static Server serverA;
     static Server serverB;
     static ManagedChannel channelA;
+    static ManagedChannel channelB;
     static URLFrontierBlockingStub stubA;
+    static URLFrontierBlockingStub stubB;
 
     @BeforeAll
     static void setup() throws IOException {
@@ -72,7 +79,9 @@ class DistributedFrontierServiceTest {
         serverA = ServerBuilder.forPort(PORT_A).addService(serviceA).build().start();
         serverB = ServerBuilder.forPort(PORT_B).addService(serviceB).build().start();
         channelA = ManagedChannelBuilder.forTarget("localhost:" + PORT_A).usePlaintext().build();
+        channelB = ManagedChannelBuilder.forTarget("localhost:" + PORT_B).usePlaintext().build();
         stubA = URLFrontierGrpc.newBlockingStub(channelA);
+        stubB = URLFrontierGrpc.newBlockingStub(channelB);
     }
 
     private static ShardedRocksDBService newService(String path, int port) {
@@ -84,10 +93,13 @@ class DistributedFrontierServiceTest {
 
     @AfterAll
     static void teardown() throws Exception {
-        if (channelA != null) {
+        for (ManagedChannel channel : new ManagedChannel[] {channelA, channelB}) {
+            if (channel == null) {
+                continue;
+            }
             try {
-                channelA.shutdownNow();
-                channelA.awaitTermination(5, TimeUnit.SECONDS);
+                channel.shutdownNow();
+                channel.awaitTermination(5, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
@@ -324,6 +336,35 @@ class DistributedFrontierServiceTest {
         stubA.setDelay(params);
 
         assertEquals(88, serviceB.getQueues().get(qwc).getDelay());
+    }
+
+    @Test
+    @Order(10)
+    void setActiveLocalFalseDeactivatesEveryNode() {
+        try {
+            stubA.setActive(Active.newBuilder().setState(false).setLocal(false).build());
+
+            assertFalse(
+                    stubA.getActive(LOCAL_TRUE).getState(),
+                    "node A must be inactive (silent local-only on master)");
+            assertFalse(
+                    stubB.getActive(LOCAL_TRUE).getState(),
+                    "node B must be inactive (silent local-only on master)");
+        } finally {
+            stubA.setActive(Active.newBuilder().setState(true).setLocal(false).build());
+        }
+    }
+
+    @Test
+    @Order(11)
+    void setActiveLocalTrueStaysLocal() {
+        try {
+            stubA.setActive(Active.newBuilder().setState(false).setLocal(true).build());
+
+            assertTrue(stubB.getActive(LOCAL_TRUE).getState(), "node B must stay active");
+        } finally {
+            stubA.setActive(Active.newBuilder().setState(true).setLocal(true).build());
+        }
     }
 
     @Test

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
@@ -10,7 +10,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import crawlercommons.urlfrontier.URLFrontierGrpc;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
@@ -126,5 +128,19 @@ class SingleNodeShardedServiceTest {
                         .build());
 
         assertEquals(66, service.getQueues().get(QueueWithinCrawl.get(key, "DEFAULT")).getDelay());
+    }
+
+    @Test
+    void setActiveAndGetActiveLocalFalseStayLocal() {
+        Local localFalse = Local.newBuilder().setLocal(false).build();
+        try {
+            stub.setActive(Active.newBuilder().setState(false).setLocal(false).build());
+
+            assertFalse(
+                    stub.getActive(localFalse).getState(),
+                    "single-node cluster: local state is the cluster state");
+        } finally {
+            stub.setActive(Active.newBuilder().setState(true).setLocal(false).build());
+        }
     }
 }


### PR DESCRIPTION
Fixes #149.

Follow-up to #148: `setActive` had the same class of bug — the `Active` message carries `local`, but `DistributedFrontierService` had no override, so a `local=false` call only changed the receiving node. This PR also gives `getActive(local=false)` a cluster-wide meaning, since state that is writable cluster-wide should also be readable cluster-wide.

### Semantics

| Call | local=true | local=false (cluster) |
|---|---|---|
| SetActive | receiving node only | applied locally + forwarded `local=true` to every node (reuses `broadcastAll` from #148: all respond → success, first failure → error) |
| GetActive | receiving node's state | **AND of every node's state** — true only if all nodes are active |

GetActive details:
- Mixed state → `false`, plus a WARN log to make the divergence visible.
- Unreachable node → RPC error, never a fabricated `false`.
- Every node is queried, no short-circuit — a dedicated test proves an error is returned even when the local node is already inactive.
- One shared deadline for the whole aggregation (30s total, not 30s × N).
- Unlike the #148 overrides there is no `isClosing()` guard on `setActive`: the base method changes the flag even while closing, so a guard would silently downgrade a cluster call to local-only.

### Consistency caveats (documented in the Javadoc)

- Concurrent `setActive` calls are not globally ordered; conflicting broadcasts may leave nodes divergent even when each call reports success.
- `getActive` is not an atomic snapshot: it aggregates the states observed during the query window.
- The `active` flag is now `volatile` (it is written by gRPC handler threads and read by `getURLs` without synchronization) — this addresses JVM visibility only, not distributed ordering.

### Tests

7 new tests across the existing two-node harness and the single-node guard: broadcast reaches both nodes, `local=true` isolation, mixed-state AND, all-active, dead-node error, no-short-circuit proof, single-node behaviour unchanged. Full service module: 78/78 green.
