### PR TITLE
Send URLs from several threads in PutURLs with --threads

### DIFF
--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -20,7 +20,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -53,59 +56,38 @@ public class PutURLs implements Callable<Integer> {
             description = "crawl to get the stats for")
     private String crawl;
 
+    @Option(
+            names = {"-t", "--threads"},
+            defaultValue = "1",
+            paramLabel = "NUM",
+            description =
+                    "number of threads sending URLs, each on its own stream (default to 1). The"
+                            + " URLs are shared between them, they are not sent more than once.")
+    private int threads;
+
+    @Option(
+            names = {"-w", "--in-flight"},
+            defaultValue = "10000",
+            paramLabel = "NUM",
+            description =
+                    "maximum number of URLs sent on a stream but not confirmed yet, per thread"
+                            + " (default to 10000)")
+    private int inFlight;
+
     @Override
     public Integer call() {
 
-        ManagedChannel channel =
-                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
-                        .usePlaintext()
-                        .build();
+        final int streams = Math.max(1, threads);
 
-        URLFrontierStub stub = URLFrontierGrpc.newStub(channel);
-
-        final AtomicBoolean completed = new AtomicBoolean(false);
-        // set when the stream is terminated by an error: no further acks will
-        // ever be received, so we must not wait for the missing ones
-        final AtomicBoolean streamError = new AtomicBoolean(false);
+        final AtomicInteger sent = new AtomicInteger(0);
         final AtomicInteger acked = new AtomicInteger(0);
         final AtomicInteger failed = new AtomicInteger(0);
         final AtomicInteger skipped = new AtomicInteger(0);
         final AtomicInteger ok = new AtomicInteger(0);
 
-        int sent = 0;
-
-        StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage> responseObserver =
-                new StreamObserver<>() {
-
-                    @Override
-                    public void onNext(crawlercommons.urlfrontier.Urlfrontier.AckMessage value) {
-                        // receives confirmation that the value has been received
-                        acked.addAndGet(1);
-                        if (value.getStatus().equals(AckMessage.Status.SKIPPED)) {
-                            skipped.getAndIncrement();
-                        } else if (value.getStatus().equals(AckMessage.Status.FAIL)) {
-                            failed.getAndIncrement();
-                        } else if (value.getStatus().equals(AckMessage.Status.OK)) {
-                            ok.getAndIncrement();
-                        }
-                    }
-
-                    @Override
-                    public void onError(Throwable t) {
-                        streamError.set(true);
-                        completed.set(true);
-                        System.err.println("Error while sending the URLs: " + t.getMessage());
-                    }
-
-                    @Override
-                    public void onCompleted() {
-                        completed.set(true);
-                    }
-                };
-
-        StreamObserver<URLItem> streamObserver = stub.putURLs(responseObserver);
-
-        int linenum = 0;
+        // set when any of the streams is terminated by an error
+        final AtomicBoolean streamError = new AtomicBoolean(false);
+        final AtomicBoolean readError = new AtomicBoolean(false);
 
         Instant start = Instant.now();
 
@@ -138,70 +120,47 @@ public class PutURLs implements Callable<Integer> {
                 REPORT_INTERVAL_SEC,
                 TimeUnit.SECONDS);
 
-        boolean readError = false;
-
-        // read the file line by line so that arbitrarily large inputs can be handled
+        // the file is read once and the lines handed out in chunks, so that adding threads
+        // multiplies the parsing and sending but not the reading
         try (BufferedReader reader = Files.newBufferedReader(Paths.get(file))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
 
-                // the stream is dead, no point in sending anything else
-                if (streamError.get()) {
-                    break;
-                }
+            final LineSource lines = new LineSource(reader);
 
-                // don't sent too many in one go
-                while (sent > acked.get() + 10000 && !streamError.get()) {
-                    try {
-                        Thread.sleep(10);
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-
-                URLItem item = parse(line, crawl);
-                if (item == null) {
-                    System.err.println("Invalid input line " + linenum);
-                } else {
-                    try {
-                        streamObserver.onNext(item);
-                        sent++;
-                    } catch (IllegalStateException e) {
-                        // the stream got terminated while we were sending
-                        break;
-                    }
-                }
-                linenum++;
+            final List<Thread> senders = new ArrayList<>(streams);
+            for (int i = 0; i < streams; i++) {
+                Thread sender =
+                        new Thread(
+                                () ->
+                                        sendFrom(
+                                                lines,
+                                                sent,
+                                                acked,
+                                                ok,
+                                                skipped,
+                                                failed,
+                                                streamError,
+                                                readError),
+                                "PutURLs-sender-" + i);
+                senders.add(sender);
+                sender.start();
             }
+
+            for (Thread sender : senders) {
+                sender.join();
+            }
+
         } catch (IOException e1) {
-            readError = true;
+            readError.set(true);
             System.err.println("Error while reading " + file + ": " + e1.getMessage());
-        }
-
-        // the server has already terminated the stream on error
-        if (!streamError.get()) {
-            try {
-                streamObserver.onCompleted();
-            } catch (IllegalStateException e) {
-                // the stream got terminated in the meantime
-            }
-        }
-
-        // wait for completion - stop straight away if the stream failed as the
-        // remaining items will never be acked
-        while (!completed.get() || (!streamError.get() && sent != acked.get())) {
-            try {
-                Thread.sleep(10);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
 
         reporter.shutdownNow();
 
         long timetaken = Instant.now().toEpochMilli() - start.toEpochMilli();
 
-        System.out.println("Sent: " + sent);
+        System.out.println("Sent: " + sent.get());
         System.out.println("Acked: " + acked.get());
         System.out.println("OK: " + ok.get());
         System.out.println("Skipped: " + skipped.get());
@@ -213,15 +172,210 @@ public class PutURLs implements Callable<Integer> {
         if (streamError.get()) {
             System.err.println(
                     "The connection to the Frontier failed, "
-                            + (sent - acked.get())
+                            + (sent.get() - acked.get())
                             + " URLs out of "
-                            + sent
+                            + sent.get()
                             + " sent were not confirmed");
         }
 
-        channel.shutdownNow();
+        return (streamError.get() || readError.get()) ? 1 : 0;
+    }
 
-        return (streamError.get() || readError) ? 1 : 0;
+    /**
+     * Sends URLs taken from the shared source on a stream of its own until the source is exhausted,
+     * then waits for the Frontier to confirm every one of them.
+     */
+    private void sendFrom(
+            final LineSource lines,
+            final AtomicInteger sent,
+            final AtomicInteger acked,
+            final AtomicInteger ok,
+            final AtomicInteger skipped,
+            final AtomicInteger failed,
+            final AtomicBoolean streamError,
+            final AtomicBoolean readError) {
+
+        final ManagedChannel channel =
+                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
+                        .usePlaintext()
+                        .build();
+
+        try {
+            final URLFrontierStub stub = URLFrontierGrpc.newStub(channel);
+
+            // how far this stream is allowed to run ahead of the Frontier, counted on its
+            // own so that a slow stream does not hold the others back
+            final int window = Math.max(1, inFlight);
+            final AtomicInteger streamSent = new AtomicInteger(0);
+            final AtomicInteger streamAcked = new AtomicInteger(0);
+
+            // counted down when the Frontier closes the stream, which it only does once
+            // everything it received has been acked
+            final CountDownLatch finished = new CountDownLatch(1);
+
+            // errors on this stream only, the shared flag is for the exit code
+            final AtomicBoolean thisStreamFailed = new AtomicBoolean(false);
+
+            StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage> responseObserver =
+                    new StreamObserver<>() {
+
+                        @Override
+                        public void onNext(
+                                crawlercommons.urlfrontier.Urlfrontier.AckMessage value) {
+                            // receives confirmation that the value has been received
+                            streamAcked.incrementAndGet();
+                            acked.addAndGet(1);
+                            if (value.getStatus().equals(AckMessage.Status.SKIPPED)) {
+                                skipped.getAndIncrement();
+                            } else if (value.getStatus().equals(AckMessage.Status.FAIL)) {
+                                failed.getAndIncrement();
+                            } else if (value.getStatus().equals(AckMessage.Status.OK)) {
+                                ok.getAndIncrement();
+                            }
+                        }
+
+                        @Override
+                        public void onError(Throwable t) {
+                            thisStreamFailed.set(true);
+                            streamError.set(true);
+                            System.err.println("Error while sending the URLs: " + t.getMessage());
+                            finished.countDown();
+                        }
+
+                        @Override
+                        public void onCompleted() {
+                            finished.countDown();
+                        }
+                    };
+
+            final StreamObserver<URLItem> streamObserver = stub.putURLs(responseObserver);
+
+            boolean interrupted = false;
+
+            outer:
+            while (!thisStreamFailed.get()) {
+
+                final LineSource.Chunk chunk;
+                try {
+                    chunk = lines.next();
+                } catch (IOException e) {
+                    readError.set(true);
+                    System.err.println("Error while reading " + file + ": " + e.getMessage());
+                    break;
+                }
+                if (chunk == null) {
+                    break;
+                }
+
+                for (int i = 0; i < chunk.lines.size(); i++) {
+
+                    // the stream is dead, no point in sending anything else
+                    if (thisStreamFailed.get()) {
+                        break outer;
+                    }
+
+                    URLItem item = parse(chunk.lines.get(i), crawl);
+                    if (item == null) {
+                        System.err.println("Invalid input line " + (chunk.firstLineNumber + i));
+                        continue;
+                    }
+
+                    // don't sent too many in one go
+                    while (streamSent.get() > streamAcked.get() + window
+                            && !thisStreamFailed.get()) {
+                        try {
+                            Thread.sleep(10);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            interrupted = true;
+                            break outer;
+                        }
+                    }
+
+                    if (thisStreamFailed.get()) {
+                        break outer;
+                    }
+
+                    try {
+                        streamObserver.onNext(item);
+                        streamSent.incrementAndGet();
+                        sent.incrementAndGet();
+                    } catch (IllegalStateException e) {
+                        // the stream got terminated while we were sending
+                        break outer;
+                    }
+                }
+            }
+
+            // the server has already terminated the stream on error
+            if (!thisStreamFailed.get()) {
+                try {
+                    streamObserver.onCompleted();
+                } catch (IllegalStateException e) {
+                    // the stream got terminated in the meantime
+                }
+            }
+
+            if (!interrupted) {
+                try {
+                    finished.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+
+    /**
+     * Hands out the lines of the input to the sender threads, a chunk at a time so that they are
+     * not all queueing on the reader for every single line.
+     */
+    private static final class LineSource {
+
+        /** how many lines a sender takes at once */
+        private static final int CHUNK_SIZE = 512;
+
+        private final BufferedReader reader;
+
+        private int nextLineNumber = 0;
+
+        private boolean exhausted = false;
+
+        LineSource(BufferedReader reader) {
+            this.reader = reader;
+        }
+
+        static final class Chunk {
+            final int firstLineNumber;
+            final List<String> lines;
+
+            Chunk(int firstLineNumber, List<String> lines) {
+                this.firstLineNumber = firstLineNumber;
+                this.lines = lines;
+            }
+        }
+
+        /** Returns the next lines to send, or null once the input has been used up. */
+        synchronized Chunk next() throws IOException {
+            if (exhausted) {
+                return null;
+            }
+            final List<String> chunk = new ArrayList<>(CHUNK_SIZE);
+            String line;
+            while (chunk.size() < CHUNK_SIZE && (line = reader.readLine()) != null) {
+                chunk.add(line);
+            }
+            if (chunk.isEmpty()) {
+                exhausted = true;
+                return null;
+            }
+            final Chunk result = new Chunk(nextLineNumber, chunk);
+            nextLineNumber += chunk.size();
+            return result;
+        }
     }
 
     /**


### PR DESCRIPTION
## What

Adds `-t/--threads` to `PutURLs`, so URLs can be sent on several streams at once, and `-w/--in-flight` to expose the send window that was hardcoded to 10000.

## Why

A single `putURLs` stream leaves the Frontier idle a good part of the time. Sampling the server's threads while one stream was injecting showed the write threads parked on an empty task queue for **42% of samples** — blocked on `AbstractQueuedSynchronizer$ConditionNode.block`, i.e. genuinely waiting for work rather than contending on a lock. The client, not the Frontier, was setting the pace.

## How

- `--threads` runs N sender threads, each with its own channel and its own stream.
- The input is read **once** and handed out in chunks of 512 lines by a synchronised `LineSource`, so adding threads multiplies the parsing and sending but not the file reading or UTF-8 decoding.
- Waiting for the end of a stream is now a `CountDownLatch` counted down when the Frontier closes it — which it only does once everything it received has been acked. The previous `sent != acked` spin does not generalise to several streams.
- The 10ms sleep-poll window is unchanged in behaviour, just counted per stream now.

## Measurements

2M URLs, 20 cores, fresh RocksDB per run, interleaved with runs of the unmodified client to account for drift:

| threads | OPS | client CPU |
|---|---|---|
| old client | 98.4k, 89.0k | 36.9s, 41.4s |
| `-t 1` | 95.7k, 91.4k | 37.9s, 39.7s |
| `-t 2` | 130.1k, 124.3k | 47.8s, 49.9s |
| `-t 4` | 87.6k | 108s |
| `-t 8` | 76.3k | 131s |

`-t 1` is at parity with the old client (the two pairs came out −2.7% and +2.6%, noise in both directions). **Two streams is the sweet spot, worth about a third more throughput.** Past that it degrades and the server burns much more CPU for the same work — 117s at `-t 2` against 236s at `-t 8`. The default stays at 1, so nothing changes unless you ask for it.

## For reviewers

- **A semaphore released by the ack callback was tried and dropped.** Replacing the 10ms sleep-poll with per-item `acquire`/`release` cost 9% throughput and a third more client CPU for no gain. Two concurrent *unmodified* clients reached the same throughput as two semaphore-driven threads, which is what settled it: the extra stream is what matters, not the backpressure mechanism.
- **`finished.await()` has no timeout.** If the server accepts items then never acks or closes, the client hangs. The old code had the same failure mode via its spin loop, so this is not a regression, but it now looks like a blocking wait rather than a visible spin in a thread dump.
- `sent` is aggregated across threads and reported as one total; there are no per-stream figures.
- Error output from N threads interleaves on stderr — a failing stream prints once per stream.
- The benchmark numbers above were gathered with a service build that also carried an unrelated, disabled-by-default write-batching refactor. That refactor measured as cost-free in its off state (98.7k against a 97.2k baseline), so the comparison holds, but the runs were not repeated against this branch's service in isolation.

## Testing

- Full suite passes: 111 service tests, 4 client tests including `PutURLsTest`.
- Functional check at `-t 1` and `-t 4` over 20k URLs: correct OK/Skipped counts, no duplicates in the frontier, no hangs.
