### PR TITLE
Report the OPS every 30 seconds while PutURLs is running

### DIFF
--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -21,14 +21,21 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
 
 @Command(name = "PutURLs", description = "Send URLs from a file into a Frontier")
 public class PutURLs implements Callable<Integer> {
+
+    /** how often the intermediate throughput is displayed */
+    private static final long REPORT_INTERVAL_SEC = 30;
 
     @ParentCommand private Client parent;
 
@@ -102,6 +109,35 @@ public class PutURLs implements Callable<Integer> {
 
         Instant start = Instant.now();
 
+        // reports the throughput at regular intervals so that any degradation over time is visible
+        ScheduledExecutorService reporter =
+                Executors.newSingleThreadScheduledExecutor(
+                        r -> {
+                            Thread t = new Thread(r, "PutURLs-OPS-reporter");
+                            t.setDaemon(true);
+                            return t;
+                        });
+
+        final AtomicInteger lastAcked = new AtomicInteger(0);
+        final AtomicLong lastReport = new AtomicLong(start.toEpochMilli());
+
+        reporter.scheduleAtFixedRate(
+                () -> {
+                    long now = Instant.now().toEpochMilli();
+                    long elapsed = now - lastReport.getAndSet(now);
+                    int current = acked.get();
+                    int delta = current - lastAcked.getAndSet(current);
+                    System.out.println(
+                            String.format(
+                                    "Acked: %d - OPS over the last %d sec: %.2f",
+                                    current,
+                                    Math.round(elapsed / 1000.0),
+                                    delta * 1000.0 / Math.max(1, elapsed)));
+                },
+                REPORT_INTERVAL_SEC,
+                REPORT_INTERVAL_SEC,
+                TimeUnit.SECONDS);
+
         boolean readError = false;
 
         // read the file line by line so that arbitrarily large inputs can be handled
@@ -160,6 +196,8 @@ public class PutURLs implements Callable<Integer> {
                 Thread.currentThread().interrupt();
             }
         }
+
+        reporter.shutdownNow();
 
         long timetaken = Instant.now().toEpochMilli() - start.toEpochMilli();
 


### PR DESCRIPTION
## What

`PutURLs` now prints the throughput at regular intervals while it is injecting, in addition to the final summary:

```
Acked: 452301 - OPS over the last 30 sec: 15076.70
```

A daemon scheduled reporter fires every 30 seconds and prints the total acked count plus the OPS measured over that window only — the delta of acked URLs divided by the actual elapsed time since the previous tick.

## Why

Long injections only reported a single cumulative average at the very end, which averages away any slowdown. Per-interval rates make degradation over the course of a run visible as it happens.

## Notes for reviewers

- The final summary is unchanged and still ends with the cumulative `Average OPS`.
- The reporter thread is a daemon and is shut down before the summary is printed, so it cannot keep the JVM alive or interleave with the final output.
- Verified by temporarily setting the interval to 1s against a rate-limited in-process frontier: the periodic lines appeared at the expected cadence with rates matching the server's throttle. The interval was then restored to 30s and the throwaway test removed.
- `PutURLsTest` and `VersionProviderTest` pass, as does `validate-code-format`.

DCO: the commit is signed off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)