### PR TITLE
Delete the whole key range of a queue, including its last key

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -773,22 +773,11 @@ public class RocksDBService extends AbstractFrontierService {
         }
 
         // if endKey is null it means that there is no other crawlID after this one
-        boolean includeEndKey = false;
-
+        // the tables do not all use the same key layout, so we can't take the last
+        // key of one of them as the end of the range: use the smallest key which is
+        // greater than everything sharing the prefix instead
         if (endKey == null) {
-            try (RocksIterator iter = rocksDB.newIterator(columnFamilyHandleList.get(0))) {
-                iter.seekToLast();
-                if (iter.isValid()) {
-                    // this is the last known URL
-                    endKey = iter.key();
-                    includeEndKey = true;
-                }
-            }
-        }
-
-        // no end key found?
-        if (endKey == null) {
-            throw new RuntimeException("No endkey found");
+            endKey = upperBound(prefix);
         }
 
         // delete the ranges in the queues table as well as the URLs already
@@ -796,12 +785,16 @@ public class RocksDBService extends AbstractFrontierService {
         rocksDB.deleteRange(columnFamilyHandleList.get(1), prefix, endKey);
         rocksDB.deleteRange(columnFamilyHandleList.get(0), prefix, endKey);
         rocksDB.deleteRange(columnFamilyHandleList.get(3), prefix, endKey);
+    }
 
-        if (includeEndKey) {
-            rocksDB.deleteRange(columnFamilyHandleList.get(1), endKey, endKey);
-            rocksDB.delete(columnFamilyHandleList.get(0), endKey);
-            rocksDB.deleteRange(columnFamilyHandleList.get(3), endKey, endKey);
-        }
+    /**
+     * Smallest key which is greater than every key starting with the prefix. The prefixes used for
+     * the deletions always end with the separator, incrementing its last byte is therefore enough.
+     */
+    private static byte[] upperBound(final byte[] prefix) {
+        final byte[] end = Arrays.copyOf(prefix, prefix.length);
+        end[end.length - 1]++;
+        return end;
     }
 
     @Override

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -559,8 +559,8 @@ public class RocksDBService extends AbstractFrontierService {
         } catch (RocksDBException e) {
             LOG.error(
                     "Exception caught when deleting ranges - {} - {}",
-                    new String(startKey),
-                    new String(endKey),
+                    asString(startKey),
+                    asString(endKey),
                     e);
         }
 
