### PR TITLE
Use an atomic claim for queuesBeingDeleted

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -75,8 +75,7 @@ public class RocksDBService extends AbstractFrontierService {
         this(new HashMap<>(), host, port);
     }
 
-    private final ConcurrentHashMap<QueueWithinCrawl, QueueWithinCrawl> queuesBeingDeleted =
-            new ConcurrentHashMap<>();
+    private final Set<QueueWithinCrawl> queuesBeingDeleted = ConcurrentHashMap.newKeySet();
 
     public RocksDBService(final Map<String, String> configuration, String host, int port) {
 
@@ -391,7 +390,7 @@ public class RocksDBService extends AbstractFrontierService {
         final QueueWithinCrawl qk = QueueWithinCrawl.get(Qkey, crawlID);
 
         // ignore this url if the queue is being deleted
-        if (queuesBeingDeleted.containsKey(qk)) {
+        if (queuesBeingDeleted.contains(qk)) {
             LOG.info("Not adding {} as its queue {} is being deleted", url, Qkey);
             return Status.SKIPPED;
         }
@@ -528,47 +527,48 @@ public class RocksDBService extends AbstractFrontierService {
 
         // is this queue already being deleted?
         // no need to do it again
-        if (queuesBeingDeleted.contains(qc)) {
+        if (!queuesBeingDeleted.add(qc)) {
             return sizeQueue;
         }
 
-        queuesBeingDeleted.put(qc, qc);
-
-        String prefixed_queue = qc.toString() + "_";
-
-        // find the next key by alphabetical order, taking the separator into account
-        QueueWithinCrawl[] array = getQueues().keySet().toArray(new QueueWithinCrawl[0]);
-        String[] prefixed_queues = new String[array.length];
-        for (int i = 0; i < array.length; i++) {
-            prefixed_queues[i] = array[i] + "_";
-        }
-        Arrays.sort(prefixed_queues);
-        byte[] startKey = null;
-        byte[] endKey = null;
-        for (String p_queue : prefixed_queues) {
-            if (startKey != null) {
-                endKey = p_queue.getBytes(StandardCharsets.UTF_8);
-                break;
-            } else if (prefixed_queue.equals(p_queue)) {
-                startKey = prefixed_queue.getBytes(StandardCharsets.UTF_8);
-            }
-        }
-
         try {
-            deleteRanges(startKey, endKey);
-        } catch (RocksDBException e) {
-            LOG.error(
-                    "Exception caught when deleting ranges - {} - {}",
-                    asString(startKey),
-                    asString(endKey),
-                    e);
+            String prefixed_queue = qc.toString() + "_";
+
+            // find the next key by alphabetical order, taking the separator into account
+            QueueWithinCrawl[] array = getQueues().keySet().toArray(new QueueWithinCrawl[0]);
+            String[] prefixed_queues = new String[array.length];
+            for (int i = 0; i < array.length; i++) {
+                prefixed_queues[i] = array[i] + "_";
+            }
+            Arrays.sort(prefixed_queues);
+            byte[] startKey = null;
+            byte[] endKey = null;
+            for (String p_queue : prefixed_queues) {
+                if (startKey != null) {
+                    endKey = p_queue.getBytes(StandardCharsets.UTF_8);
+                    break;
+                } else if (prefixed_queue.equals(p_queue)) {
+                    startKey = prefixed_queue.getBytes(StandardCharsets.UTF_8);
+                }
+            }
+
+            try {
+                deleteRanges(startKey, endKey);
+            } catch (RocksDBException e) {
+                LOG.error(
+                        "Exception caught when deleting ranges - {} - {}",
+                        asString(startKey),
+                        asString(endKey),
+                        e);
+            }
+
+            QueueInterface q = getQueues().remove(qc);
+            sizeQueue += q.countActive();
+            sizeQueue += q.getCountCompleted();
+        } finally {
+            queuesBeingDeleted.remove(qc);
         }
 
-        QueueInterface q = getQueues().remove(qc);
-        sizeQueue += q.countActive();
-        sizeQueue += q.getCountCompleted();
-
-        queuesBeingDeleted.remove(qc);
         return sizeQueue;
     }
 
@@ -751,17 +751,18 @@ public class RocksDBService extends AbstractFrontierService {
             }
 
             for (QueueWithinCrawl quid : toDelete) {
-                if (queuesBeingDeleted.contains(quid)) {
+                // already being deleted by another thread?
+                if (!queuesBeingDeleted.add(quid)) {
                     continue;
-                } else {
-                    queuesBeingDeleted.put(quid, quid);
                 }
 
-                QueueInterface q = getQueues().remove(quid);
-                total += q.countActive();
-                total += q.getCountCompleted();
-
-                queuesBeingDeleted.remove(quid);
+                try {
+                    QueueInterface q = getQueues().remove(quid);
+                    total += q.countActive();
+                    total += q.getCountCompleted();
+                } finally {
+                    queuesBeingDeleted.remove(quid);
+                }
             }
         }
         return total;


### PR DESCRIPTION
Fixes #173.

`RocksDBService` guarded concurrent deletes with a `ConcurrentHashMap<QueueWithinCrawl, QueueWithinCrawl>` used as a set, and tested membership with `Map.contains(Object)` — the legacy value-scan method (`containsValue`), not `containsKey`. It returned the right answer only because the map stored `qc -> qc`, but it was an O(n) scan of every in-flight deletion, fragile if the value ever stopped mirroring the key, and inconsistent with `containsKey` used for the same map in `putURLItem`.

## Changes

- **`queuesBeingDeleted` is now a `Set`** built with `ConcurrentHashMap.newKeySet()`, so membership is O(1) by construction and the legacy value-scan is no longer reachable.
- **Atomic claim** in both `deleteLocalQueue` and `deleteLocalCrawl`: `if (!queuesBeingDeleted.add(qc)) return ...;` replaces the `contains`-then-`put` check-then-act. Previously two threads deleting the same queue could both observe "not being deleted" and both proceed into `deleteRanges` and `getQueues().remove(qc)`, with the loser dereferencing a `null` from `remove` and the returned count wrong.
- **`try`/`finally` around both delete bodies**, so the claim is released if `deleteRanges` or `remove` throws. In the previous code the entry leaked and that queue could never be deleted again for the lifetime of the process.

The `getQueues().remove(qc)` NPE is left alone here — it is tracked as a separate issue — though the atomic claim removes the race that was one way to trigger it.

## Testing

`mvn -pl service test -Dtest='*RocksDB*'` — 20 tests, 0 failures, 1 skipped. `validate-code-format` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)