### PR TITLE
Report the version from the POM instead of hardcoding it

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -15,6 +15,17 @@
 	<description>Command line client implemented in Java for simple interactions with a URLFrontier server</description>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+			</resource>
+			<!-- holds version.properties, from which the version is reported at runtime -->
+			<resource>
+				<directory>src/main/resources-filtered</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -61,6 +72,12 @@
 			<artifactId>protobuf-java-util</artifactId>
 			<!-- Version must match protoc version or must be newer -->
 			<version>${protobuf.java.util.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
 		</dependency>
 
 	</dependencies>

--- a/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
@@ -10,7 +10,7 @@ import picocli.CommandLine.Option;
 @Command(
         name = "Client",
         mixinStandardHelpOptions = true,
-        version = "2.6-SNAPSHOT",
+        versionProvider = VersionProvider.class,
         subcommands = {
             ListNodes.class,
             ListQueues.class,

--- a/client/src/main/java/crawlercommons/urlfrontier/client/VersionProvider.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/VersionProvider.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.client;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Reports the version of the client as set in the POM. The properties file it reads is filtered by
+ * Maven at build time, which avoids having to hardcode the version in the sources when releasing.
+ */
+public class VersionProvider implements IVersionProvider {
+
+    static final String UNKNOWN_VERSION = "unknown";
+
+    private static final String RESOURCE = "/crawlercommons/urlfrontier/client/version.properties";
+
+    @Override
+    public String[] getVersion() throws IOException {
+        final Properties props = new Properties();
+        try (InputStream is = VersionProvider.class.getResourceAsStream(RESOURCE)) {
+            if (is == null) {
+                return new String[] {UNKNOWN_VERSION};
+            }
+            props.load(is);
+        }
+        return new String[] {props.getProperty("version", UNKNOWN_VERSION)};
+    }
+}

--- a/client/src/main/resources-filtered/crawlercommons/urlfrontier/client/version.properties
+++ b/client/src/main/resources-filtered/crawlercommons/urlfrontier/client/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/client/src/test/java/crawlercommons/urlfrontier/client/VersionProviderTest.java
+++ b/client/src/test/java/crawlercommons/urlfrontier/client/VersionProviderTest.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Guards against a broken resource filtering configuration in the POM. */
+class VersionProviderTest {
+
+    @Test
+    void versionIsResolvedFromTheProject() throws Exception {
+        final String[] version = new VersionProvider().getVersion();
+        assertEquals(1, version.length);
+        assertNotEquals(VersionProvider.UNKNOWN_VERSION, version[0]);
+        assertFalse(version[0].contains("${"), "version was not filtered: " + version[0]);
+    }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -24,6 +24,17 @@
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>false</filtering>
+			</resource>
+			<!-- holds version.properties, from which the version is reported at runtime -->
+			<resource>
+				<directory>src/main/resources-filtered</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -25,7 +25,10 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "URL Frontier Server", mixinStandardHelpOptions = true, version = "2.6-SNAPSHOT")
+// NOTE: mixinStandardHelpOptions is deliberately not used. '-h' is taken by --hostname below and
+// picocli silently drops the whole standard mixin when one of its names is already in use, leaving
+// the command with neither --help nor --version. Both are declared explicitly instead.
+@Command(name = "URL Frontier Server", versionProvider = VersionProvider.class)
 public class URLFrontierServer implements Callable<Integer> {
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(URLFrontierServer.class);
@@ -57,6 +60,18 @@ public class URLFrontierServer implements Callable<Integer> {
             paramLabel = "NUM",
             description = "Port number to use for Prometheus server")
     int prometheus_server;
+
+    @Option(
+            names = {"--help"},
+            usageHelp = true,
+            description = "Show this help message and exit.")
+    boolean helpRequested;
+
+    @Option(
+            names = {"-V", "--version"},
+            versionHelp = true,
+            description = "Print version information and exit.")
+    boolean versionRequested;
 
     @Parameters List<String> positional;
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/VersionProvider.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/VersionProvider.java
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import picocli.CommandLine.IVersionProvider;
+
+/**
+ * Reports the version of the service as set in the POM. The properties file it reads is filtered by
+ * Maven at build time, which avoids having to hardcode the version in the sources when releasing.
+ */
+public class VersionProvider implements IVersionProvider {
+
+    static final String UNKNOWN_VERSION = "unknown";
+
+    private static final String RESOURCE = "/crawlercommons/urlfrontier/service/version.properties";
+
+    @Override
+    public String[] getVersion() throws IOException {
+        final Properties props = new Properties();
+        try (InputStream is = VersionProvider.class.getResourceAsStream(RESOURCE)) {
+            if (is == null) {
+                return new String[] {UNKNOWN_VERSION};
+            }
+            props.load(is);
+        }
+        return new String[] {props.getProperty("version", UNKNOWN_VERSION)};
+    }
+}

--- a/service/src/main/resources-filtered/crawlercommons/urlfrontier/service/version.properties
+++ b/service/src/main/resources-filtered/crawlercommons/urlfrontier/service/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/VersionProviderTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/VersionProviderTest.java
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+/** Guards against a broken resource filtering configuration in the POM. */
+class VersionProviderTest {
+
+    @Test
+    void versionIsResolvedFromTheProject() throws Exception {
+        final String[] version = new VersionProvider().getVersion();
+        assertEquals(1, version.length);
+        assertNotEquals(VersionProvider.UNKNOWN_VERSION, version[0]);
+        assertFalse(version[0].contains("${"), "version was not filtered: " + version[0]);
+    }
+}


### PR DESCRIPTION
The version was duplicated as a literal in the picocli `@Command` annotation of both
`Client` and `URLFrontierServer`, so releasing meant editing Java sources on top of the
POMs — with nothing to catch it when that was forgotten. `maven-release-plugin` and
`versions:set` only ever touch POMs, so either would have shipped a jar reporting the
wrong version.

Both modules now filter a `version.properties` at build time and read it back through an
`IVersionProvider`. No Java file in the repo mentions a version any more, so a POM-only
bump is enough.

### Details

Per module (`client`, `service`):

* a `<resources>` block that keeps `src/main/resources` **unfiltered** and adds a filtered
  `src/main/resources-filtered`. Deliberately not blanket-filtering `src/main/resources` —
  `service` keeps `logback.xml` there, and filtering would eat any `${}` it later gains.
* `src/main/resources-filtered/crawlercommons/urlfrontier/{client,service}/version.properties`,
  one line: `version=${project.version}`. Package-qualified paths so the two can never
  collide under shade.
* `VersionProvider`, falling back to `"unknown"` when the resource is absent.
* a test that fails the build if the version comes back as `unknown` or still contains `${`,
  i.e. if the filtering config ever breaks.

`client` also gains a `junit-jupiter` test dependency — it had no tests at all before.

### Drive-by fix: the service had no `--help` or `--version`

`URLFrontierServer` set `mixinStandardHelpOptions = true`, but its own `-h/--hostname`
collides with the mixin's `-h`, and picocli **silently drops the entire mixin** in that case
rather than raising an error. Verified against picocli 4.7.7 — with the clash the registered
options are just `[-h, --hostname]`; without it you also get `--help`, `-V`, `--version`.

So the service accepted neither `--help` nor `-V`, and its hardcoded version string was
unreachable text. This predates this PR (confirmed against `master`), but it would have left
the new provider dead code as well.

`-h` is documented for cluster mode in `service/README.md`, so it stays as `--hostname`;
`--help` and `-V/--version` are declared explicitly instead. Purely additive — no existing
option changed. This is the one part of the PR that alters the CLI surface, so worth a look.

### Verification

* `mvn clean verify -DskipFormatCode=false` green across all five modules, incl. the
  google-java-format check.
* `-V` on both **shaded** jars reports `2.6-SNAPSHOT` (shade was the real risk here).
* `mvn versions:set -DnewVersion=2.6-VERIFY` + rebuild with no source edits → both CLIs
  report `2.6-VERIFY`. Reverted afterwards.
* `-h 1.2.3.4 -p 17071` still starts the server reporting `1.2.3.4:17071`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
