### PR TITLE
ci: update stale GitHub Actions to current majors

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -11,31 +11,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v6
         with:
           images: crawlercommons/url-frontier
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7
+        uses: docker/setup-qemu-action@v4
         with:
           platforms: all
 
       - name: Setup Docker buildx
         id: buildx
-        uses: docker/setup-buildx-action@4c0219f9ac95b02789c1075625400b2acbff50b1
+        uses: docker/setup-buildx-action@v4
 
       - name: Build, tag, and push image to DockerHub
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@v7
         with:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
     - name: Set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'temurin'


### PR DESCRIPTION
The Docker Hub workflow was running on actions from the v1/v2 era, including three raw commit-SHA pins that had not been touched in years. This brings both workflows up to the current major versions.

### `.github/workflows/dockerhub.yml`

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v3 | v7 |
| `docker/metadata-action` | v3 | v6 |
| `docker/login-action` | v1 | v4 |
| `docker/setup-qemu-action` | `2b82ce8` (~v1) | v4 |
| `docker/setup-buildx-action` | `4c0219f` (~v1) | v4 |
| `docker/build-push-action` | `ac9327e` (~v2) | v7 |

The three SHA pins are replaced with major tags so the whole file is consistent. Happy to pin everything to SHAs instead if that is preferred for supply-chain hardening.

### `.github/workflows/maven.yml`

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-java` | v4 | v5 |

No inputs changed — `java-version`, `distribution` and `cache: maven` are all still valid on `setup-java@v5`, and the buildx/build-push inputs (`builder`, `platforms`, `context`, `file`, `tags`, `labels`) are unchanged in the new majors.

### Testing

The Maven workflow is exercised by this PR itself. The Docker Hub workflow only triggers on tag pushes, so it will not be validated until the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)