### PR TITLE
Make the getURLs queue control checks atomic

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -116,7 +116,9 @@ public abstract class AbstractFrontierService
     // threads: volatile for visibility (JVM-level only, not distributed ordering)
     private volatile boolean active = true;
 
-    private int defaultDelayForQueues = 1;
+    // written by setDelay on gRPC handler threads, read by the getURLs gate on other threads:
+    // volatile for visibility only, not linearized against the per-queue gates
+    private volatile int defaultDelayForQueues = 1;
 
     // used for reporting itself in a cluster setup
     protected final String address;
@@ -374,7 +376,11 @@ public abstract class AbstractFrontierService
             QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
             QueueInterface queue = getQueues().get(qwc);
             if (queue != null) {
-                queue.setBlockedUntil(request.getTime());
+                // same monitor as the reservation gate: a reservation started after this
+                // RPC completes observes the update
+                synchronized (queue) {
+                    queue.setBlockedUntil(request.getTime());
+                }
             }
         }
         responseObserver.onNext(Empty.getDefaultInstance());
@@ -390,7 +396,9 @@ public abstract class AbstractFrontierService
                 QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
                 QueueInterface queue = getQueues().get(qwc);
                 if (queue != null) {
-                    queue.setDelay(request.getDelayRequestable());
+                    synchronized (queue) {
+                        queue.setDelay(request.getDelayRequestable());
+                    }
                 }
             }
         }
