### PR TITLE
Reuse a single WriteOptions instance in RocksDBService

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -66,6 +66,10 @@ public class RocksDBService extends AbstractFrontierService {
     // opened
     private final List<ColumnFamilyHandle> columnFamilyHandleList = new ArrayList<>();
 
+    // the same options are used for every write: allocating a native object per
+    // URL would be pure overhead on the write path
+    private final WriteOptions writeOptions = new WriteOptions();
+
     private Statistics statistics;
 
     private static final Striped<Lock> STRIPED_LOCKS = Striped.lock(128); // 128 stripes
@@ -406,8 +410,7 @@ public class RocksDBService extends AbstractFrontierService {
             final byte[] existenceKey = existenceKeyString.getBytes(StandardCharsets.UTF_8);
 
             // is this URL already known?
-            try (WriteBatch writeBatch = new WriteBatch();
-                    WriteOptions writeOps = new WriteOptions()) {
+            try (WriteBatch writeBatch = new WriteBatch()) {
 
                 if (isClosing()) {
                     return Status.FAIL;
@@ -480,7 +483,7 @@ public class RocksDBService extends AbstractFrontierService {
 
                 // batch the updates - this way the scheduling and main tables will always be in
                 // sync
-                rocksDB.write(writeOps, writeBatch);
+                rocksDB.write(writeOptions, writeBatch);
 
             } catch (RocksDBException e) {
                 LOG.error("RocksDB exception", e);
@@ -613,6 +616,9 @@ public class RocksDBService extends AbstractFrontierService {
                 LOG.error("Closing ", e);
             }
         }
+
+        // released once the db is closed and no write can be in flight anymore
+        writeOptions.close();
     }
 
     /**


### PR DESCRIPTION
## What

`putURLItem` created and closed a `WriteOptions` for every URL, allocating and freeing a native object plus its JNI handle on each write. This replaces it with a single instance created at construction time.

The options are never mutated, so sharing one instance across the write threads is safe: RocksDB takes them by const reference on each `write()` call. The per-call `WriteBatch` stays in the try-with-resources.

The handle is released in `close()`, after the db itself has been closed — by that point `super.close()` has drained the write executor, so no write can still be referencing it.

## Why

Crawls are write heavy, and this is on the hot path: one native allocation and free per URL ingested.

To set expectations, this is a modest win on its own. The `rocksDB.get()` existence check at the top of `putURLItem` still dominates the write path, especially for brand new URLs, where the lookup misses and has to check every sorted run. Enabling bloom filters by default would be the bigger lever there — worth a separate PR.

## Testing

`mvn -pl service test -Dtest='RocksDB*Test'` — 20 tests run, 0 failures, 1 skipped (pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)