### PR TITLE
Don't hang in PutURLs when the stream fails, fixes #169

### DIFF
--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import picocli.CommandLine.Command;
@@ -27,7 +28,7 @@ import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
 @Command(name = "PutURLs", description = "Send URLs from a file into a Frontier")
-public class PutURLs implements Runnable {
+public class PutURLs implements Callable<Integer> {
 
     @ParentCommand private Client parent;
 
@@ -46,7 +47,7 @@ public class PutURLs implements Runnable {
     private String crawl;
 
     @Override
-    public void run() {
+    public Integer call() {
 
         ManagedChannel channel =
                 ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
@@ -56,6 +57,9 @@ public class PutURLs implements Runnable {
         URLFrontierStub stub = URLFrontierGrpc.newStub(channel);
 
         final AtomicBoolean completed = new AtomicBoolean(false);
+        // set when the stream is terminated by an error: no further acks will
+        // ever be received, so we must not wait for the missing ones
+        final AtomicBoolean streamError = new AtomicBoolean(false);
         final AtomicInteger acked = new AtomicInteger(0);
         final AtomicInteger failed = new AtomicInteger(0);
         final AtomicInteger skipped = new AtomicInteger(0);
@@ -81,8 +85,9 @@ public class PutURLs implements Runnable {
 
                     @Override
                     public void onError(Throwable t) {
+                        streamError.set(true);
                         completed.set(true);
-                        t.printStackTrace();
+                        System.err.println("Error while sending the URLs: " + t.getMessage());
                     }
 
                     @Override
@@ -97,13 +102,20 @@ public class PutURLs implements Runnable {
 
         Instant start = Instant.now();
 
+        boolean readError = false;
+
         List<String> allLines;
         try {
             allLines = Files.readAllLines(Paths.get(file));
             for (String line : allLines) {
 
+                // the stream is dead, no point in sending anything else
+                if (streamError.get()) {
+                    break;
+                }
+
                 // don't sent too many in one go
-                while (sent > acked.get() + 10000) {
+                while (sent > acked.get() + 10000 && !streamError.get()) {
                     try {
                         Thread.sleep(10);
                     } catch (InterruptedException e) {
@@ -115,19 +127,33 @@ public class PutURLs implements Runnable {
                 if (item == null) {
                     System.err.println("Invalid input line " + linenum);
                 } else {
-                    streamObserver.onNext(parse(line, crawl));
-                    sent++;
+                    try {
+                        streamObserver.onNext(item);
+                        sent++;
+                    } catch (IllegalStateException e) {
+                        // the stream got terminated while we were sending
+                        break;
+                    }
                 }
                 linenum++;
             }
         } catch (IOException e1) {
-            e1.printStackTrace();
+            readError = true;
+            System.err.println("Error while reading " + file + ": " + e1.getMessage());
         }
 
-        streamObserver.onCompleted();
+        // the server has already terminated the stream on error
+        if (!streamError.get()) {
+            try {
+                streamObserver.onCompleted();
+            } catch (IllegalStateException e) {
+                // the stream got terminated in the meantime
+            }
+        }
 
-        // wait for completion
-        while (!completed.get() || sent != acked.get()) {
+        // wait for completion - stop straight away if the stream failed as the
+        // remaining items will never be acked
+        while (!completed.get() || (!streamError.get() && sent != acked.get())) {
             try {
                 Thread.sleep(10);
             } catch (InterruptedException e) {
@@ -143,9 +169,21 @@ public class PutURLs implements Runnable {
         System.out.println("Skipped: " + skipped.get());
         System.out.println("Failed: " + failed.get());
         System.out.println("Total time: " + timetaken + " msec");
-        System.out.println("Average OPS: " + acked.get() / Math.max(1, timetaken / 1000));
+        System.out.println(
+                String.format("Average OPS: %.2f", acked.get() * 1000.0 / Math.max(1, timetaken)));
+
+        if (streamError.get()) {
+            System.err.println(
+                    "The connection to the Frontier failed, "
+                            + (sent - acked.get())
+                            + " URLs out of "
+                            + sent
+                            + " sent were not confirmed");
+        }
 
         channel.shutdownNow();
+
+        return (streamError.get() || readError) ? 1 : 0;
     }
 
     /**

--- a/client/src/test/java/crawlercommons/urlfrontier/client/PutURLsTest.java
+++ b/client/src/test/java/crawlercommons/urlfrontier/client/PutURLsTest.java
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+/** Checks that PutURLs terminates and reports a failure when the stream breaks, see #169. */
+class PutURLsTest {
+
+    private static final int URL_COUNT = 50;
+
+    private Server server;
+
+    @TempDir Path tempDir;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.shutdownNow();
+        }
+    }
+
+    @Test
+    void returnsZeroWhenAllTheURLsAreAcked() throws Exception {
+        // never fails
+        startServer(Integer.MAX_VALUE);
+        assertEquals(0, runClient());
+    }
+
+    @Test
+    void doesNotHangWhenTheServerFails() throws Exception {
+        // the acks stop coming after the 5th URL
+        startServer(5);
+        assertEquals(1, runClient());
+    }
+
+    @Test
+    void returnsNonZeroWhenTheFileCannotBeRead() throws Exception {
+        startServer(Integer.MAX_VALUE);
+        assertEquals(1, run(tempDir.resolve("does-not-exist.txt")));
+    }
+
+    private int runClient() throws Exception {
+        Path input = tempDir.resolve("urls.txt");
+        List<String> urls = new ArrayList<>();
+        for (int i = 0; i < URL_COUNT; i++) {
+            urls.add("http://example.com/" + i);
+        }
+        Files.write(input, urls);
+        return run(input);
+    }
+
+    /** Runs the command in a separate thread so that a regression fails instead of hanging. */
+    private int run(Path input) throws Exception {
+        Callable<Integer> command =
+                () ->
+                        new CommandLine(new Client())
+                                .execute(
+                                        "-t",
+                                        "localhost",
+                                        "-p",
+                                        Integer.toString(server.getPort()),
+                                        "PutURLs",
+                                        "-f",
+                                        input.toString());
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<Integer> result = executor.submit(command);
+            return result.get(30, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    /** Starts a frontier which breaks the stream after having acked maxAcks items. */
+    private void startServer(final int maxAcks) throws IOException {
+        server =
+                ServerBuilder.forPort(0)
+                        .addService(
+                                new URLFrontierGrpc.URLFrontierImplBase() {
+                                    @Override
+                                    public StreamObserver<URLItem> putURLs(
+                                            StreamObserver<AckMessage> responseObserver) {
+                                        return new StreamObserver<>() {
+
+                                            int received = 0;
+                                            boolean broken = false;
+
+                                            @Override
+                                            public void onNext(URLItem value) {
+                                                if (broken) {
+                                                    return;
+                                                }
+                                                if (++received > maxAcks) {
+                                                    broken = true;
+                                                    responseObserver.onError(
+                                                            Status.INTERNAL
+                                                                    .withDescription("boom")
+                                                                    .asRuntimeException());
+                                                    return;
+                                                }
+                                                responseObserver.onNext(
+                                                        AckMessage.newBuilder()
+                                                                .setID(value.getID())
+                                                                .setStatus(AckMessage.Status.OK)
+                                                                .build());
+                                            }
+
+                                            @Override
+                                            public void onError(Throwable t) {}
+
+                                            @Override
+                                            public void onCompleted() {
+                                                if (!broken) {
+                                                    responseObserver.onCompleted();
+                                                }
+                                            }
+                                        };
+                                    }
+                                })
+                        .build()
+                        .start();
+    }
+}


### PR DESCRIPTION
Fixes #169.

## The hang

`onError` set the same `completed` flag as `onCompleted`, so on the error path the wait loop condition `!completed.get() || sent != acked.get()` stayed true forever: the stream was dead, no further acks could arrive, and the client spun at 100 iterations/second without ever exiting.

A separate `streamError` flag is now set in `onError`, and the loop becomes:

```java
while (!completed.get() || (!streamError.get() && sent != acked.get())) {
```

Three related spots needed the same treatment:

- the back-pressure loop (`sent > acked.get() + 10000`) had the identical problem and now also breaks on error;
- the read loop stops feeding a dead stream;
- `onNext`/`onCompleted` are guarded against `IllegalStateException` for the race where the stream dies between the check and the call — gRPC's `CallToStreamObserverAdapter` throws once the call is aborted.

`PutURLs` is now a `Callable<Integer>` so picocli propagates an exit code: `1` on stream error or an unreadable input file, `0` otherwise. On failure it prints how many of the sent URLs were never confirmed. The stack trace in `onError` is replaced by the status message, consistent with `GetURLStatus`.

## The two minor points

- each input line was parsed twice; `onNext` now reuses the already-parsed item;
- `Average OPS` used integer division twice, collapsing the divisor to 1 for any run under two seconds. It is now computed in floating point, so a 50-URL run in 112 ms reports `446.43` instead of `50`.

## Test

`PutURLsTest` starts a real frontier on an ephemeral port that acks *n* items then calls `onError`, and drives the command through picocli in a worker thread with a 30 s timeout so a regression fails instead of hanging the build. It covers success (exit 0), mid-stream failure (exit 1) and an unreadable file (exit 1).

Verified the test catches the bug: with the old wait condition restored, `doesNotHangWhenTheServerFails` times out; with the fix all three pass. No new dependencies — the server uses `grpc-netty-shaded`, already on the client classpath.

🤖 Generated with [Claude Code](https://claude.com/claude-code)