### PR TITLE
Make the getURLs politeness gate atomic under concurrent requests

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -499,6 +499,21 @@ public abstract class AbstractFrontierService
         responseObserver.onCompleted();
     }
 
+    /**
+     * Checks whether a queue is currently eligible for serving URLs: its politeness delay has
+     * elapsed and it has not reached its cap of in-process URLs.
+     */
+    boolean checkQueueEligibility(QueueInterface queue, long now, int maxURLsPerQueue) {
+        int delay = queue.getDelay();
+        if (delay == -1) {
+            delay = getDefaultDelayForQueues();
+        }
+        if (queue.getLastProduced() + delay >= now) {
+            return false;
+        }
+        return queue.getInProcess(now) < maxURLsPerQueue;
+    }
+
     @Override
     public void getURLs(GetParams request, StreamObserver<URLInfo> responseObserver) {
         // on hold or shutting down
@@ -589,16 +604,8 @@ public abstract class AbstractFrontierService
                 return;
             }
 
-            // too early?
-            int delay = queue.getDelay();
-            if (delay == -1) delay = getDefaultDelayForQueues();
-            if (queue.getLastProduced() + delay >= now) {
-                responseObserver.onCompleted();
-                return;
-            }
-
-            // already has its fill of URLs in process
-            if (queue.getInProcess(now) >= maxURLsPerQueue) {
+            // too early or already has its fill of URLs in process?
+            if (!checkQueueEligibility(queue, now, maxURLsPerQueue)) {
                 responseObserver.onCompleted();
                 return;
             }
@@ -676,15 +683,8 @@ public abstract class AbstractFrontierService
                 continue;
             }
 
-            // too early?
-            int delay = currentQueue.getDelay();
-            if (delay == -1) delay = getDefaultDelayForQueues();
-            if (currentQueue.getLastProduced() + delay >= now) {
-                continue;
-            }
-
-            // already has its fill of URLs in process
-            if (currentQueue.getInProcess(now) >= maxURLsPerQueue) {
+            // too early or already has its fill of URLs in process?
+            if (!checkQueueEligibility(currentQueue, now, maxURLsPerQueue)) {
                 continue;
             }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.commons.io.FileUtils;
@@ -499,19 +500,67 @@ public abstract class AbstractFrontierService
         responseObserver.onCompleted();
     }
 
+    /** Returned by {@link #tryReserveQueue} when the queue cannot be reserved. */
+    static final long RESERVE_FAILED = Long.MIN_VALUE;
+
     /**
-     * Checks whether a queue is currently eligible for serving URLs: its politeness delay has
-     * elapsed and it has not reached its cap of in-process URLs.
+     * In-band marker stored in lastProduced while a send is in flight, so that no other request can
+     * reserve the queue regardless of executor scheduling delays. lastProduced is only ever read by
+     * this class, is not persisted, and 0 is a legitimate value, hence the sentinels.
      */
