### PR TITLE
Don't continue after onError in getURLStatus, fixes #164

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -858,6 +858,7 @@ public class RocksDBService extends AbstractFrontierService {
                         LOG.error(e.getMessage(), e);
                         responseObserver.onError(
                                 io.grpc.Status.fromThrowable(e).asRuntimeException());
+                        return;
                     }
 
                     found = true;
@@ -879,10 +880,15 @@ public class RocksDBService extends AbstractFrontierService {
 
             try {
                 byte[] baCreatDt = rocksDB.get(columnFamilyHandleList.get(3), existenceKey);
-                creatDt = ByteBuffer.wrap(baCreatDt).getLong();
+                // no creation date stored for this URL e.g. it predates the
+                // creationDates column family
+                if (baCreatDt != null) {
+                    creatDt = ByteBuffer.wrap(baCreatDt).getLong();
+                }
             } catch (RocksDBException e) {
                 LOG.error("Cannot read creation date ", e);
                 responseObserver.onError(io.grpc.Status.fromThrowable(e).asRuntimeException());
+                return;
             }
 
             responseObserver.onNext(buildURLItem(builder, knownbuilder, info, fromEpoch, creatDt));
@@ -1031,8 +1037,8 @@ public class RocksDBService extends AbstractFrontierService {
                     hasNext = rocksIterator.isValid();
                 }
 
-                ByteBuffer lCreated = ByteBuffer.wrap(created);
-                return buildURLItem(builder, knownBuilder, info, fromEpoch, lCreated.getLong());
+                long createdEpoch = created == null ? 0L : ByteBuffer.wrap(created).getLong();
+                return buildURLItem(builder, knownBuilder, info, fromEpoch, createdEpoch);
             }
 
             return null; // Shouldn't happen

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -24,9 +24,12 @@ import crawlercommons.urlfrontier.service.rocksdb.RocksDBService;
 import io.grpc.stub.StreamObserver;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -40,6 +43,8 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
 import org.slf4j.LoggerFactory;
 
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -898,6 +903,134 @@ class RocksDBServiceTest {
 
         rocksDBService.countURLs(countParams, countObserver);
         assertEquals(4L, count.get());
+    }
+
+    /**
+     * URLs stored before the creationDates column family was introduced have no creation date. The
+     * service must return them with a creation date of 0 instead of throwing a NPE, see #164.
+     */
+    @Test
+    @Order(93)
+    void testMissingCreationDate() throws Exception {
+
+        final String crawlId = "crawl_id";
+        final String url = "https://www.nocreationdate.com/page";
+        final String key = "nocreationdate_queue";
+
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(crawlId).setKey(key).build();
+
+        crawlercommons.urlfrontier.Urlfrontier.URLItem.Builder builder = URLItem.newBuilder();
+        builder.setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build());
+        builder.setID(crawlId + "_" + url);
+
+        final AtomicBoolean putCompleted = new AtomicBoolean(false);
+        StreamObserver<AckMessage> ackObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(AckMessage value) {
+                        assertEquals(AckMessage.Status.OK, value.getStatus());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        fail();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        putCompleted.set(true);
+                    }
+                };
+
+        StreamObserver<URLItem> putObserver = rocksDBService.putURLs(ackObserver);
+        putObserver.onNext(builder.build());
+        putObserver.onCompleted();
+        assertTrue(putCompleted.get());
+
+        // simulate a URL without a creation date by removing the entry from the
+        // creationDates column family
+        deleteCreationDate(crawlId, key, url);
+
+        final AtomicInteger count = new AtomicInteger(0);
+        final AtomicInteger errors = new AtomicInteger(0);
+        final AtomicBoolean completed = new AtomicBoolean(false);
+
+        StreamObserver<URLItem> statusObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(URLItem value) {
+                        logURLItem(value);
+                        assertEquals(0, value.getCreationDate());
+                        count.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        errors.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        completed.set(true);
+                    }
+                };
+
+        URLStatusRequest request =
+                URLStatusRequest.newBuilder().setCrawlID(crawlId).setKey(key).setUrl(url).build();
+
+        rocksDBService.getURLStatus(request, statusObserver);
+
+        assertEquals(0, errors.get());
+        assertEquals(1, count.get());
+        assertTrue(completed.get());
+
+        // the iterator used by listURLs must cope with it as well
+        final AtomicInteger listed = new AtomicInteger(0);
+        StreamObserver<URLItem> listObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(URLItem value) {
+                        assertEquals(0, value.getCreationDate());
+                        listed.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        t.printStackTrace();
+                        fail();
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                };
+
+        ListUrlParams params =
+                ListUrlParams.newBuilder().setCrawlID(crawlId).setKey(key).setSize(100).build();
+
+        rocksDBService.listURLs(params, listObserver);
+        assertEquals(1, listed.get());
+    }
+
+    /** Removes the creation date of a URL straight from the underlying RocksDB instance. */
+    @SuppressWarnings("unchecked")
+    private static void deleteCreationDate(String crawlId, String key, String url)
+            throws Exception {
+        Field dbField = RocksDBService.class.getDeclaredField("rocksDB");
+        dbField.setAccessible(true);
+        RocksDB db = (RocksDB) dbField.get(rocksDBService);
+
+        Field handlesField = RocksDBService.class.getDeclaredField("columnFamilyHandleList");
+        handlesField.setAccessible(true);
+        List<ColumnFamilyHandle> handles =
+                (List<ColumnFamilyHandle>) handlesField.get(rocksDBService);
+
+        String existenceKey = QueueWithinCrawl.get(key, crawlId).toString() + "_" + url;
+        db.delete(handles.get(3), existenceKey.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
Fixes #164.

## Changes

**`getURLStatus`** — two error paths called `onError(...)` without returning, so execution fell through to `onNext()` + `onCompleted()` on an already-terminated `StreamObserver` (an `IllegalStateException` on the server side):

- the protobuf parse failure, where `info` was also still `null` and NPEd inside `buildURLItem`
- the creation-date read failure

Both now return.

**Missing creation date** — `rocksDB.get` returns `null` when the key is absent, which is the case for any URL stored before the `creationDates` column family was introduced, or whose creation-date record was removed. `ByteBuffer.wrap(null)` NPEd outside the `catch`. The creation date now defaults to `0`.

The same null dereference was present in `RocksDBURLItemIterator.next()`, which backs `listURLs`, and is fixed the same way. That one is beyond the letter of the issue but shares the root cause — happy to drop it if you'd rather keep the change minimal.

## Test

`RocksDBServiceTest.testMissingCreationDate` puts a URL, removes its creation-date entry directly from the underlying RocksDB, then checks that both `getURLStatus` and `listURLs` return the item with a creation date of `0` and no error. It fails with an NPE without the fix.

Full service test suite passes (100 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)