### PR TITLE
Keep the Bloom filters out of the block cache

### DIFF
--- a/service/config.ini
+++ b/service/config.ini
@@ -31,11 +31,9 @@ rocksdb.max_bytes_for_level_base = 536870912
 # bytes per URL, for a false positive rate of roughly 1%
 # rocksdb.bloom.filters.bits_per_key = 10
 
-# size in bytes of the block cache, which holds the filters and the index in
-# memory as well as the data read from the SST files. This is off-heap memory,
-# it comes on top of the JVM heap. Only used when the filters are enabled.
-# The default is 268435456, i.e. 256MB
-# rocksdb.block_cache_size = 268435456
+# note that the filters are kept in memory outside the block cache, which costs
+# about 1.25 bytes per URL at the default of 10 bits per key. They are not
+# partitioned, so caching them would mean re-reading several MB at a time
 
 # Set to true to enable gRPC server reflection.
 server.enable_reflection = false

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -37,13 +37,11 @@ import java.util.concurrent.locks.Lock;
 import org.apache.commons.lang3.StringUtils;
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
-import org.rocksdb.Cache;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
 import org.rocksdb.Filter;
-import org.rocksdb.LRUCache;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
@@ -73,11 +71,9 @@ public class RocksDBService extends AbstractFrontierService {
     // URL would be pure overhead on the write path
     private final WriteOptions writeOptions = new WriteOptions();
 
-    // native objects referenced by the table configuration, kept so that they can
-    // be released when the service is closed - null if the filters are disabled
+    // native object referenced by the table configuration, kept so that it can be
+    // released when the service is closed - null if the filters are disabled
     private Filter bloomFilter;
-
-    private Cache blockCache;
 
     private Statistics statistics;
 
@@ -201,8 +197,10 @@ public class RocksDBService extends AbstractFrontierService {
      * blocks of the SST files when the URL is not known yet. Universal compaction leaves several
      * sorted runs to look into, which is what makes them worth their memory here.
      *
-     * <p>The index and filter blocks are held in the block cache so that they stay bounded as the
-     * frontier grows, with a high priority so that data blocks get evicted before them.
+     * <p>Everything else is left to its RocksDB default, in particular the filters are not held in
+     * the block cache: they are not partitioned, so there is a single filter block per SST file and
+     * the files are large here. Caching them means evicting and re-reading several MB at a time,
+     * which costs far more than the data block reads the filters save.
      */
     private BlockBasedTableConfig buildTableConfig(final Map<String, String> configuration) {
 
@@ -212,27 +210,11 @@ public class RocksDBService extends AbstractFrontierService {
             bitsPerKey = Double.parseDouble(sBitsPerKey);
         }
 
-        long blockCacheSize = 256 * 1024 * 1024L;
-        final String sBlockCacheSize = configuration.get("rocksdb.block_cache_size");
-        if (sBlockCacheSize != null) {
-            blockCacheSize = Long.parseLong(sBlockCacheSize);
-        }
-
-        LOG.info(
-                "Configuring Bloom filters with {} bits per key and a block cache of {} bytes",
-                bitsPerKey,
-                blockCacheSize);
+        LOG.info("Configuring Bloom filters with {} bits per key", bitsPerKey);
 
         bloomFilter = new BloomFilter(bitsPerKey);
-        blockCache = new LRUCache(blockCacheSize);
 
-        return new BlockBasedTableConfig()
-                .setFilterPolicy(bloomFilter)
-                .setBlockCache(blockCache)
-                .setCacheIndexAndFilterBlocks(true)
-                .setCacheIndexAndFilterBlocksWithHighPriority(true)
-                .setPinL0FilterAndIndexBlocksInCache(true)
-                .setOptimizeFiltersForMemory(true);
+        return new BlockBasedTableConfig().setFilterPolicy(bloomFilter);
     }
 
     private void recovery() {
@@ -683,10 +665,6 @@ public class RocksDBService extends AbstractFrontierService {
 
         if (bloomFilter != null) {
             bloomFilter.close();
-        }
-
-        if (blockCache != null) {
-            blockCache.close();
         }
     }
 


### PR DESCRIPTION
Fixes the ingestion regression introduced by #186.

## What went wrong

#186 put the index and filter blocks in a bounded 256MB block cache, to keep their memory footprint from growing with the frontier. That was the wrong trade.

The filters are not partitioned, so there is a single filter block per SST file, and universal compaction makes those files large — about **3.15MB per filter block** here. Once enough files accumulate they no longer all fit in the cache, and every lookup re-reads several MB from disk, where without the filters it would have read a single 4KB data block.

From a four minute ingestion, with `rocksdb.stats` on:

```
rocksdb.block.cache.filter.bytes.insert : 1,320,226,753,736   (1.32 TB)
rocksdb.block.cache.filter.add / miss   :       419,303
rocksdb.block.cache.index.miss          :         5,358
```

1.32TB of filter traffic. The index blocks are the same size but are missed 5,358 times, so they stay resident and cost nothing — which is why this stayed invisible until the file count grew, around 11M URLs in.

## The fix

The table configuration is left to its RocksDB defaults apart from the filter policy itself. That keeps the filters resident in the memory of the table readers: read once, never evicted, about 1.25 bytes per URL. `rocksdb.block_cache_size` goes away with them.

## Measurements

Same machine, same input, fresh database, 280 seconds per run, cumulative URLs acked in millions:

| 30s sample | filters + block cache (#186) | no filters | filters only (this PR) |
| --- | --- | --- | --- |
| 4 | 10.72 | 10.04 | 10.37 |
| 5 | **11.77** | 12.38 | 12.79 |
| 6 | **12.54** | 14.70 | 15.17 |
| 7 | 14.43 | 16.78 | 17.58 |
| 9 | 19.41 | 20.13 | **21.47** |

The collapse at sample 5 is the reported regression. This PR is **+6.7%** over having no filters at all and leads at every sample, with the filters skipping 25,007,236 data block reads and no filter cache traffic whatsoever.

Two caveats. Both the control and this PR show one transient dip at different points (33k and 53k OPS) — compaction noise, present with and without filters, unlike the sustained two-sample collapse above. And this is measured with a 2.7GB database on a machine with 31GB of RAM, so data blocks come from page cache; the filter win should be larger once a frontier outgrows RAM, which is the case they exist for.

## Testing

`mvn -pl service test` — 111 tests, 0 failures, 2 skipped (pre-existing). The opt-out was also checked end to end: `rocksdb.bloom.filters = false` configures no filter at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
