### PR TITLE
Route setCrawlLimit to the queue owner in distributed mode

### DIFF
--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -313,6 +313,8 @@ message CrawlLimitParams {
   uint32 limit = 2;
   // crawl ID
   string crawlID = 3;
+  // only for this instance
+  bool local = 4;
 }
 
 message URLStatusRequest {

--- a/client/src/main/java/crawlercommons/urlfrontier/client/SetCrawlLimit.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/SetCrawlLimit.java
@@ -31,6 +31,13 @@ public class SetCrawlLimit implements Runnable {
             description = "the limit. (0 to disable)")
     private int limit;
 
+    @CommandLine.Option(
+            names = {"--local"},
+            defaultValue = "false",
+            paramLabel = "BOOLEAN",
+            description = "restricts the scope to this frontier instance")
+    private boolean local;
+
     @Override
     public void run() {
         ManagedChannel channel =
@@ -45,6 +52,7 @@ public class SetCrawlLimit implements Runnable {
         builder.setCrawlID(crawl);
         builder.setKey(key);
         builder.setLimit(limit);
+        builder.setLocal(local);
 
         blockingFrontier.setCrawlLimit(builder.build());
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -956,8 +956,9 @@ public abstract class AbstractFrontierService
         }
     }
 
+    @Override
     public void setCrawlLimit(CrawlLimitParams params, StreamObserver<Empty> responseObserver) {
-        QueueWithinCrawl searchKey = new QueueWithinCrawl(params.getKey(), params.getCrawlID());
+        QueueWithinCrawl searchKey = QueueWithinCrawl.get(params.getKey(), params.getCrawlID());
 
         QueueInterface qi = getQueues().get(searchKey);
         if (qi != null) {

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -18,6 +18,7 @@ import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
 import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
 import crawlercommons.urlfrontier.Urlfrontier.Boolean;
+import crawlercommons.urlfrontier.Urlfrontier.CrawlLimitParams;
 import crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Empty;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
@@ -217,6 +218,31 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 qwc,
                 observer -> super.blockQueueUntil(localParams, observer),
                 (stub, observer) -> stub.blockQueueUntil(localParams, observer),
+                responseObserver);
+    }
+
+    /**
+     * In cluster mode, a keyed request with local=false is routed to the node owning the queue. An
+     * empty key is invalid for this keyed-only operation and fails locally. local=true always stays
+     * local.
+     */
+    @Override
+    public void setCrawlLimit(CrawlLimitParams request, StreamObserver<Empty> responseObserver) {
+        if (request.getLocal() || !clusterMode || isClosing() || request.getKey().isEmpty()) {
+            super.setCrawlLimit(request, responseObserver);
+            return;
+        }
+        final QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
+        // forward the normalized crawlID so owners that don't normalize internally still match
+        final CrawlLimitParams localParams =
+                CrawlLimitParams.newBuilder(request)
+                        .setCrawlID(qwc.getCrawlid())
+                        .setLocal(true)
+                        .build();
+        routeToOwner(
+                qwc,
+                observer -> super.setCrawlLimit(localParams, observer),
+                (stub, observer) -> stub.setCrawlLimit(localParams, observer),
                 responseObserver);
     }
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -17,12 +17,14 @@ import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Active;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
+import crawlercommons.urlfrontier.Urlfrontier.CrawlLimitParams;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.QueueMetadata;
 import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -386,6 +388,70 @@ class DistributedFrontierServiceTest {
     @Order(13)
     void getActiveLocalFalseIsTrueWhenAllNodesActive() {
         assertTrue(stubA.getActive(LOCAL_FALSE).getState());
+    }
+
+    @Test
+    @Order(14)
+    void setCrawlLimitLocalFalseReachesOwnerWithEmptyCrawlID() throws Exception {
+        // empty crawlID exercises the end-to-end normalization: owner computation,
+        // forwarded message and base-method lookup must all agree on DEFAULT
+        final String key = keyOwnedBy(1, "limit-routed");
+        createQueue(key, "");
+        final QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "");
+
+        QueueMetadata ownerQueue = (QueueMetadata) serviceB.getQueues().get(qwc);
+        assertNotNull(ownerQueue, "queue must exist on the owner (node B)");
+        ownerQueue.setCompletedCount(1);
+        assertFalse(ownerQueue.isLimitReached());
+
+        stubA.setCrawlLimit(
+                CrawlLimitParams.newBuilder().setKey(key).setCrawlID("").setLimit(1).build());
+
+        assertTrue(
+                ownerQueue.isLimitReached(),
+                "the limit set through the non-owner must be applied on the owner");
+    }
+
+    @Test
+    @Order(15)
+    void setCrawlLimitLocalTrueOnNonOwnerFailsAndLeavesOwnerUntouched() throws Exception {
+        final String key = keyOwnedBy(1, "limit-local");
+        createQueue(key, "DEFAULT");
+        final QueueWithinCrawl qwc = QueueWithinCrawl.get(key, "DEFAULT");
+
+        QueueMetadata ownerQueue = (QueueMetadata) serviceB.getQueues().get(qwc);
+        assertNotNull(ownerQueue);
+        ownerQueue.setCompletedCount(1);
+        assertFalse(ownerQueue.isLimitReached());
+
+        assertThrows(
+                StatusRuntimeException.class,
+                () ->
+                        stubA.setCrawlLimit(
+                                CrawlLimitParams.newBuilder()
+                                        .setKey(key)
+                                        .setCrawlID("DEFAULT")
+                                        .setLimit(1)
+                                        .setLocal(true)
+                                        .build()),
+                "local=true on a node that does not own the queue must fail");
+        assertFalse(ownerQueue.isLimitReached(), "the owner's queue must be untouched");
+    }
+
+    @Test
+    @Order(16)
+    void setCrawlLimitOnMissingQueuePropagatesRemoteError() {
+        // owned by B but never created: the routed call must propagate the owner's error
+        final String key = keyOwnedBy(1, "limit-missing");
+        assertThrows(
+                StatusRuntimeException.class,
+                () ->
+                        stubA.setCrawlLimit(
+                                CrawlLimitParams.newBuilder()
+                                        .setKey(key)
+                                        .setCrawlID("DEFAULT")
+                                        .setLimit(1)
+                                        .build()));
     }
 
     @Test

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/SingleNodeShardedServiceTest.java
@@ -5,18 +5,21 @@ package crawlercommons.urlfrontier.service.cluster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import crawlercommons.urlfrontier.URLFrontierGrpc;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.Active;
+import crawlercommons.urlfrontier.Urlfrontier.CrawlLimitParams;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.Local;
 import crawlercommons.urlfrontier.Urlfrontier.QueueDelayParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.QueueMetadata;
 import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -128,6 +131,57 @@ class SingleNodeShardedServiceTest {
                         .build());
 
         assertEquals(66, service.getQueues().get(QueueWithinCrawl.get(key, "DEFAULT")).getDelay());
+    }
+
+    @Test
+    void setCrawlLimitLocalFalseAppliedLocally() throws Exception {
+        String key = "single-limit.test";
+        CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<URLItem> input =
+                URLFrontierGrpc.newStub(channel)
+                        .putURLs(
+                                new StreamObserver<AckMessage>() {
+                                    @Override
+                                    public void onNext(AckMessage value) {}
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        latch.countDown();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        latch.countDown();
+                                    }
+                                });
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://" + key + "/page")
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .build();
+        input.onNext(
+                URLItem.newBuilder()
+                        .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                        .build());
+        input.onCompleted();
+        assertTrue(latch.await(10, TimeUnit.SECONDS), "putURLs did not complete in time");
+
+        QueueMetadata queue =
+                (QueueMetadata) service.getQueues().get(QueueWithinCrawl.get(key, "DEFAULT"));
+        assertNotNull(queue);
+        queue.setCompletedCount(1);
+        assertFalse(queue.isLimitReached());
+
+        stub.setCrawlLimit(
+                CrawlLimitParams.newBuilder()
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .setLimit(1)
+                        .setLocal(false)
+                        .build());
+
+        assertTrue(queue.isLimitReached(), "single node: the limit must be applied locally");
     }
 
     @Test


### PR DESCRIPTION
Fixes #154.

`CrawlLimitParams` gains `bool local = 4` and `DistributedFrontierService` routes `local=false` requests to the queue owner with `local=true`, exactly like `SetDelay`/`BlockQueueUntil` since #148 (same guard, same `routeToOwner`, same per-RPC forwarding deadline). The client gets a `--local` flag.

The base method now looks the queue up with the normalized crawl ID (`QueueWithinCrawl.get`), and the forwarded message carries the normalized ID too — without this, a request with an empty crawlID computes the right owner but then fails "not found" there.

Compatibility: wire-compatible — old clients work against new servers and get the new owner-routing (`local` defaults to false, which is the point of the fix). An ingress node running an older version keeps today's local-only behavior until upgraded. One mixed-cluster caveat: forwarding to a 2.5 owner applies the limit but returns `INTERNAL: No value received for unary call`, because 2.5 predates #155; a coordinated upgrade avoids it.

Note: #156 touches the same method (adds the synchronized block); whichever lands second I'll rebase.
