### PR TITLE
Clear the whole queueInfos table on start-up, fixes #163

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -676,7 +676,10 @@ public class RocksDBService extends AbstractFrontierService {
         if (queuesRead != 0) {
             // empty the table so that we don't read it again
             // if there has been a nasty crash
+            // the end key of deleteRange is exclusive, hence the
+            // explicit deletion of the last key
             rocksDB.deleteRange(columnFamilyHandleList.get(2), firstKey, lastKey);
+            rocksDB.delete(columnFamilyHandleList.get(2), lastKey);
         }
 
         long end = System.currentTimeMillis();

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBRecoveryTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBRecoveryTest.java
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import crawlercommons.urlfrontier.Urlfrontier;
+import crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams;
+import crawlercommons.urlfrontier.service.rocksdb.RocksDBService;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RocksDBRecoveryTest {
+
+    private static final String ROCKSDB_PATH = "./target/rocksdb-recovery";
+
+    private RocksDBService service;
+
+    @BeforeEach
+    void setup() {
+        FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
+    }
+
+    /** Releases the lock on the directory even if a test failed halfway through * */
+    @AfterEach
+    void cleanup() throws IOException {
+        if (service != null) {
+            service.close();
+            service = null;
+        }
+        FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
+    }
+
+    /** Closes the current instance if there is one and opens a new one on the same directory * */
+    private RocksDBService restart() throws IOException {
+        if (service != null) {
+            service.close();
+        }
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", ROCKSDB_PATH);
+        service = new RocksDBService(conf, "localhost", 7071);
+        return service;
+    }
+
+    /**
+     * The queue infos table must be emptied once it has been read, otherwise a leftover entry makes
+     * the next restart believe that it holds the full list of queues - see #163
+     */
+    @Test
+    void queueInfosAreFullyClearedOnStartup() throws IOException {
+
+        // the queue infos get persisted on a clean shutdown
+        RocksDBService frontier = restart();
+        ServiceTestUtil.initURLs(frontier);
+        assertEquals(3, frontier.getQueues().size());
+
+        // restart: the queue infos are read and the table must be emptied
+        frontier = restart();
+        assertEquals(3, frontier.getQueues().size());
+
+        // get rid of every queue: the queue infos table must not
+        // contain anything about them anymore
+        for (QueueWithinCrawl qwc : new ArrayList<>(frontier.getQueues().keySet())) {
+            deleteQueue(frontier, qwc);
+        }
+        assertEquals(0, frontier.getQueues().size());
+
+        // any entry left over from the previous restart would be resurrected here
+        frontier = restart();
+        assertEquals(0, frontier.getQueues().size());
+    }
+
+    /** The queues must all be recovered when the previous instance did not shut down cleanly * */
+    @Test
+    void allQueuesRecoveredAfterCrash() throws IOException {
+
+        RocksDBService frontier = restart();
+        ServiceTestUtil.initURLs(frontier);
+        final Set<QueueWithinCrawl> expected = new HashSet<>(frontier.getQueues().keySet());
+        assertEquals(3, expected.size());
+
+        // this instance reads the queue infos and empties the table but,
+        // as it does not get closed properly, does not write them back
+        frontier = restart();
+        assertEquals(3, frontier.getQueues().size());
+        // simulates an unclean shutdown: the RocksDB instance is released so that
+        // it can be reopened but the stats about the queues are not persisted
+        frontier.getQueues().clear();
+
+        // the queues have to be rebuilt from the URL tables
+        frontier = restart();
+        assertEquals(expected, new HashSet<>(frontier.getQueues().keySet()));
+    }
+
+    private void deleteQueue(RocksDBService service, QueueWithinCrawl qwc) {
+
+        StreamObserver<Urlfrontier.Long> observer =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.Long value) {}
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        fail();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        service.deleteQueue(
+                QueueWithinCrawlParams.newBuilder()
+                        .setKey(qwc.getQueue())
+                        .setCrawlID(qwc.getCrawlid())
+                        .build(),
+                observer);
+    }
+}


### PR DESCRIPTION
## Problem

`deleteRange(begin, end)` removes `[begin, end)` — the end key is exclusive. `readQueueInfos` passed the last entry it had just read as the end key, so that entry was never deleted and the `queueInfos` table was left holding exactly one record.

The guard therefore did not work. After an unclean shutdown the next start-up read that single leftover record, `recovery()` saw a non-zero result and skipped `recoveryQscan`, and the server came up believing it had one queue while the URL tables still held all of them.

## Fix

Delete the last key explicitly after the range deletion.

## Tests

`RocksDBRecoveryTest` covers both halves of the issue against a real RocksDB directory:

- `queueInfosAreFullyClearedOnStartup` — populate 3 queues, clean shutdown, restart, delete every queue, restart again. A leftover record shows up as a phantom queue.
- `allQueuesRecoveredAfterCrash` — the reported scenario: after a restart that reads the infos table, an unclean shutdown (queue stats never written back) must leave the next start-up rebuilding all 3 queues from the URL tables.

Both fail on `master` with exactly the reported symptom — the second reports `[queue_mysite, delete_queue, another_queue]` expected but `[queue_mysite]` restored — and pass with the fix. Full service suite: 97 tests, 0 failures.

## Not included

`deleteRanges` has the same class of bug in its `includeEndKey` branch: `deleteRange(cf, endKey, endKey)` is an empty range, so column families 1 and 3 keep their final row when the last queue is deleted (only CF 0 uses `delete` correctly). That can resurrect a deleted queue on a `checkOnRecovery` start-up. It is a distinct defect and is left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)