### PR TITLE
Pass the configuration to ShardedRocksDBService itself

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
@@ -30,7 +30,9 @@ public class ShardedRocksDBService extends DistributedFrontierService {
     private final RocksDBService instance;
 
     public ShardedRocksDBService(final Map<String, String> configuration, String host, int port) {
-        super(host, port);
+        // the executors of this instance are the ones serving the traffic, they must be
+        // sized from the configuration and not from the defaults
+        super(configuration, host, port);
 
         instance = new RocksDBService(configuration, host, port);
         // take coordinates of the nodes + able to identify itself in the list

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ShardedServiceConfigurationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ShardedServiceConfigurationTest.java
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The sharded service must build its own executors from the configuration: they are the ones
+ * serving getURLs and putURLs, the ones of the wrapped instance are never used.
+ *
+ * <p>Lives in the same package as {@link AbstractFrontierService} so that the executors can be read
+ * directly.
+ */
+class ShardedServiceConfigurationTest {
+
+    private static final int PORT = 7404;
+    private static final String PATH = "./target/rocksdb-sharded-conf";
+
+    @Test
+    void threadPoolSettingsAreHonoured() throws Exception {
+        FileUtils.deleteQuietly(new File(PATH));
+        final Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", PATH);
+        conf.put("nodes", "localhost:" + PORT);
+        conf.put("read.thread.num", "7");
+        conf.put("write.thread.num", "9");
+
+        ShardedRocksDBService service = new ShardedRocksDBService(conf, "localhost", PORT);
+        try {
+            assertEquals(
+                    7,
+                    ((ThreadPoolExecutor) service.readExecutorService).getCorePoolSize(),
+                    "read.thread.num must be applied to the sharded service");
+            assertEquals(
+                    9,
+                    ((ThreadPoolExecutor) service.writeExecutorService).getCorePoolSize(),
+                    "write.thread.num must be applied to the sharded service");
+        } finally {
+            service.close();
+            FileUtils.deleteQuietly(new File(PATH));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #175

`ShardedRocksDBService` passed the configuration to the wrapped `RocksDBService` but called the **no-config** super constructor for itself, which resolves to `DistributedFrontierService(String, int)` and on to `AbstractFrontierService(emptyMap, host, port)`.

Those outer executors are the ones that actually serve traffic — `getURLs` uses the sharded instance's `readExecutorService`, `DistributedFrontierService.putURLs` its `writeExecutorService` — so `read.thread.num` and `write.thread.num` were silently ignored on a sharded deployment and fell back to a quarter of the available processors.

## Change

One line: `super(host, port)` → `super(configuration, host, port)`.

Plus a regression test asserting that `read.thread.num=7` / `write.thread.num=9` land on the sharded service's own executors. It lives in package `crawlercommons.urlfrontier.service` so it can read the protected `readExecutorService` / `writeExecutorService` fields directly. It fails on master and passes here.

Tests: `*Sharded*`, `DistributedFrontierServiceTest`, `RocksDBServiceTest` — 43 run, 0 failures, 1 skipped (pre-existing).

## Note on the second effect described in the issue

The issue also reports that the inner instance's unused pools cost "a meaningful number of idle threads". That part does not hold: `Executors.newFixedThreadPool(n)` returns a `ThreadPoolExecutor` that creates its core threads lazily, on first `execute()`, and nothing ever submits to the inner executors. Creating a pool of 64 leaves the thread count unchanged. So the redundant pools cost two objects, not threads, and I have not added the suggested marker-constructor to suppress them — it would widen `AbstractFrontierService`'s constructor surface (or make the two executor fields nullable, which `close()` would then have to guard) for no runtime saving. Happy to add it if you'd rather have it for tidiness.

One cosmetic consequence: a sharded deployment now logs the pool sizes twice at startup, once for the outer service and once for the inner one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
