### PR TITLE
Complete streams asynchronously instead of busy-waiting, fixes #170

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -700,7 +700,6 @@ public abstract class AbstractFrontierService
         final AtomicInteger numQueuesTried = new AtomicInteger();
         final AtomicInteger numQueuesSent = new AtomicInteger();
         final AtomicInteger totalSent = new AtomicInteger();
-        final AtomicInteger inProcess = new AtomicInteger();
 
         QueueWithinCrawl firstCrawlQueue = null;
 
@@ -709,6 +708,26 @@ public abstract class AbstractFrontierService
             responseObserver.onCompleted();
             return;
         }
+
+        // the response is closed by whichever thread finishes last: this one if all the
+        // queues have already been served, otherwise the last worker to complete
+        final AsyncCompletion completion =
+                new AsyncCompletion(
+                        () -> {
+                            LOG.info(
+                                    "Sent {} from {} queue(s) in {} msec; tried {} queues. {}",
+                                    totalSent,
+                                    numQueuesSent,
+                                    (System.currentTimeMillis() - start),
+                                    numQueuesTried,
+                                    requestID.toString());
+
+                            getURLs_urls_count.inc(totalSent.get());
+
+                            requestTimer.observeDuration();
+
+                            synchStreamObs.onCompleted();
+                        });
 
         while (numQueuesSent.get() < maxQueues) {
 
@@ -743,7 +762,7 @@ public abstract class AbstractFrontierService
                 continue;
             }
 
-            inProcess.incrementAndGet();
+            completion.taskStarted();
 
             try {
                 readExecutorService.execute(
@@ -775,15 +794,15 @@ public abstract class AbstractFrontierService
                                 }
                             } finally {
                                 // even if finalizeReservation throws, these must run or the
-                                // busy-wait below never terminates
-                                inProcess.decrementAndGet();
+                                // response is never closed
                                 numQueuesTried.incrementAndGet();
+                                completion.taskDone();
                             }
                         });
             } catch (RejectedExecutionException e) {
                 // the task never started: release the reservation and undo the counter
                 finalizeReservation(currentQueue, now, previousLastProduced, 0, true);
-                inProcess.decrementAndGet();
+                completion.taskDone();
                 LOG.error(
                         "Executor rejected getURLs task for queue {} {}",
                         currentCrawlQueue,
@@ -793,28 +812,9 @@ public abstract class AbstractFrontierService
             }
         }
 
-        // wait for all threads to have finished
-        while (inProcess.get() != 0) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
-
-        LOG.info(
-                "Sent {} from {} queue(s) in {} msec; tried {} queues. {}",
-                totalSent,
-                numQueuesSent,
-                (System.currentTimeMillis() - start),
-                numQueuesTried,
-                requestID.toString());
-
-        getURLs_urls_count.inc(totalSent.get());
-
-        requestTimer.observeDuration();
-
-        synchStreamObs.onCompleted();
+        // no more queues will be submitted: the response is closed here if every worker
+        // has already finished, or by the last one to finish otherwise
+        completion.noMoreTasks();
     }
 
     protected abstract int sendURLsForQueue(
@@ -861,7 +861,9 @@ public abstract class AbstractFrontierService
 
         return new StreamObserver<URLItem>() {
 
-            final AtomicInteger unacked = new AtomicInteger();
+            // closes the response once the client has stopped sending and every item
+            // handed to the write executor has been acked
+            final AsyncCompletion completion = new AsyncCompletion(sso::onCompleted);
 
             @Override
             public void onNext(URLItem value) {
@@ -885,16 +887,28 @@ public abstract class AbstractFrontierService
                     return;
                 }
 
-                unacked.incrementAndGet();
+                completion.taskStarted();
 
-                writeExecutorService.execute(
-                        () -> {
-                            final Status status = putURLItem(value);
-                            LOG.debug("putURL -> {} got status {}", url, status);
-                            final AckMessage ackedMessage = ack.setStatus(status).build();
-                            sso.onNext(ackedMessage);
-                            unacked.decrementAndGet();
-                        });
+                try {
+                    writeExecutorService.execute(
+                            () -> {
+                                try {
+                                    final Status status = putURLItem(value);
+                                    LOG.debug("putURL -> {} got status {}", url, status);
+                                    final AckMessage ackedMessage = ack.setStatus(status).build();
+                                    sso.onNext(ackedMessage);
+                                } finally {
+                                    // whatever happens the item must be released or the
+                                    // response is never closed
+                                    completion.taskDone();
+                                }
+                            });
+                } catch (RejectedExecutionException e) {
+                    // the task never started: tell the client instead of leaving it waiting
+                    LOG.error("Executor rejected putURLs task for {}", url, e);
+                    sso.onNext(ack.setStatus(Status.FAIL).build());
+                    completion.taskDone();
+                }
             }
 
             @Override
@@ -914,15 +928,9 @@ public abstract class AbstractFrontierService
             @Override
             public void onCompleted() {
                 // will this ever get called if the client is constantly streaming?
-                // check that all the work for this stream has ended
-                while (unacked.get() != 0) {
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-                sso.onCompleted();
+                // the response is closed here if all the work for this stream has already
+                // ended, or by the last item to be acked otherwise
+                completion.noMoreTasks();
             }
         };
     }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AsyncCompletion.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AsyncCompletion.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Tracks the asynchronous work started on behalf of a single request or stream and runs a
