### PR TITLE
ci: publish Docker image on release published rather than tag push

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,9 +1,8 @@
 name: Dockerhub Deployment
 
 on:
-  push:
-    tags:
-      - '*'
+  release:
+    types: [published]
 
 jobs:
   deploy:
@@ -18,6 +17,9 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: crawlercommons/url-frontier
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
 
       - name: Login to DockerHub
         uses: docker/login-action@v1


### PR DESCRIPTION
## What

Changes the Docker Hub deployment workflow trigger from `push: tags: ['*']` to `release: types: [published]`, and makes the image tag policy explicit.

## Why

- Any tag push previously triggered a multi-arch build+push and moved `:latest`. That includes the tag `maven-release-plugin` creates during `release:prepare`, so the image went out before `release:perform` had even staged to Maven Central — and any stray/experimental tag would silently take over `:latest`.
- Triggering on published releases means the image ships only once the release is intentionally published. Draft releases don't fire, so notes can be prepared freely.
- A release can be re-published / the workflow re-run, rather than having to delete and force-push a tag.

## Tag policy

`docker/metadata-action` was relying on the default `latest=auto`, which sets `:latest` on any tag event — including pre-releases. The tags are now explicit:

```yaml
tags: |
  type=ref,event=tag
  type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
```

`github.ref` on a release event is `refs/tags/<tag>`, so `type=ref,event=tag` still resolves to the version tag as before (e.g. `2.5`). Pre-releases get their version tag but no longer take over `:latest`.

## Note

Action versions are deliberately left untouched here — those are being bumped in a separate PR.

## Release process change

One extra manual step: after `mvn release:perform`, a GitHub Release must be created and published for the tag in order for the Docker image to be built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)