-    boolean checkQueueEligibility(QueueInterface queue, long now, int maxURLsPerQueue) {
-        int delay = queue.getDelay();
-        if (delay == -1) {
-            delay = getDefaultDelayForQueues();
+    static final long RESERVATION_IN_PROGRESS = Long.MAX_VALUE;
+
+    /**
+     * Atomically checks that a queue is eligible for serving URLs (politeness delay elapsed,
+     * in-process cap not reached, no send already in flight) and reserves it by storing {@link
+     * #RESERVATION_IN_PROGRESS} in lastProduced. Callers MUST finalize the reservation with {@link
+     * #finalizeReservation}.
+     *
+     * @return the previous lastProduced value if the queue was reserved, {@link #RESERVE_FAILED}
+     *     otherwise
+     */
+    long tryReserveQueue(QueueInterface queue, long now, int maxURLsPerQueue) {
+        synchronized (queue) {
+            long previous = queue.getLastProduced();
+            // must be checked first: it also guards the delay check below against overflow
+            // (RESERVATION_IN_PROGRESS + delay wraps negative)
+            if (previous == RESERVATION_IN_PROGRESS) {
+                return RESERVE_FAILED;
+            }
+            int delay = queue.getDelay();
+            if (delay == -1) {
+                delay = getDefaultDelayForQueues();
+            }
+            if (previous + delay >= now || queue.getInProcess(now) >= maxURLsPerQueue) {
+                return RESERVE_FAILED;
+            }
+            queue.setLastProduced(RESERVATION_IN_PROGRESS);
+            return previous;
         }
-        if (queue.getLastProduced() + delay >= now) {
-            return false;
+    }
+
+    /**
+     * Finalizes a reservation taken with {@link #tryReserveQueue}. Fail-closed: when the send did
+     * not complete normally its outcome is unknown (URLs may have been emitted before the
+     * exception), so the politeness window is enforced.
+     */
+    void finalizeReservation(
+            QueueInterface queue,
+            long reservationTime,
+            long previous,
+            int sent,
+            boolean completedNormally) {
+        synchronized (queue) {
+            if (queue.getLastProduced() != RESERVATION_IN_PROGRESS) {
+                // should never happen: no other writer while the queue is reserved
+                return;
+            }
+            if (completedNormally && sent == 0) {
+                queue.setLastProduced(previous);
+            } else {
+                queue.setLastProduced(reservationTime);
+            }
         }
-        return queue.getInProcess(now) < maxURLsPerQueue;
     }
 
     @Override
@@ -604,15 +653,29 @@ public abstract class AbstractFrontierService
                 return;
             }
 
-            // too early or already has its fill of URLs in process?
-            if (!checkQueueEligibility(queue, now, maxURLsPerQueue)) {
+            // atomically check the politeness gate and reserve the queue
+            final long previousLastProduced = tryReserveQueue(queue, now, maxURLsPerQueue);
+            if (previousLastProduced == RESERVE_FAILED) {
                 responseObserver.onCompleted();
                 return;
             }
 
-            int totalSent =
-                    sendURLsForQueue(
-                            queue, qwc, maxURLsPerQueue, secsUntilRequestable, now, synchStreamObs);
+            int totalSent = 0;
+            boolean completedNormally = false;
+            try {
+                totalSent =
+                        sendURLsForQueue(
+                                queue,
+                                qwc,
+                                maxURLsPerQueue,
+                                secsUntilRequestable,
+                                now,
+                                synchStreamObs);
+                completedNormally = true;
+            } finally {
+                finalizeReservation(queue, now, previousLastProduced, totalSent, completedNormally);
+            }
+
             responseObserver.onCompleted();
 
             getURLs_urls_count.inc(totalSent);
@@ -623,10 +686,6 @@ public abstract class AbstractFrontierService
                     key,
                     (System.currentTimeMillis() - start),
                     requestID.toString());
-
-            if (totalSent != 0) {
-                queue.setLastProduced(now);
-            }
 
             requestTimer.observeDuration();
 
@@ -683,33 +742,60 @@ public abstract class AbstractFrontierService
                 continue;
             }
 
-            // too early or already has its fill of URLs in process?
-            if (!checkQueueEligibility(currentQueue, now, maxURLsPerQueue)) {
+            // atomically check the politeness gate and reserve the queue
+            final long previousLastProduced = tryReserveQueue(currentQueue, now, maxURLsPerQueue);
+            if (previousLastProduced == RESERVE_FAILED) {
                 continue;
             }
 
             inProcess.incrementAndGet();
 
-            readExecutorService.execute(
-                    () -> {
-                        final int sentForQ =
-                                sendURLsForQueue(
-                                        currentQueue,
-                                        currentCrawlQueue,
-                                        maxURLsPerQueue,
-                                        secsUntilRequestable,
-                                        now,
-                                        synchStreamObs);
-
-                        if (sentForQ > 0) {
-                            currentQueue.setLastProduced(now);
-                            totalSent.addAndGet(sentForQ);
-                            numQueuesSent.incrementAndGet();
-                        }
-
-                        inProcess.decrementAndGet();
-                        numQueuesTried.incrementAndGet();
-                    });
+            try {
+                readExecutorService.execute(
+                        () -> {
+                            int sentForQ = 0;
+                            boolean completedNormally = false;
+                            try {
+                                try {
+                                    sentForQ =
+                                            sendURLsForQueue(
+                                                    currentQueue,
+                                                    currentCrawlQueue,
+                                                    maxURLsPerQueue,
+                                                    secsUntilRequestable,
+                                                    now,
+                                                    synchStreamObs);
+                                    completedNormally = true;
+                                } finally {
+                                    finalizeReservation(
+                                            currentQueue,
+                                            now,
+                                            previousLastProduced,
+                                            sentForQ,
+                                            completedNormally);
+                                }
+                                if (sentForQ > 0) {
+                                    totalSent.addAndGet(sentForQ);
+                                    numQueuesSent.incrementAndGet();
+                                }
+                            } finally {
+                                // even if finalizeReservation throws, these must run or the
+                                // busy-wait below never terminates
+                                inProcess.decrementAndGet();
+                                numQueuesTried.incrementAndGet();
+                            }
+                        });
+            } catch (RejectedExecutionException e) {
+                // the task never started: release the reservation and undo the counter
+                finalizeReservation(currentQueue, now, previousLastProduced, 0, true);
+                inProcess.decrementAndGet();
+                LOG.error(
+                        "Executor rejected getURLs task for queue {} {}",
+                        currentCrawlQueue,
+                        requestID,
+                        e);
+                break;
+            }
         }
 
         // wait for all threads to have finished

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.GetParams;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces issue #147: the politeness gate in getURLs must be atomic — a queue must not be served
+ * more than once inside its delay window when requests are concurrent.
+ */
+class GetURLsReservationTest {
+
+    static final String CRAWL_ID = "crawl_id";
+    static final String KEY = "queue_mysite";
+
+    /** MemoryFrontierService whose sendURLsForQueue can block on a latch, return 0, or throw. */
+    static class InstrumentedMemoryService extends MemoryFrontierService {
+        final AtomicInteger sendInvocations = new AtomicInteger();
+        final CountDownLatch enteredSend = new CountDownLatch(1);
+        final CountDownLatch releaseSend = new CountDownLatch(1);
+        volatile boolean blockFirstSend = false;
+        volatile boolean returnZero = false;
+        volatile boolean throwOnFirstSend = false;
+
+        InstrumentedMemoryService() {
+            super("localhost", 0);
+        }
+
+        @Override
+        protected int sendURLsForQueue(
+                QueueInterface queue,
+                QueueWithinCrawl key,
+                int maxURLsPerQueue,
+                int secsUntilRequestable,
+                long now,
+                SynchronizedStreamObserver<URLInfo> observer) {
+            int invocation = sendInvocations.incrementAndGet();
+            if (invocation == 1) {
+                if (throwOnFirstSend) {
+                    throw new RuntimeException("simulated send failure");
+                }
+                if (blockFirstSend) {
+                    enteredSend.countDown();
+                    try {
+                        releaseSend.await(10, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            }
+            if (returnZero) {
+                return 0;
+            }
+            return super.sendURLsForQueue(
+                    queue, key, maxURLsPerQueue, secsUntilRequestable, now, observer);
+        }
+    }
+
+    static class CollectingObserver implements StreamObserver<URLInfo> {
+        final AtomicInteger received = new AtomicInteger();
+        final CountDownLatch completed = new CountDownLatch(1);
+
+        @Override
+        public void onNext(URLInfo value) {
+            received.incrementAndGet();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            completed.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            completed.countDown();
+        }
+    }
+
+    /** Seeds two due URLs into KEY/CRAWL_ID and returns the queue with its delay set to 300s. */
+    static QueueInterface seedQueue(InstrumentedMemoryService service) throws Exception {
+        AtomicBoolean done = new AtomicBoolean(false);
+        AtomicInteger acked = new AtomicInteger();
+        StreamObserver<URLItem> put =
+                service.putURLs(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                done.set(true);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                done.set(true);
+                            }
+                        });
+        for (String url : new String[] {"https://www.mysite.com/a", "https://www.mysite.com/b"}) {
+            URLInfo info =
+                    URLInfo.newBuilder().setUrl(url).setCrawlID(CRAWL_ID).setKey(KEY).build();
+            put.onNext(
+                    URLItem.newBuilder()
+                            .setID(CRAWL_ID + "_" + url)
+                            .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                            .build());
+        }
+        put.onCompleted();
+        while (!done.get() || acked.get() != 2) {
+            Thread.sleep(5);
+        }
+        QueueInterface queue = service.getQueues().get(QueueWithinCrawl.get(KEY, CRAWL_ID));
+        queue.setDelay(300);
+        return queue;
+    }
+
+    @Test
+    void rotationPathServesQueueOnlyOncePerWindow() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        seedQueue(service);
+        service.blockFirstSend = true;
+
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+
+        CollectingObserver first = new CollectingObserver();
+        Thread t1 = new Thread(() -> service.getURLs(request, first));
+        t1.start();
+        assertTrue(service.enteredSend.await(5, TimeUnit.SECONDS), "first send never started");
+
+        // while the first send is in flight, a concurrent request must skip the queue
+        CollectingObserver second = new CollectingObserver();
+        service.getURLs(request, second);
+        assertTrue(second.completed.await(5, TimeUnit.SECONDS));
+
+        service.releaseSend.countDown();
+        t1.join(5000);
+
+        assertEquals(
+                1,
+                service.sendInvocations.get(),
+                "queue was served more than once inside its delay window");
+    }
+
+    @Test
+    void keyedPathServesQueueOnlyOncePerWindow() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        seedQueue(service);
+        service.blockFirstSend = true;
+
+        GetParams request =
+                GetParams.newBuilder()
+                        .setKey(KEY)
+                        .setCrawlID(CRAWL_ID)
+                        .setMaxUrlsPerQueue(1)
+                        .setDelayRequestable(30)
+                        .build();
+
+        CollectingObserver first = new CollectingObserver();
+        Thread t1 = new Thread(() -> service.getURLs(request, first));
+        t1.start();
+        assertTrue(service.enteredSend.await(5, TimeUnit.SECONDS), "first send never started");
+
+        CollectingObserver second = new CollectingObserver();
+        service.getURLs(request, second);
+        assertTrue(second.completed.await(5, TimeUnit.SECONDS));
+
+        service.releaseSend.countDown();
+        t1.join(5000);
+
+        assertEquals(
+                1,
+                service.sendInvocations.get(),
+                "queue was served more than once inside its delay window");
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -4,6 +4,8 @@
 package crawlercommons.urlfrontier.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
@@ -13,6 +15,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
 import io.grpc.stub.StreamObserver;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -189,5 +192,82 @@ class GetURLsReservationTest {
                 1,
                 service.sendInvocations.get(),
                 "queue was served more than once inside its delay window");
+    }
+
+    @Test
+    void zeroSentDoesNotPenalizeQueue() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        service.returnZero = true;
+
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+
+        CollectingObserver first = new CollectingObserver();
+        service.getURLs(request, first);
+        assertTrue(first.completed.await(5, TimeUnit.SECONDS));
+
+        // nothing was sent: the previous lastProduced must be restored
+        assertEquals(0, queue.getLastProduced());
+
+        // and the queue is immediately reservable again
+        CollectingObserver second = new CollectingObserver();
+        service.getURLs(request, second);
+        assertTrue(second.completed.await(5, TimeUnit.SECONDS));
+        assertEquals(2, service.sendInvocations.get());
+    }
+
+    @Test
+    void inFlightReservationBlocksBeyondDelayWindow() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        queue.setDelay(5);
+        long now = 100;
+
+        // package-private helpers are declared on AbstractFrontierService
+        AbstractFrontierService frontier = service;
+
+        long previous = frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE);
+        assertNotEquals(AbstractFrontierService.RESERVE_FAILED, previous);
+
+        // a timestamp-based reservation would have expired here; the in-flight marker holds
+        assertEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now + 5 + 1, Integer.MAX_VALUE));
+
+        frontier.finalizeReservation(queue, now, previous, 3, true);
+        assertEquals(now, queue.getLastProduced());
+
+        // after finalization the normal delay rules apply again
+        assertEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now + 5, Integer.MAX_VALUE));
+        assertNotEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now + 6, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void exceptionDuringSendFailsClosedAndDoesNotHang() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        service.throwOnFirstSend = true;
+
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+
+        // without the try/finally around sendURLsForQueue this call never returns
+        CollectingObserver first = new CollectingObserver();
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> service.getURLs(request, first));
+
+        // fail-closed: outcome unknown, so the politeness window is enforced
+        assertNotEquals(AbstractFrontierService.RESERVATION_IN_PROGRESS, queue.getLastProduced());
+        assertNotEquals(0, queue.getLastProduced());
+
+        // a second request inside the window must not serve the queue
+        CollectingObserver second = new CollectingObserver();
+        service.getURLs(request, second);
+        assertTrue(second.completed.await(5, TimeUnit.SECONDS));
+        assertEquals(1, service.sendInvocations.get());
     }
 }