@@ -948,7 +956,9 @@ public abstract class AbstractFrontierService
 
         QueueInterface qi = getQueues().get(searchKey);
         if (qi != null) {
-            qi.setCrawlLimit(params.getLimit());
+            synchronized (qi) {
+                qi.setCrawlLimit(params.getLimit());
+            }
         } else {
             LOG.error(
                     "Queue with key: {} and CrawlId: {} was not found.",

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -511,10 +511,10 @@ public abstract class AbstractFrontierService
     static final long RESERVATION_IN_PROGRESS = Long.MAX_VALUE;
 
     /**
-     * Atomically checks that a queue is eligible for serving URLs (politeness delay elapsed,
-     * in-process cap not reached, no send already in flight) and reserves it by storing {@link
-     * #RESERVATION_IN_PROGRESS} in lastProduced. Callers MUST finalize the reservation with {@link
-     * #finalizeReservation}.
+     * Atomically checks that a queue is eligible for serving URLs (not blocked, crawl limit not
+     * reached, politeness delay elapsed, in-process cap not reached, no send already in flight) and
+     * reserves it by storing {@link #RESERVATION_IN_PROGRESS} in lastProduced. Callers MUST
+     * finalize the reservation with {@link #finalizeReservation}.
      *
      * @return the previous lastProduced value if the queue was reserved, {@link #RESERVE_FAILED}
      *     otherwise
@@ -525,6 +525,9 @@ public abstract class AbstractFrontierService
             // must be checked first: it also guards the delay check below against overflow
             // (RESERVATION_IN_PROGRESS + delay wraps negative)
             if (previous == RESERVATION_IN_PROGRESS) {
+                return RESERVE_FAILED;
+            }
+            if (queue.getBlockedUntil() >= now || queue.isLimitReached()) {
                 return RESERVE_FAILED;
             }
             int delay = queue.getDelay();
@@ -647,12 +650,6 @@ public abstract class AbstractFrontierService
                 return;
             }
 
-            // it is locked
-            if (queue.getBlockedUntil() >= now) {
-                synchStreamObs.onCompleted();
-                return;
-            }
-
             // atomically check the politeness gate and reserve the queue
             final long previousLastProduced = tryReserveQueue(queue, now, maxURLsPerQueue);
             if (previousLastProduced == RESERVE_FAILED) {
@@ -729,16 +726,6 @@ public abstract class AbstractFrontierService
 
             // if a crawlID has been specified make sure it matches
             if (crawlID != null && !currentCrawlQueue.getCrawlid().equals(crawlID)) {
-                continue;
-            }
-
-            // it is locked
-            if (currentQueue.getBlockedUntil() >= now) {
-                continue;
-            }
-
-            // Max urls reached
-            if (currentQueue.isLimitReached()) {
                 continue;
             }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
@@ -4,11 +4,11 @@
 package crawlercommons.urlfrontier.service.memory;
 
 import crawlercommons.urlfrontier.service.QueueInterface;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterface {
 
@@ -18,7 +18,8 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
 
     // keep a hash of the completed URLs
     // these won't be refetched
-    private HashSet<String> completed = new HashSet<>();
+    // written by the putURLs worker threads, read by the getURLs gate via isLimitReached
+    private Set<String> completed = ConcurrentHashMap.newKeySet();
 
     private Optional<Integer> limit = Optional.empty();
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -14,6 +14,7 @@ import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import crawlercommons.urlfrontier.service.memory.URLQueue;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
@@ -269,5 +270,68 @@ class GetURLsReservationTest {
         service.getURLs(request, second);
         assertTrue(second.completed.await(5, TimeUnit.SECONDS));
         assertEquals(1, service.sendInvocations.get());
+    }
+
+    @Test
+    void keyedRequestHonoursCrawlLimit() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        queue.setCrawlLimit(1);
+        ((URLQueue) queue).addToCompleted("https://www.mysite.com/done");
+        assertTrue(queue.isLimitReached());
+
+        GetParams request =
+                GetParams.newBuilder()
+                        .setKey(KEY)
+                        .setCrawlID(CRAWL_ID)
+                        .setMaxUrlsPerQueue(1)
+                        .setDelayRequestable(30)
+                        .build();
+        CollectingObserver observer = new CollectingObserver();
+        service.getURLs(request, observer);
+        assertTrue(observer.completed.await(5, TimeUnit.SECONDS));
+
+        assertEquals(
+                0,
+                service.sendInvocations.get(),
+                "a queue past its crawl limit must not be served on the keyed path");
+    }
+
+    @Test
+    void gateRejectsBlockedAndLimitedQueues() throws Exception {
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        queue.setDelay(5);
+        AbstractFrontierService frontier = service;
+        long now = 100;
+
+        // blocked, including the boundary blockedUntil == now
+        queue.setBlockedUntil(now + 50);
+        assertEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE));
+        queue.setBlockedUntil(now);
+        assertEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE));
+
+        // unblocked: reserves; finalize to release the marker
+        queue.setBlockedUntil(now - 1);
+        long previous = frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE);
+        assertNotEquals(AbstractFrontierService.RESERVE_FAILED, previous);
+        frontier.finalizeReservation(queue, now, previous, 0, true);
+
+        // limit reached
+        queue.setCrawlLimit(1);
+        ((URLQueue) queue).addToCompleted("https://www.mysite.com/done");
+        assertEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE));
+
+        // limit disabled again: reserves
+        queue.setCrawlLimit(0);
+        assertNotEquals(
+                AbstractFrontierService.RESERVE_FAILED,
+                frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE));
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -17,6 +17,7 @@ import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
 import crawlercommons.urlfrontier.service.memory.URLQueue;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -333,5 +334,59 @@ class GetURLsReservationTest {
         assertNotEquals(
                 AbstractFrontierService.RESERVE_FAILED,
                 frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE));
+    }
+
+    @Test
+    void controlUpdateDuringInFlightReservationLeavesMarkerIntact() throws Exception {
+        // regression test: an update while a send is reserved must not clobber the marker
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        QueueInterface queue = seedQueue(service);
+        queue.setDelay(5);
+        AbstractFrontierService frontier = service;
+        long now = 100;
+
+        long previous = frontier.tryReserveQueue(queue, now, Integer.MAX_VALUE);
+        assertNotEquals(AbstractFrontierService.RESERVE_FAILED, previous);
+
+        queue.setDelay(60); // control update mid-flight
+        assertEquals(AbstractFrontierService.RESERVATION_IN_PROGRESS, queue.getLastProduced());
+
+        frontier.finalizeReservation(queue, now, previous, 2, true);
+        assertEquals(now, queue.getLastProduced());
+    }
+
+    @Test
+    void queueBlockedViaRpcIsNotServedAfterwards() throws Exception {
+        // integration test: sequential, does not prove the synchronization itself
+        InstrumentedMemoryService service = new InstrumentedMemoryService();
+        seedQueue(service);
+
+        AtomicBoolean blocked = new AtomicBoolean(false);
+        service.blockQueueUntil(
+                crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams.newBuilder()
+                        .setKey(KEY)
+                        .setCrawlID(CRAWL_ID)
+                        .setTime(Instant.now().getEpochSecond() + 3600)
+                        .build(),
+                new StreamObserver<crawlercommons.urlfrontier.Urlfrontier.Empty>() {
+                    @Override
+                    public void onNext(crawlercommons.urlfrontier.Urlfrontier.Empty value) {}
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onCompleted() {
+                        blocked.set(true);
+                    }
+                });
+        assertTrue(blocked.get());
+
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+        CollectingObserver observer = new CollectingObserver();
+        service.getURLs(request, observer);
+        assertTrue(observer.completed.await(5, TimeUnit.SECONDS));
+        assertEquals(0, service.sendInvocations.get());
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/QueueControlSynchronizationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/QueueControlSynchronizationTest.java
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
+import crawlercommons.urlfrontier.Urlfrontier.CrawlLimitParams;
+import crawlercommons.urlfrontier.Urlfrontier.Empty;
+import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The control RPCs must update queue state under the queue monitor — the same lock the reservation
+ * gate uses (#152).
+ */
+class QueueControlSynchronizationTest {
+
+    /** Records whether each setter was invoked while holding this queue's monitor. */
+    static class LockRecordingQueue implements QueueInterface {
+        volatile boolean delayLocked;
+        volatile boolean blockedLocked;
+        volatile boolean limitLocked;
+
+        @Override
+        public void setDelay(int delayRequestable) {
+            delayLocked = Thread.holdsLock(this);
+        }
+
+        @Override
+        public void setBlockedUntil(long until) {
+            blockedLocked = Thread.holdsLock(this);
+        }
+
+        @Override
+        public void setCrawlLimit(int crawlLimit) {
+            limitLocked = Thread.holdsLock(this);
+        }
+
+        @Override
+        public long getBlockedUntil() {
+            return -1;
+        }
+
+        @Override
+        public int getDelay() {
+            return -1;
+        }
+
+        @Override
+        public void setLastProduced(long lastProduced) {}
+
+        @Override
+        public long getLastProduced() {
+            return 0;
+        }
+
+        @Override
+        public int getInProcess(long now) {
+            return 0;
+        }
+
+        @Override
+        public int getCountCompleted() {
+            return 0;
+        }
+
+        @Override
+        public int countActive() {
+            return 0;
+        }
+
+        @Override
+        public Boolean isLimitReached() {
+            return false;
+        }
+    }
+
+    static class NoopEmptyObserver implements StreamObserver<Empty> {
+        @Override
+        public void onNext(Empty value) {}
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {}
+    }
+
+    @Test
+    void controlUpdatesHoldTheQueueMonitor() {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        LockRecordingQueue queue = new LockRecordingQueue();
+        QueueWithinCrawl qwc = QueueWithinCrawl.get("lockq", "crawl_id");
+        service.getQueues().put(qwc, queue);
+
+        service.setDelay(
+                QueueDelayParams.newBuilder()
+                        .setKey("lockq")
+                        .setCrawlID("crawl_id")
+                        .setDelayRequestable(7)
+                        .build(),
+                new NoopEmptyObserver());
+        service.blockQueueUntil(
+                BlockQueueParams.newBuilder()
+                        .setKey("lockq")
+                        .setCrawlID("crawl_id")
+                        .setTime(9999999999L)
+                        .build(),
+                new NoopEmptyObserver());
+        service.setCrawlLimit(
+                CrawlLimitParams.newBuilder()
+                        .setKey("lockq")
+                        .setCrawlID("crawl_id")
+                        .setLimit(5)
+                        .build(),
+                new NoopEmptyObserver());
+
+        assertTrue(queue.delayLocked, "setDelay must hold the queue monitor");
+        assertTrue(queue.blockedLocked, "blockQueueUntil must hold the queue monitor");
+        assertTrue(queue.limitLocked, "setCrawlLimit must hold the queue monitor");
+    }
+}


### PR DESCRIPTION
Fixes #152.

The reservation gate from #151 now also checks `blockedUntil` and the crawl limit, so both `getURLs` paths take every eligibility decision atomically under the queue monitor — this also fixes the keyed path never consulting `isLimitReached()`. The control RPCs (`setDelay`, `blockQueueUntil`, `setCrawlLimit`) update the queue under the same monitor, and `defaultDelayForQueues` is now volatile.

The guarantee this buys: for an existing keyed queue that is not concurrently removed and recreated, once a successful queue-control RPC completes, reservations started afterwards observe the updated block, delay or limit. A reservation already in flight may complete. Default-delay updates are visible across threads but are not linearized against every queue.

Two side notes: `URLQueue.completed` (memory implementation) becomes a concurrent set — it's written by putURLs threads and the gate now reads it through `isLimitReached()`, a plain `HashSet` has no cross-thread visibility guarantee there. The synchronization tests assert `Thread.holdsLock` through an instrumented queue, so they fail deterministically without the fix rather than relying on racing threads.
