### PR TITLE
Enable Bloom filters by default in RocksDBService

### DIFF
--- a/service/config.ini
+++ b/service/config.ini
@@ -21,6 +21,22 @@ rocksdb.max_background_jobs = 4
 rocksdb.max_subcompactions = 2
 rocksdb.max_bytes_for_level_base = 536870912
 
+# Bloom filters make the lookup done for every URL sent to putURLs cheap when
+# the URL is not known yet, which is the common case when crawling.
+# Enabled by default, set to false to disable them.
+# rocksdb.bloom.filters = false
+
+# number of bits per key used by the filters: the more bits, the fewer false
+# positives and the more memory they need. The default is 10, i.e. about 1.25
+# bytes per URL, for a false positive rate of roughly 1%
+# rocksdb.bloom.filters.bits_per_key = 10
+
+# size in bytes of the block cache, which holds the filters and the index in
+# memory as well as the data read from the SST files. This is off-heap memory,
+# it comes on top of the JVM heap. Only used when the filters are enabled.
+# The default is 268435456, i.e. 256MB
+# rocksdb.block_cache_size = 268435456
+
 # Set to true to enable gRPC server reflection.
 server.enable_reflection = false
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -37,10 +37,13 @@ import java.util.concurrent.locks.Lock;
 import org.apache.commons.lang3.StringUtils;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