### PR DESCRIPTION
Fixes #147.

`getURLs()` checks a queue's politeness window (`lastProduced + delay >= now`) without any lock and updates `lastProduced` later — on the read executor in the rotation path, after the synchronous send in the keyed path. Two concurrent requests can both read the same `lastProduced` before either updates it, so the same queue gets served twice inside its delay window. With several clients polling (multiple spout tasks, or several topologies on one frontier), `setDelay` and the default delay end up best-effort rather than a guarantee.

The fix reserves the queue before dispatching, as discussed on the issue: `tryReserveQueue()` re-checks the delay and the in-process cap under `synchronized (queue)` and stores an in-flight marker (`Long.MAX_VALUE`) in `lastProduced`. While the marker is set no other request can reserve the queue. The marker rather than a plain `setLastProduced(now)` matters when the executor is congested: a timestamp reservation expires after the delay even if the task hasn't run yet, and the race reopens. `lastProduced` is only ever read by `AbstractFrontierService`, is not persisted, and 0 is a legitimate value, so the in-band sentinels are safe and `QueueInterface` doesn't change.

On completion the reservation is finalized:

- sent > 0 → `lastProduced = now`, as before
- sent == 0 → the previous value is restored, so an empty queue is not penalized with a full delay window
- executor rejected the task → previous value restored
- the send threw → `lastProduced = now`, fail-closed: URLs may already have been streamed before the exception, so the window is enforced

While restructuring the executor task I also wrapped the bookkeeping in try/finally: previously an exception in `sendURLsForQueue()` left the request's `inProcess` counter incremented forever and `getURLs()` never returned. There's a dedicated test for that case.

The tests reproduce the race deterministically (no sleeps) with a `MemoryFrontierService` subclass whose `sendURLsForQueue()` can block on a latch, return 0, or throw: concurrent rotation and keyed requests serve a queue only once per window (both fail on master), zero-sent queues stay immediately reservable, an in-flight reservation still blocks after the window would have expired, and an exception fails closed without hanging the request.

This also fixes the visibility of `lastProduced`, which is a plain non-volatile `long` today.
