### PR TITLE
Iterate over the queues lazily instead of copying them, fixes OOM in getStats

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -440,45 +439,43 @@ public abstract class AbstractFrontierService
         final Map<String, Long> s = new HashMap<>();
 
         int inProc = 0;
-        int numQueues = 0;
-        int size = 0;
+        long numQueues = 0;
+        long size = 0;
         long completed = 0;
         long activeQueues = 0;
 
-        List<QueueInterface> lqueues = new LinkedList<>();
-
         final String normalisedCrawlID = CrawlID.normaliseCrawlID(request.getCrawlID());
+
+        // the queues are aggregated as they are iterated over: a frontier can hold
+        // millions of them, holding them all in a collection would blow the heap
+        final Iterator<QueueInterface> queues;
 
         // specific queue?
         if (!request.getKey().isEmpty()) {
             QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
             QueueInterface q = getQueues().get(qwc);
             if (q != null) {
-                lqueues.add(q);
+                queues = List.of(q).iterator();
             } else {
                 // TODO notify an error to the client
+                queues = Collections.emptyIterator();
             }
         }
         // all the queues within the crawlID
         else {
-
-            // check that the queues belong to the crawlid specified
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                    getQueues().entrySetView().iterator();
-            while (iterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-                QueueWithinCrawl qwc = e.getKey();
-                if (qwc.getCrawlid().equals(normalisedCrawlID)) {
-                    lqueues.add(e.getValue());
-                }
-            }
+            // the iterator is weakly consistent, no risk of
+            // ConcurrentModificationException
+            queues =
+                    getQueues().entrySet().stream()
+                            .filter(e -> e.getKey().getCrawlid().equals(normalisedCrawlID))
+                            .map(Entry::getValue)
+                            .iterator();
         }
-        // backed by the queues so can result in a
-        // ConcurrentModificationException
 
         long now = Instant.now().getEpochSecond();
 