+import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.Filter;
+import org.rocksdb.LRUCache;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -69,6 +72,12 @@ public class RocksDBService extends AbstractFrontierService {
     // the same options are used for every write: allocating a native object per
     // URL would be pure overhead on the write path
     private final WriteOptions writeOptions = new WriteOptions();
+
+    // native objects referenced by the table configuration, kept so that they can
+    // be released when the service is closed - null if the filters are disabled
+    private Filter bloomFilter;
+
+    private Cache blockCache;
 
     private Statistics statistics;
 
@@ -103,7 +112,7 @@ public class RocksDBService extends AbstractFrontierService {
 
         boolean checkOnRecovery = configuration.containsKey("rocksdb.recovery.check");
 
-        boolean bloomFilters = configuration.containsKey("rocksdb.bloom.filters");
+        boolean bloomFilters = useBloomFilters(configuration);
 
         try (final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions()) {
 
@@ -113,6 +122,10 @@ public class RocksDBService extends AbstractFrontierService {
             }
 
             cfOpts.optimizeUniversalStyleCompaction();
+
+            if (bloomFilters) {
+                cfOpts.setTableFormatConfig(buildTableConfig(configuration));
+            }
 
             // list of column family descriptors, first entry must always be default column
             // family
@@ -124,12 +137,6 @@ public class RocksDBService extends AbstractFrontierService {
                             new ColumnFamilyDescriptor("creationDates".getBytes(), cfOpts));
 
             long start = System.currentTimeMillis();
-
-            if (bloomFilters) {
-                LOG.info("Configuring Bloom filters");
-                cfOpts.setTableFormatConfig(
-                        new BlockBasedTableConfig().setFilterPolicy(new BloomFilter(10, false)));
-            }
 
             try (final DBOptions options = new DBOptions()) {
                 options.setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
@@ -172,6 +179,60 @@ public class RocksDBService extends AbstractFrontierService {
 
             LOG.info("{} queues discovered in {} msec", getQueues().size(), (end2 - end));
         }
+    }
+
+    /**
+     * The filters are enabled by default: every URL sent to putURLItem needs a lookup to find out
+     * whether it is already known and most of them are not, which is the case they make cheap.
+     *
+     * <p>They used to be enabled with a valueless <i>rocksdb.bloom.filters</i> flag, so the mere
+     * presence of the key is still taken to mean 'enabled'.
+     */
+    static boolean useBloomFilters(final Map<String, String> configuration) {
+        if (!configuration.containsKey("rocksdb.bloom.filters")) {
+            return true;
+        }
+        final String value = configuration.get("rocksdb.bloom.filters");
+        return value == null || value.isEmpty() || Boolean.parseBoolean(value);
+    }
+
+    /**
+     * The filters spare the lookup done for every URL in putURLItem from having to read the data
+     * blocks of the SST files when the URL is not known yet. Universal compaction leaves several
+     * sorted runs to look into, which is what makes them worth their memory here.
+     *
+     * <p>The index and filter blocks are held in the block cache so that they stay bounded as the
+     * frontier grows, with a high priority so that data blocks get evicted before them.
+     */
+    private BlockBasedTableConfig buildTableConfig(final Map<String, String> configuration) {
+
+        double bitsPerKey = 10d;
+        final String sBitsPerKey = configuration.get("rocksdb.bloom.filters.bits_per_key");
+        if (sBitsPerKey != null) {
+            bitsPerKey = Double.parseDouble(sBitsPerKey);
+        }
+
+        long blockCacheSize = 256 * 1024 * 1024L;
+        final String sBlockCacheSize = configuration.get("rocksdb.block_cache_size");
+        if (sBlockCacheSize != null) {
+            blockCacheSize = Long.parseLong(sBlockCacheSize);
+        }
+
+        LOG.info(
+                "Configuring Bloom filters with {} bits per key and a block cache of {} bytes",
+                bitsPerKey,
+                blockCacheSize);
+
+        bloomFilter = new BloomFilter(bitsPerKey);
+        blockCache = new LRUCache(blockCacheSize);
+
+        return new BlockBasedTableConfig()
+                .setFilterPolicy(bloomFilter)
+                .setBlockCache(blockCache)
+                .setCacheIndexAndFilterBlocks(true)
+                .setCacheIndexAndFilterBlocksWithHighPriority(true)
+                .setPinL0FilterAndIndexBlocksInCache(true)
+                .setOptimizeFiltersForMemory(true);
     }
 
     private void recovery() {
@@ -619,6 +680,14 @@ public class RocksDBService extends AbstractFrontierService {
 
         // released once the db is closed and no write can be in flight anymore
         writeOptions.close();
+
+        if (bloomFilter != null) {
+            bloomFilter.close();
+        }
+
+        if (blockCache != null) {
+            blockCache.close();
+        }
     }
 
     /**

--- a/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.rocksdb;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Checks how the rocksdb.bloom.filters configuration key is interpreted */
+class RocksDBBloomFilterConfigTest {
+
+    @Test
+    void enabledWhenNotConfigured() {
+        assertTrue(RocksDBService.useBloomFilters(new HashMap<>()));
+    }
+
+    /** the key used to be a flag without a value */
+    @Test
+    void enabledWhenKeyHasNoValue() {
+        final Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.bloom.filters", null);
+        assertTrue(RocksDBService.useBloomFilters(conf));
+
+        conf.put("rocksdb.bloom.filters", "");
+        assertTrue(RocksDBService.useBloomFilters(conf));
+    }
+
+    @Test
+    void enabledWhenSetToTrue() {
+        final Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.bloom.filters", "true");
+        assertTrue(RocksDBService.useBloomFilters(conf));
+    }
+
+    @Test
+    void disabledWhenSetToFalse() {
+        final Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.bloom.filters", "false");
+        assertFalse(RocksDBService.useBloomFilters(conf));
+    }
+}


### PR DESCRIPTION
## What

Bloom filters were opt-in behind `rocksdb.bloom.filters`. They are now on by default, with the index and filter blocks held in the block cache.

## Why

Every URL sent to `putURLItem` needs a lookup to find out whether it is already known, and during a growing crawl most of them are not. A lookup for a missing key is the worst case: it has to check every sorted run, and `optimizeUniversalStyleCompaction` leaves several of them around. Without filters each of those checks reads actual data blocks. This is the only I/O bound step on the write path, so it is where the time goes.

## Memory

The filters cost about 1.25 bytes per URL at 10 bits per key, and the keys here are long (`crawlid_queue_url`), so the index blocks are sizeable too.

RocksDB's default is `cache_index_and_filter_blocks = false`, which pins all of that in table reader memory, unbounded and off-heap — at a few hundred million URLs that is an OOM waiting to happen in a container. So they go in the block cache instead, with `cacheIndexAndFilterBlocksWithHighPriority` so data blocks get evicted before them, L0's pinned, and `optimizeFiltersForMemory` on.

That only works if the cache is big enough to hold the filters, and the RocksDB default cache is small, hence an explicit 256MB LRU cache. **This is the main thing to review**: it is a real increase in RSS compared to the current default, tunable via `rocksdb.block_cache_size`.

## Configuration

`rocksdb.bloom.filters` was a valueless flag read with `containsKey`, so `rocksdb.bloom.filters = false` in a config file would have *enabled* them. Now that the default is on, that is the difference between a working opt-out and one that silently does nothing:

| form | result |
| --- | --- |
| key absent | enabled |
| `rocksdb.bloom.filters` (no value, the old style) | enabled |
| `rocksdb.bloom.filters = false` | disabled |

`rocksdb.bloom.filters.bits_per_key` (default 10) and `rocksdb.block_cache_size` (default 256MB) are new. All three are documented in `config.ini`.

The same `containsKey` pattern is still used for `rocksdb.purge`, `rocksdb.stats` and `rocksdb.recovery.check` — worth fixing separately, `purge = false` wiping the crawl directory being the unpleasant one.

## Notes for existing deployments

Filters are written into the SST files, so an existing database only gains them as compaction rewrites its data. A fresh DB shows the effect immediately.

## Testing

`mvn -pl service test` — 111 tests, 0 failures, 2 skipped (pre-existing). The new `RocksDBBloomFilterConfigTest` covers the four forms of the config key above.

Not yet benchmarked end to end; the intent is to measure it with the client's `PutURLs` average OPS on a large input, comparing runs that both start from an empty DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