+ * completion action exactly once, on whichever thread finishes last.
+ *
+ * <p>This lets a gRPC handler thread return as soon as it has handed the work over, instead of
+ * blocking until the tasks it submitted have finished.
+ *
+ * <p>The producer (the thread registering the tasks) implicitly holds one unit of outstanding work
+ * until it calls {@link #noMoreTasks()}, so the action cannot fire early while tasks are still
+ * being registered. Every {@link #taskStarted()} must be matched by exactly one {@link
+ * #taskDone()}, including on the paths where the task could not be submitted at all.
+ */
+public final class AsyncCompletion {
+
+    private final Runnable onCompletion;
+
+    /** outstanding tasks, plus one for the producer until it declares itself done */
+    private final AtomicInteger outstanding = new AtomicInteger(1);
+
+    private final AtomicBoolean completed = new AtomicBoolean();
+
+    public AsyncCompletion(Runnable onCompletion) {
+        this.onCompletion = onCompletion;
+    }
+
+    /** Registers a task about to be handed over to another thread. */
+    public void taskStarted() {
+        outstanding.incrementAndGet();
+    }
+
+    /** Signals that a registered task has finished, whether it succeeded or not. */
+    public void taskDone() {
+        release();
+    }
+
+    /** Signals that no further task will be registered. */
+    public void noMoreTasks() {
+        release();
+    }
+
+    private void release() {
+        if (outstanding.decrementAndGet() == 0 && completed.compareAndSet(false, true)) {
+            onCompletion.run();
+        }
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -33,6 +33,7 @@ import crawlercommons.urlfrontier.Urlfrontier.StringList;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.AbstractFrontierService;
+import crawlercommons.urlfrontier.service.AsyncCompletion;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -50,8 +51,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.LoggerFactory;
 
 public abstract class DistributedFrontierService extends AbstractFrontierService {
@@ -73,6 +78,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     /** Maximum time granted to a forwarded control call before failing the caller. */
     static final int FORWARD_DEADLINE_SECONDS = 30;
+
+    /** How often the items forwarded to other nodes are checked for expiry. */
+    static final int INPROCESS_CLEANUP_SECONDS = 10;
 
     private final CacheLoader<String, ManagedChannel> channelLoader =
             new CacheLoader<String, ManagedChannel>() {
@@ -337,36 +345,28 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                                                 crawlercommons.urlfrontier.Urlfrontier.AckMessage
                                                         value) {
 
-                                            // go back to the client
-                                            // and notify that it has worked
-                                            // we know that the observer in the cache
-                                            // is a synchronized one
-                                            StreamObserver<AckMessage> stream =
-                                                    inprocesscache.getIfPresent(value.getID());
-                                            if (stream != null) {
-                                                LOG.debug(
-                                                        "Got stream to ack back for {} with status {}",
-                                                        value.getID(),
-                                                        value.getStatus());
-                                                try {
-                                                    stream.onNext(value);
-                                                } catch (Exception e) {
-                                                    LOG.error(
-                                                            "Error while communicating back with the client: {} ",
-                                                            e.getLocalizedMessage());
-                                                }
-                                            } else {
+                                            // the ID carried by the ack is the correlation
+                                            // token we generated when forwarding the item;
+                                            // remove it whether we can return the value or not
+                                            final PendingAck pending =
+                                                    inprocesscache.asMap().remove(value.getID());
+
+                                            if (pending == null) {
                                                 LOG.error(
                                                         "No stream found to ack back for {} with status {}",
                                                         value.getID(),
                                                         value.getStatus());
+                                                return;
                                             }
-                                            // remove it whether we have been able to return the
-                                            // value or not
-                                            // this is an issue if 2 or more instances of the same
-                                            // URL
-                                            // are sent within a short period of time
-                                            inprocesscache.invalidate(value.getID());
+
+                                            LOG.debug(
+                                                    "Got stream to ack back for {} with status {}",
+                                                    pending.clientID,
+                                                    value.getStatus());
+
+                                            // go back to the client and notify that it has
+                                            // worked, under the ID the client knows about
+                                            pending.ack(value.getStatus());
                                         }
 
                                         @Override
@@ -412,46 +412,102 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     .expireAfterAccess(1, TimeUnit.MINUTES)
                     .build((CacheLoader) observerloader);
 
-    private final RemovalListener<
-                    String, StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage>>
-            inProcessRemovalListener =
-                    new RemovalListener<>() {
-                        @Override
-                        public void onRemoval(
-                                RemovalNotification<String, StreamObserver<AckMessage>>
-                                        notification) {
-                            // try to notify the client if something was sent to another instance
-                            // but never
-                            // came back?
-                            if (notification.wasEvicted()) {
-                                String ID = notification.getKey();
-                                LOG.debug(
-                                        "Trying to notify original stream about eviction of {}",
-                                        ID);
-                                StreamObserver<AckMessage> stream = notification.getValue();
-                                if (stream != null) {
-                                    try {
-                                        stream.onNext(
-                                                AckMessage.newBuilder()
-                                                        .setID(ID)
-                                                        .setStatus(Status.FAIL)
-                                                        .build());
-                                    } catch (Exception e) {
-                                        LOG.error(
-                                                "Error while communicating back with the client: {} ",
-                                                e.getLocalizedMessage());
-                                    }
-                                }
-                            }
-                        }
-                    };
+    /**
+     * An item forwarded to another node, waiting for that node to ack it back. Held in {@link
+     * #inprocesscache} under a correlation token: the ID given by the client can be repeated within
+     * a stream or across streams, a token never is.
+     */
+    private static final class PendingAck {
 
-    private Cache<String, StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage>>
-            inprocesscache =
-                    CacheBuilder.newBuilder()
-                            .expireAfterAccess(1, TimeUnit.MINUTES)
-                            .removalListener(inProcessRemovalListener)
-                            .build();
+        private final String clientID;
+
+        /** the synchronized observer of the client stream the item came from */
+        private final StreamObserver<AckMessage> client;
+
+        /** completion of that stream: this item is one of its outstanding tasks */
+        private final AsyncCompletion completion;
+
+        private final AtomicBoolean acked = new AtomicBoolean();
+
+        PendingAck(String clientID, StreamObserver<AckMessage> client, AsyncCompletion completion) {
+            this.clientID = clientID;
+            this.client = client;
+            this.completion = completion;
+        }
+
+        /**
+         * Sends the status back to the client under its own ID and releases the item. Subsequent
+         * calls do nothing: the ack coming back from the remote node can race with the eviction of
+         * an item given up on.
+         */
+        void ack(Status status) {
+            if (!acked.compareAndSet(false, true)) {
+                return;
+            }
+            try {
+                client.onNext(AckMessage.newBuilder().setID(clientID).setStatus(status).build());
+            } catch (Exception e) {
+                LOG.error(
+                        "Error while communicating back with the client: {} ",
+                        e.getLocalizedMessage());
+            } finally {
+                completion.taskDone();
+            }
+        }
+    }
+
+    private final RemovalListener<String, PendingAck> inProcessRemovalListener =
+            new RemovalListener<>() {
+                @Override
+                public void onRemoval(RemovalNotification<String, PendingAck> notification) {
+                    // try to notify the client if something was sent to another instance but never
+                    // came back?
+                    if (notification.wasEvicted()) {
+                        PendingAck pending = notification.getValue();
+                        if (pending != null) {
+                            LOG.debug(
+                                    "Trying to notify original stream about eviction of {}",
+                                    pending.clientID);
+                            pending.ack(Status.FAIL);
+                        }
+                    }
+                }
+            };
+
+    private Cache<String, PendingAck> inprocesscache =
+            CacheBuilder.newBuilder()
+                    .expireAfterAccess(1, TimeUnit.MINUTES)
+                    .removalListener(inProcessRemovalListener)
+                    .build();
+
+    /**
+     * Guava evicts only during cache activity: without a heartbeat, a stream whose remote acks
+     * never come back would stay open instead of being failed by the expiry above.
+     */
+    private final ScheduledExecutorService inprocessCacheCleaner =
+            Executors.newSingleThreadScheduledExecutor(
+                    r -> {
+                        Thread t = new Thread(r, "inprocesscache-cleanup");
+                        t.setDaemon(true);
+                        return t;
+                    });
+
+    {
+        inprocessCacheCleaner.scheduleWithFixedDelay(
+                () -> {
+                    try {
+                        inprocesscache.cleanUp();
+                    } catch (Exception e) {
+                        LOG.error("Exception while cleaning up the in-process cache", e);
+                    }
+                },
+                INPROCESS_CLEANUP_SECONDS,
+                INPROCESS_CLEANUP_SECONDS,
+                TimeUnit.SECONDS);
+    }
+
+    /** Correlation tokens for the items forwarded to other nodes; unique within this instance. */
+    private final AtomicLong correlationSequence = new AtomicLong();
 
     /** Delete the queue based on the key in parameter */
     @Override
@@ -656,6 +712,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     @Override
     public void close() throws IOException {
         super.close();
+        inprocessCacheCleaner.shutdownNow();
         // close all the connections
         channelCache.invalidateAll();
     }
@@ -678,7 +735,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
         return new StreamObserver<URLItem>() {
 
-            final AtomicInteger unacked = new AtomicInteger();
+            // closes the response once the client has stopped sending and every item has
+            // been written locally or acked back by the node it was forwarded to
+            final AsyncCompletion completion = new AsyncCompletion(sso::onCompleted);
 
             @Override
             public void onNext(URLItem value) {
@@ -734,16 +793,28 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 LOG.trace("LocalNodeIndex {}", localNodeIndex);
 
                 if (partition == localNodeIndex) {
-                    unacked.incrementAndGet();
+                    completion.taskStarted();
 
-                    writeExecutorService.execute(
-                            () -> {
-                                final Status s = putURLItem(value);
-                                LOG.debug("Local putURL -> {} got status {}", url, s);
-                                final AckMessage ackedMessage = ack.setStatus(s).build();
-                                sso.onNext(ackedMessage);
-                                unacked.decrementAndGet();
-                            });
+                    try {
+                        writeExecutorService.execute(
+                                () -> {
+                                    try {
+                                        final Status s = putURLItem(value);
+                                        LOG.debug("Local putURL -> {} got status {}", url, s);
+                                        final AckMessage ackedMessage = ack.setStatus(s).build();
+                                        sso.onNext(ackedMessage);
+                                    } finally {
+                                        // whatever happens the item must be released or the
+                                        // response is never closed
+                                        completion.taskDone();
+                                    }
+                                });
+                    } catch (RejectedExecutionException e) {
+                        // the task never started: tell the client instead of leaving it waiting
+                        LOG.error("Executor rejected putURLs task for {}", url, e);
+                        sso.onNext(ack.setStatus(Status.FAIL).build());
+                        completion.taskDone();
+                    }
                 } else {
                     // forward to non-local node
                     LOG.debug(
@@ -752,22 +823,36 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                             partition,
                             getNodes().get(partition));
 
-                    // if the same ID is already being processed by
-                    // a remote Frontier, just wait until it has been completed
-                    while (inprocesscache.getIfPresent(ack.getID()) != null) {
-                        try {
-                            Thread.sleep(50);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt(); // set the flag back to <code>true
-                        }
+                    // the item goes out under a correlation token of ours rather than the
+                    // client's ID: the same ID can legitimately be sent more than once, in
+                    // which case the acks could no longer be told apart
+                    final String token = Long.toString(correlationSequence.incrementAndGet());
+                    final PendingAck pending = new PendingAck(ack.getID(), sso, completion);
+
+                    completion.taskStarted();
+
+                    // store the tuple to return in a temporary cache; must be in place
+                    // before the item goes out as the ack can come back at any point
+                    inprocesscache.put(token, pending);
+
+                    try {
+                        // get the stream observer for the node in charge of the partition
+                        // and give it the value to process
+                        observercache
+                                .getUnchecked(partition)
+                                .onNext(URLItem.newBuilder(value).setID(token).build());
+                    } catch (Exception e) {
+                        LOG.error(
+                                "Error while sending {} to partition {}: {}",
+                                url,
+                                partition,
+                                e.getLocalizedMessage());
+                        // no ack will ever come back for it: fail it now instead of
+                        // waiting for the entry to expire
+                        observercache.invalidate(partition);
+                        inprocesscache.invalidate(token);
+                        pending.ack(Status.FAIL);
                     }
-
-                    // store the tuple to return in a temporary cache
-                    inprocesscache.put(ack.getID(), sso);
-
-                    // get the stream observer for the node in charge of the partition
-                    // and give it the value to process
-                    observercache.getUnchecked(partition).onNext(value);
                 }
             }
 
@@ -787,15 +872,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
             @Override
             public void onCompleted() {
-                // check that all the work for this stream has ended
-                while (unacked.get() != 0 || inprocesscache.asMap().containsValue(sso)) {
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-                sso.onCompleted();
+                // the response is closed here if all the work for this stream has already
+                // ended, or by the last item to be acked otherwise
+                completion.noMoreTasks();
             }
         };
     }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/AsyncCompletionTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/AsyncCompletionTest.java
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class AsyncCompletionTest {
+
+    @Test
+    void noTaskCompletesOnTheProducerThread() {
+        AtomicInteger completions = new AtomicInteger();
+        AsyncCompletion completion = new AsyncCompletion(completions::incrementAndGet);
+
+        completion.noMoreTasks();
+
+        assertEquals(1, completions.get());
+    }
+
+    @Test
+    void registeredTasksHoldTheCompletionBack() {
+        AtomicInteger completions = new AtomicInteger();
+        AsyncCompletion completion = new AsyncCompletion(completions::incrementAndGet);
+
+        completion.taskStarted();
+        completion.taskStarted();
+        completion.noMoreTasks();
+        assertEquals(0, completions.get(), "outstanding tasks must keep the completion pending");
+
+        completion.taskDone();
+        assertEquals(0, completions.get());
+
+        completion.taskDone();
+        assertEquals(1, completions.get(), "the last task to finish must complete");
+    }
+
+    @Test
+    void tasksFinishingBeforeTheProducerDoNotCompleteEarly() {
+        AtomicInteger completions = new AtomicInteger();
+        AsyncCompletion completion = new AsyncCompletion(completions::incrementAndGet);
+
+        // a task can finish while the producer is still registering the next ones
+        completion.taskStarted();
+        completion.taskDone();
+        assertEquals(0, completions.get(), "the producer may still register more tasks");
+
+        completion.taskStarted();
+        completion.taskDone();
+        assertEquals(0, completions.get());
+
+        completion.noMoreTasks();
+        assertEquals(1, completions.get());
+    }
+
+    @Test
+    void completesExactlyOnceUnderConcurrency() throws Exception {
+        final int tasks = 64;
+        ExecutorService pool = Executors.newFixedThreadPool(8);
+        try {
+            for (int run = 0; run < 200; run++) {
+                AtomicInteger completions = new AtomicInteger();
+                AsyncCompletion completion = new AsyncCompletion(completions::incrementAndGet);
+                CountDownLatch start = new CountDownLatch(1);
+                CountDownLatch done = new CountDownLatch(tasks);
+
+                for (int i = 0; i < tasks; i++) {
+                    completion.taskStarted();
+                    pool.execute(
+                            () -> {
+                                try {
+                                    start.await();
+                                    completion.taskDone();
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                } finally {
+                                    done.countDown();
+                                }
+                            });
+                }
+
+                start.countDown();
+                completion.noMoreTasks();
+
+                assertTrue(done.await(10, TimeUnit.SECONDS));
+                assertEquals(1, completions.get(), "the action must run exactly once");
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -145,9 +145,10 @@ class GetURLsReservationTest {
         GetParams request =
                 GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
 
+        // the rotation path hands the queues to the read executor and returns: the send
+        // is still in flight when the call comes back
         CollectingObserver first = new CollectingObserver();
-        Thread t1 = new Thread(() -> service.getURLs(request, first));
-        t1.start();
+        service.getURLs(request, first);
         assertTrue(service.enteredSend.await(5, TimeUnit.SECONDS), "first send never started");
 
         // while the first send is in flight, a concurrent request must skip the queue
@@ -156,7 +157,7 @@ class GetURLsReservationTest {
         assertTrue(second.completed.await(5, TimeUnit.SECONDS));
 
         service.releaseSend.countDown();
-        t1.join(5000);
+        assertTrue(first.completed.await(5, TimeUnit.SECONDS), "first request never completed");
 
         assertEquals(
                 1,
@@ -258,9 +259,10 @@ class GetURLsReservationTest {
         GetParams request =
                 GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
 
-        // without the try/finally around sendURLsForQueue this call never returns
+        // without the try/finally around sendURLsForQueue the response is never closed
         CollectingObserver first = new CollectingObserver();
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> service.getURLs(request, first));
+        assertTrue(first.completed.await(5, TimeUnit.SECONDS), "the response was never closed");
 
         // fail-closed: outcome unknown, so the politeness window is enforced
         assertNotEquals(AbstractFrontierService.RESERVATION_IN_PROGRESS, queue.getLastProduced());

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceTest.java
@@ -602,6 +602,7 @@ class MemoryFrontierServiceTest {
         StreamObserver<URLItem> streamObserver = memoryFrontierService.putURLs(responseObserver);
         streamObserver.onNext(builder1.build());
         streamObserver.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(completed);
 
         assertEquals(1, skipped.get());
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/NonBlockingStreamsTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/NonBlockingStreamsTest.java
@@ -1,0 +1,178 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.GetParams;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces issue #170: a gRPC handler thread must not be held while the work it handed over to an
+ * executor is running. The response is closed by whichever thread finishes last instead.
+ */
+class NonBlockingStreamsTest {
+
+    private static final String CRAWL_ID = "crawl_id";
+    private static final String KEY = "queue_mysite";
+
+    /** MemoryFrontierService whose write and read paths can be held on a latch. */
+    static class BlockingService extends MemoryFrontierService {
+
+        final CountDownLatch enteredPut = new CountDownLatch(1);
+        final CountDownLatch releasePut = new CountDownLatch(1);
+        final CountDownLatch enteredSend = new CountDownLatch(1);
+        final CountDownLatch releaseSend = new CountDownLatch(1);
+
+        volatile boolean blockPuts = false;
+        volatile boolean blockSends = false;
+
+        BlockingService() {
+            super("localhost", 0);
+        }
+
+        @Override
+        protected AckMessage.Status putURLItem(URLItem value) {
+            if (blockPuts) {
+                enteredPut.countDown();
+                await(releasePut);
+            }
+            return super.putURLItem(value);
+        }
+
+        @Override
+        protected int sendURLsForQueue(
+                QueueInterface queue,
+                QueueWithinCrawl key,
+                int maxURLsPerQueue,
+                int secsUntilRequestable,
+                long now,
+                SynchronizedStreamObserver<URLInfo> observer) {
+            if (blockSends) {
+                enteredSend.countDown();
+                await(releaseSend);
+            }
+            return super.sendURLsForQueue(
+                    queue, key, maxURLsPerQueue, secsUntilRequestable, now, observer);
+        }
+
+        private static void await(CountDownLatch latch) {
+            try {
+                latch.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /** Counts the acks and signals when the response stream is closed. */
+    static class AckCollector implements StreamObserver<AckMessage> {
+        final AtomicInteger acked = new AtomicInteger();
+        final CountDownLatch closed = new CountDownLatch(1);
+
+        @Override
+        public void onNext(AckMessage value) {
+            acked.incrementAndGet();
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            closed.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            closed.countDown();
+        }
+    }
+
+    static class URLCollector implements StreamObserver<URLInfo> {
+        final CountDownLatch closed = new CountDownLatch(1);
+
+        @Override
+        public void onNext(URLInfo value) {}
+
+        @Override
+        public void onError(Throwable t) {
+            closed.countDown();
+        }
+
+        @Override
+        public void onCompleted() {
+            closed.countDown();
+        }
+    }
+
+    private static URLItem discovered(String url) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(CRAWL_ID).setKey(KEY).build();
+        return URLItem.newBuilder()
+                .setID(CRAWL_ID + "_" + url)
+                .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                .build();
+    }
+
+    @Test
+    void putURLsDoesNotBlockTheInboundStream() throws Exception {
+        BlockingService service = new BlockingService();
+        service.blockPuts = true;
+
+        AckCollector acks = new AckCollector();
+        StreamObserver<URLItem> put = service.putURLs(acks);
+        put.onNext(discovered("https://www.mysite.com/a"));
+        assertTrue(service.enteredPut.await(5, TimeUnit.SECONDS), "the write never started");
+
+        // the handler thread must come straight back: it used to spin until the write
+        // executor had drained
+        assertTimeoutPreemptively(Duration.ofSeconds(5), put::onCompleted);
+        assertEquals(
+                1, acks.closed.getCount(), "the response must stay open while an item is unacked");
+
+        service.releasePut.countDown();
+        assertTrue(acks.closed.await(5, TimeUnit.SECONDS), "the response was never closed");
+        assertEquals(1, acks.acked.get(), "the item must still be acked");
+
+        service.close();
+    }
+
+    @Test
+    void getURLsDoesNotBlockTheHandlerThread() throws Exception {
+        BlockingService service = new BlockingService();
+
+        AckCollector seeded = new AckCollector();
+        StreamObserver<URLItem> put = service.putURLs(seeded);
+        put.onNext(discovered("https://www.mysite.com/a"));
+        put.onCompleted();
+        assertTrue(seeded.closed.await(5, TimeUnit.SECONDS), "seeding did not complete");
+
+        service.blockSends = true;
+
+        // the rotation path, i.e. no key in the request: the queues are served by the
+        // read executor
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+        URLCollector urls = new URLCollector();
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> service.getURLs(request, urls));
+
+        assertTrue(service.enteredSend.await(5, TimeUnit.SECONDS), "the send never started");
+        assertEquals(
+                1, urls.closed.getCount(), "the response must stay open while a queue is served");
+
+        service.releaseSend.countDown();
+        assertTrue(urls.closed.await(5, TimeUnit.SECONDS), "the response was never closed");
+
+        service.close();
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -619,6 +619,7 @@ class RocksDBServiceTest {
         StreamObserver<URLItem> streamObserver = rocksDBService.putURLs(responseObserver);
         streamObserver.onNext(builder1.build());
         streamObserver.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(completed);
 
         assertEquals(1, skipped.get());
 
@@ -760,6 +761,7 @@ class RocksDBServiceTest {
         StreamObserver<URLItem> streamObserver = rocksDBService.putURLs(responseObserver);
         streamObserver.onNext(builder1.build());
         streamObserver.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(completed);
 
         // Verify it has been skipped
         // Once a URL is "known", it can't be set back to "discovered"
@@ -824,6 +826,7 @@ class RocksDBServiceTest {
         StreamObserver<URLItem> streamObserver2 = rocksDBService.putURLs(responseObserver2);
         streamObserver2.onNext(builder1.build());
         streamObserver2.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(completed2);
 
         assertEquals(1, ok2.get());
 
@@ -947,6 +950,7 @@ class RocksDBServiceTest {
         StreamObserver<URLItem> putObserver = rocksDBService.putURLs(ackObserver);
         putObserver.onNext(builder.build());
         putObserver.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(putCompleted);
         assertTrue(putCompleted.get());
 
         // simulate a URL without a creation date by removing the entry from the

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ServiceTestUtil.java
@@ -20,6 +20,26 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class ServiceTestUtil {
 
+    /**
+     * Waits for a putURLs response stream to be closed, i.e. for the flag set by its onCompleted.
+     * Calling onCompleted on the request stream only signals that the client has stopped sending:
+     * the response is closed later, by the last item to be acked.
+     */
+    public static void awaitStreamClosed(AtomicBoolean completed) {
+        final long deadline = System.currentTimeMillis() + 10_000;
+        while (!completed.get()) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("the putURLs response stream was not closed in time");
+            }
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                fail("interrupted while waiting for the putURLs response stream to close");
+            }
+        }
+    }
+
     public static void initURLs(AbstractFrontierService service) {
 
         String crawlId = "crawl_id";

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -35,6 +35,8 @@ import io.grpc.stub.StreamObserver;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -452,6 +454,63 @@ class DistributedFrontierServiceTest {
                                         .setCrawlID("DEFAULT")
                                         .setLimit(1)
                                         .build()));
+    }
+
+    @Test
+    @Order(17)
+    void repeatedIdsForwardedToTheOwnerAreAllAckedUnderTheClientId() throws Exception {
+        // issue #170: forwarded items are correlated by an internal token rather than by
+        // the ID given by the client, which can legitimately be repeated
+        final String key = keyOwnedBy(1, "dupack");
+        final String id = "repeated-id";
+        final int copies = 20;
+
+        final List<AckMessage> acks = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch latch = new CountDownLatch(1);
+        StreamObserver<URLItem> input =
+                URLFrontierGrpc.newStub(channelA)
+                        .putURLs(
+                                new StreamObserver<AckMessage>() {
+                                    @Override
+                                    public void onNext(AckMessage value) {
+                                        acks.add(value);
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        latch.countDown();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        latch.countDown();
+                                    }
+                                });
+
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://" + key + "/repeated")
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .build();
+        for (int i = 0; i < copies; i++) {
+            input.onNext(
+                    URLItem.newBuilder()
+                            .setID(id)
+                            .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                            .build());
+        }
+        input.onCompleted();
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS), "putURLs did not complete in time");
+        assertEquals(copies, acks.size(), "every item must be acked exactly once");
+        for (AckMessage ack : acks) {
+            assertEquals(id, ack.getID(), "acks must carry the ID given by the client");
+            assertNotEquals(
+                    AckMessage.Status.FAIL,
+                    ack.getStatus(),
+                    "no item must be left to expire in the in-process cache");
+        }
     }
 
     @Test


### PR DESCRIPTION
Four places held a gRPC handler thread in a `Thread.sleep` polling loop while the work they had just submitted ran elsewhere. The interrupt was swallowed in each of them — the flag was restored but the loop carried on — so the request could not be cancelled either.

## Approach

New `AsyncCompletion`: it counts the outstanding tasks of a request or stream and runs the completion action exactly once, on whichever thread finishes last. The producer holds one implicit unit until it calls `noMoreTasks()`, so the action cannot fire early while tasks are still being registered.

### `AbstractFrontierService.getURLs`

Returns as soon as the queues have been handed to the read executor. The final log line, the URL counter, the latency timer and `onCompleted` move to the completion callback, so they still run exactly once, after the last worker.

### `AbstractFrontierService.putURLs`

`onCompleted` only signals that the client has stopped sending; the last ack closes the response. The worker body is wrapped in `try/finally` so a throwing `putURLItem` can no longer leave the response open, and a task rejected by the executor is acked `FAIL` rather than left unaccounted for — that leak used to hang the stream for good.

### `DistributedFrontierService.putURLs`

Items forwarded to another node go out under a unique correlation token rather than the ID given by the client, and `inprocesscache` is keyed by that token; the ack coming back is translated to the ID the client knows about. The same ID can now be sent repeatedly, within a stream or across streams, without the inbound stream stalling until the previous ack came back — previously up to a minute per duplicate if the remote node was slow or gone, and two streams using the same ID could race so that one of them never got its ack. The eviction listener and the ack path share a CAS so an item is acked and released exactly once. Failing to hand an item to the remote observer now acks `FAIL` immediately instead of waiting for the entry to expire.

The drain condition in `onCompleted` no longer scans the whole cache with `containsValue` on every iteration.

Guava evicts only during cache activity, so the one-minute expiry which fails items whose acks never come back could never fire on an otherwise idle node: the cache now gets a 10s daemon `cleanUp()` heartbeat, shut down in `close()`.

## Tests

- `AsyncCompletionTest` — ordering, no early completion, exactly-once under 200×64 concurrent releases.
- `NonBlockingStreamsTest` — both handlers return while the work is held on a latch, and the response is closed only afterwards. Both tests time out against the pre-fix code.
- `DistributedFrontierServiceTest.repeatedIdsForwardedToTheOwnerAreAllAckedUnderTheClientId` — 20 items sharing one ID, routed to the other node, all come back under the client's ID with no `FAIL`.
- Four existing tests asserted on state right after `putURLs.onCompleted` returned, which relied on it blocking until the acks had been delivered; they now wait for the response stream to be closed. One of them was a latent race that happened to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