-        for (QueueInterface q : lqueues) {
+        while (queues.hasNext()) {
+            QueueInterface q = queues.next();
             final int inProcForQ = q.getInProcess(now);
             final int activeForQ = q.countActive();
             if (inProcForQ > 0 || activeForQ > 0) {
@@ -1017,7 +1014,7 @@ public abstract class AbstractFrontierService
         long sentCount = 0;
 
         Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                getQueues().entrySetView().iterator();
+                getQueues().entrySet().iterator();
 
         while (qiterator.hasNext() && sentCount < maxURLs) {
             Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
@@ -1111,7 +1108,7 @@ public abstract class AbstractFrontierService
         long totalCount = 0;
 
         Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                getQueues().entrySetView().iterator();
+                getQueues().entrySet().iterator();
 
         while (qiterator.hasNext()) {
             Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
@@ -1183,7 +1180,7 @@ public abstract class AbstractFrontierService
 
         synchronized (getQueues()) {
             Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                    getQueues().entrySetView().iterator();
+                    getQueues().entrySet().iterator();
 
             while (qiterator.hasNext()) {
                 Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -32,7 +32,8 @@ public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
 
     /**
      * Returns a set containing the mappings in this map. The iterator returned by this set is
-     * weakly consistent. Remove is not supported by the iterator
+     * weakly consistent: entries removed by another thread while iterating are skipped rather than
+     * reported. Remove is not supported by the iterator
      */
     @Override
     Set<Map.Entry<K, V>> entrySet();
@@ -43,11 +44,4 @@ public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
      */
     @Override
     Collection<V> values();
-
-    /**
-     * Returns a set view containing the mappings in this map which is not backed by the map. (Used
-     * in listURLs and countURLs to avoid NoSuchElementException if another thread has rotated the
-     * queue in getURLs)
-     */
-    Set<Map.Entry<K, V>> entrySetView();
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -9,7 +9,6 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -183,24 +182,6 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
     }
 
     @Override
-    public Set<Map.Entry<K, V>> entrySetView() {
-        LinkedHashSet<Map.Entry<K, V>> entrySet = new LinkedHashSet<>(valueMap.size());
-        insertionOrderMap.forEach(
-                (order, key) -> {
-                    ValueEntry valueEntry = valueMap.get(key);
-                    if (valueEntry != null) {
-                        entrySet.add(new AbstractMap.SimpleImmutableEntry<>(key, valueEntry.value));
-                    } else {
-                        LOG.warn(
-                                "Inconsistent state (entrySetView): key {} exists in order map but not in value map",
-                                key);
-                    }
-                });
-
-        return entrySet;
-    }
-
-    @Override
     public Set<Map.Entry<K, V>> entrySet() {
         return new AbstractSet<Map.Entry<K, V>>() {
             @Override
@@ -209,17 +190,19 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
                     final Iterator<Entry<Long, K>> orderedIterator =
                             insertionOrderMap.entrySet().iterator();
 
-                    Entry<Long, K> nextEntry = null;
+                    // resolved by hasNext() so that next() cannot fail on a key which
+                    // has been removed by another thread in the meantime
+                    Map.Entry<K, V> nextEntry = null;
 
                     @Override
                     public boolean hasNext() {
                         while (nextEntry == null && orderedIterator.hasNext()) {
-                            Entry<Long, K> entry = orderedIterator.next();
-                            K key = entry.getValue();
+                            K key = orderedIterator.next().getValue();
                             ValueEntry valueEntry = valueMap.get(key);
                             if (valueEntry != null) {
-                                this.nextEntry = entry;
-                                return true;
+                                this.nextEntry =
+                                        new AbstractMap.SimpleImmutableEntry<>(
+                                                key, valueEntry.value);
                             }
                         }
                         return nextEntry != null;
@@ -227,16 +210,14 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
 
                     @Override
                     public Map.Entry<K, V> next() {
-                        Entry<Long, K> entry = this.nextEntry;
-                        this.nextEntry = null;
-
-                        K key = entry.getValue();
-                        ValueEntry valueEntry = valueMap.get(key);
-                        if (valueEntry == null) {
+                        if (!hasNext()) {
                             throw new NoSuchElementException();
                         }
 
-                        return new AbstractMap.SimpleImmutableEntry<>(key, valueEntry.value);
+                        Map.Entry<K, V> entry = this.nextEntry;
+                        this.nextEntry = null;
+
+                        return entry;
                     }
                 };
             }
@@ -448,31 +429,29 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
                     final Iterator<Entry<Long, K>> orderedIterator =
                             insertionOrderMap.entrySet().iterator();
 
-                    Entry<Long, K> nextEntry = null;
+                    // resolved by hasNext() so that next() cannot fail on a key which
+                    // has been removed by another thread in the meantime
+                    ValueEntry nextEntry = null;
 
                     @Override
                     public boolean hasNext() {
                         while (nextEntry == null && orderedIterator.hasNext()) {
-                            Entry<Long, K> entry = orderedIterator.next();
-                            K key = entry.getValue();
-                            if (valueMap.containsKey(key)) {
-                                nextEntry = entry;
-                                return true;
-                            }
+                            K key = orderedIterator.next().getValue();
+                            nextEntry = valueMap.get(key);
                         }
                         return nextEntry != null;
                     }
 
                     @Override
                     public V next() {
-                        Entry<Long, K> entry = nextEntry;
-                        nextEntry = null;
-                        K key = entry.getValue();
-                        ValueEntry valueEntry = valueMap.get(key);
-                        if (valueEntry == null) {
+                        if (!hasNext()) {
                             throw new NoSuchElementException();
                         }
-                        return valueEntry.value;
+
+                        ValueEntry entry = nextEntry;
+                        nextEntry = null;
+
+                        return entry.value;
                     }
                 };
             }


### PR DESCRIPTION
## Problem

`getStats` on a large frontier dies with an `OutOfMemoryError`:

```
15:32:24.925 [grpc-default-executor-6] INFO  c.u.service.AbstractFrontierService - Received stats request
Exception in thread "grpc-default-executor-6" java.lang.OutOfMemoryError: Java heap space
        at java.base/java.util.HashSet.add(HashSet.java:229)
        at crawlercommons.urlfrontier.service.ConcurrentOrderedMap.lambda$entrySetView$0(ConcurrentOrderedMap.java:192)
        at crawlercommons.urlfrontier.service.ConcurrentOrderedMap.entrySetView(ConcurrentOrderedMap.java:188)
        at crawlercommons.urlfrontier.service.AbstractFrontierService.getStats(AbstractFrontierService.java:467)
        at crawlercommons.urlfrontier.service.rocksdb.RocksDBService.getStats(RocksDBService.java:582)
```

`entrySetView()` copies every entry of the queue map into a `LinkedHashSet`, and `getStats` then copied all the queue values again into a `LinkedList` — two full-size collections built just to compute a handful of counters.

## Fix

`entrySetView()` only existed because the lazy `entrySet()` iterator had a race: `hasNext()` checked that the key was still in the value map, then `next()` fetched it again and threw `NoSuchElementException` if another thread had removed the queue in between (queue rotation in `getURLs`). The iterator now resolves the entry once inside `hasNext()` and `next()` returns it, so a concurrently removed queue is skipped rather than raising. `values()` had the same race and is fixed the same way.

With the race gone `entrySetView()` has no purpose and is removed. `getStats`, `listURLs`, `countURLs` and `purgeURLs` iterate over `entrySet()` instead, so their memory usage no longer grows with the number of queues.

`getStats` also aggregates as it iterates rather than collecting the queues first, making it O(1) in the number of queues.

## Also in here

`size` and `numberOfQueues` in `getStats` were `int` while both are declared `uint64` in the proto — on a frontier of this size the active-URL count can pass 2^31 and be reported wrapped. Both are `long` now. `inProcess` is `uint32` in the proto so it stays an `int`.

## Note for reviewers

Removing `entrySetView()` from `ConcurrentInsertionOrderMap` is a source-compatibility break for anyone outside this repo implementing that interface or calling the method. Nothing in the repo used it beyond the four call sites switched here, and no test referenced it. Happy to keep it as a deprecated delegate to `entrySet()` instead if preferred.

## Testing

Full service suite: 107 tests, 0 failures, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)