@@ -745,8 +745,9 @@ public class RocksDBService extends AbstractFrontierService {
             } catch (RocksDBException e) {
                 LOG.error(
                         "Exception caught when deleting ranges - {} - {}",
-                        new String(startKey),
-                        new String(endKey));
+                        asString(startKey),
+                        asString(endKey),
+                        e);
             }
 
             for (QueueWithinCrawl quid : toDelete) {
@@ -795,6 +796,11 @@ public class RocksDBService extends AbstractFrontierService {
         final byte[] end = Arrays.copyOf(prefix, prefix.length);
         end[end.length - 1]++;
         return end;
+    }
+
+    /** Renders a key for logging - the boundaries of a range can be null * */
+    private static String asString(final byte[] key) {
+        return key == null ? "null" : new String(key, StandardCharsets.UTF_8);
     }
 
     @Override

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBRecoveryTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBRecoveryTest.java
@@ -13,14 +13,23 @@ import io.grpc.stub.StreamObserver;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
 
 class RocksDBRecoveryTest {
 
@@ -36,22 +45,33 @@ class RocksDBRecoveryTest {
     /** Releases the lock on the directory even if a test failed halfway through * */
     @AfterEach
     void cleanup() throws IOException {
-        if (service != null) {
-            service.close();
-            service = null;
-        }
+        stop();
         FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
     }
 
     /** Closes the current instance if there is one and opens a new one on the same directory * */
     private RocksDBService restart() throws IOException {
-        if (service != null) {
-            service.close();
-        }
+        return restart(false);
+    }
+
+    private RocksDBService restart(boolean checkOnRecovery) throws IOException {
+        stop();
         Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.path", ROCKSDB_PATH);
+        if (checkOnRecovery) {
+            conf.put("rocksdb.recovery.check", "true");
+        }
         service = new RocksDBService(conf, "localhost", 7071);
         return service;
+    }
+
+    private void stop() throws IOException {
+        if (service != null) {
+            RocksDBService toClose = service;
+            // don't try closing it twice if it fails
+            service = null;
+            toClose.close();
+        }
     }
 
     /**
@@ -102,6 +122,92 @@ class RocksDBRecoveryTest {
         // the queues have to be rebuilt from the URL tables
         frontier = restart();
         assertEquals(expected, new HashSet<>(frontier.getQueues().keySet()));
+    }
+
+    /**
+     * Deleting a queue must remove everything it owns from all the tables, including for the last
+     * queue in lexicographic order, otherwise the queues get resurrected on the next start-up
+     */
+    @Test
+    void deletedQueuesAreNotResurrected() throws IOException {
+
+        RocksDBService frontier = restart();
+        ServiceTestUtil.initURLs(frontier);
+        assertEquals(3, frontier.getQueues().size());
+
+        for (QueueWithinCrawl qwc : new ArrayList<>(frontier.getQueues().keySet())) {
+            deleteQueue(frontier, qwc);
+        }
+        assertEquals(0, frontier.getQueues().size());
+
+        // the queues get rebuilt from the scheduling table: whatever the deletions
+        // left behind comes back as a queue
+        frontier = restart(true);
+        assertEquals(0, frontier.getQueues().size());
+    }
+
+    /**
+     * The rows left behind by a deletion are not necessarily visible through the API - check the
+     * tables directly
+     */
+    @Test
+    void deletedQueuesLeaveNothingBehind() throws IOException, RocksDBException {
+
+        RocksDBService frontier = restart();
+        ServiceTestUtil.initURLs(frontier);
+        assertEquals(3, frontier.getQueues().size());
+
+        for (QueueWithinCrawl qwc : new ArrayList<>(frontier.getQueues().keySet())) {
+            deleteQueue(frontier, qwc);
+        }
+
+        // release the lock on the directory so that the tables can be read
+        stop();
+
+        assertEquals(List.of(), remainingKeys("default"));
+        assertEquals(List.of(), remainingKeys("queues"));
+        assertEquals(List.of(), remainingKeys("creationDates"));
+    }
+
+    /** Lists the keys left in one of the column families used by the service * */
+    private List<String> remainingKeys(String columnFamily) throws RocksDBException {
+
+        final List<String> keys = new ArrayList<>();
+
+        try (ColumnFamilyOptions cfOpts = new ColumnFamilyOptions();
+                DBOptions options = new DBOptions()) {
+
+            final List<ColumnFamilyDescriptor> cfDescriptors =
+                    Arrays.asList(
+                            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpts),
+                            new ColumnFamilyDescriptor("queues".getBytes(), cfOpts),
+                            new ColumnFamilyDescriptor("queueInfos".getBytes(), cfOpts),
+                            new ColumnFamilyDescriptor("creationDates".getBytes(), cfOpts));
+
+            final List<ColumnFamilyHandle> handles = new ArrayList<>();
+
+            try (RocksDB db = RocksDB.open(options, ROCKSDB_PATH, cfDescriptors, handles)) {
+                try {
+                    int index = 0;
+                    for (int i = 0; i < cfDescriptors.size(); i++) {
+                        if (new String(cfDescriptors.get(i).getName()).equals(columnFamily)) {
+                            index = i;
+                        }
+                    }
+                    try (RocksIterator iter = db.newIterator(handles.get(index))) {
+                        for (iter.seekToFirst(); iter.isValid(); iter.next()) {
+                            keys.add(new String(iter.key()));
+                        }
+                    }
+                } finally {
+                    for (ColumnFamilyHandle handle : handles) {
+                        handle.close();
+                    }
+                }
+            }
+        }
+
+        return keys;
     }
 
     private void deleteQueue(RocksDBService service, QueueWithinCrawl qwc) {


### PR DESCRIPTION
`deleteRanges` is used by `deleteQueue` and `deleteCrawl` to wipe everything a queue owns from the three URL tables. The end key of `deleteRange` is exclusive, and when the queue being deleted was the last one in lexicographic order the method used the last key of the default column family as the end of the range, then tried to make up for the exclusive bound with three extra calls:

```java
if (includeEndKey) {
    rocksDB.deleteRange(columnFamilyHandleList.get(1), endKey, endKey);
    rocksDB.delete(columnFamilyHandleList.get(0), endKey);
    rocksDB.deleteRange(columnFamilyHandleList.get(3), endKey, endKey);
}
```

`deleteRange(k, k)` is an empty range, so two of those three were no-ops. Same class of bug as #163.

### What leaks

The three tables do not share a key layout:

| CF | name | key |
|---|---|---|
| 0 | default | `crawlid_queue_url` |
| 1 | queues | `crawlid_queue_0000000000_url` |
| 3 | creationDates | `crawlid_queue_url` |

- **CF 3** keeps the row of the last URL of every queue deleted while last in lexicographic order. Nothing ever removes it, and it is invisible through the API since every read path goes through CF 0 first — silent unbounded growth.
- **CF 1** was cleaned up only by accident: its keys embed the zero-padded fetch date, whose digits sort below the first character of any real URL, so the scheduling keys happen to fall inside `[prefix, endKey)`. Correct by coincidence, not by design — and a point delete of `endKey` would not have worked here, since that key is in the layout of CF 0.
- **CF 0** was handled correctly by the explicit `delete`.

### Fix

Derive the exclusive bound from the prefix itself by incrementing its last byte, which is correct for all three tables whatever their key layout. That removes the CF 0 iterator scan, the `includeEndKey` special case and the `"No endkey found"` exception path.

The second commit fixes an unrelated NPE spotted in the same methods: the catch blocks logged `new String(startKey)` / `new String(endKey)` with both possibly null, which turned a logged error into an NPE propagating out of `deleteQueue`. `deleteCrawl` also built the message but discarded the exception.

### Tests

Two tests added to `RocksDBRecoveryTest`, alongside the two that came with #163:

- `deletedQueuesLeaveNothingBehind` — deletes every queue, reopens the RocksDB directory directly and asserts CFs 0, 1 and 3 are empty. Fails before the fix, passes after.
- `deletedQueuesAreNotResurrected` — deletes every queue and restarts with `rocksdb.recovery.check`. This one passes both before and after; keeping it as a guard on the invariant.

`mvn -o -pl service -am test com.cosium.code:git-code-format-maven-plugin:validate-code-format` → 99 tests, 0 failures, format clean.