### PR TITLE
Backpressure for putURLs: bound the URLs in flight per stream

### DIFF
--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -14,6 +14,8 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -30,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -216,37 +219,68 @@ public class PutURLs implements Callable<Integer> {
             // errors on this stream only, the shared flag is for the exit code
             final AtomicBoolean thisStreamFailed = new AtomicBoolean(false);
 
-            StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage> responseObserver =
-                    new StreamObserver<>() {
+            // the sender waits on this when it is not allowed to send: an ack frees a
+            // slot in the window, the transport becoming ready frees the wire
+            final Object flow = new Object();
 
-                        @Override
-                        public void onNext(
-                                crawlercommons.urlfrontier.Urlfrontier.AckMessage value) {
-                            // receives confirmation that the value has been received
-                            streamAcked.incrementAndGet();
-                            acked.addAndGet(1);
-                            if (value.getStatus().equals(AckMessage.Status.SKIPPED)) {
-                                skipped.getAndIncrement();
-                            } else if (value.getStatus().equals(AckMessage.Status.FAIL)) {
-                                failed.getAndIncrement();
-                            } else if (value.getStatus().equals(AckMessage.Status.OK)) {
-                                ok.getAndIncrement();
-                            }
-                        }
+            // the stream seen from the transport side, needed for isReady(); set before
+            // putURLs returns
+            final AtomicReference<ClientCallStreamObserver<URLItem>> requestStream =
+                    new AtomicReference<>();
 
-                        @Override
-                        public void onError(Throwable t) {
-                            thisStreamFailed.set(true);
-                            streamError.set(true);
-                            System.err.println("Error while sending the URLs: " + t.getMessage());
-                            finished.countDown();
-                        }
+            ClientResponseObserver<URLItem, crawlercommons.urlfrontier.Urlfrontier.AckMessage>
+                    responseObserver =
+                            new ClientResponseObserver<>() {
 
-                        @Override
-                        public void onCompleted() {
-                            finished.countDown();
-                        }
-                    };
+                                @Override
+                                public void beforeStart(ClientCallStreamObserver<URLItem> stream) {
+                                    requestStream.set(stream);
+                                    stream.setOnReadyHandler(
+                                            () -> {
+                                                synchronized (flow) {
+                                                    flow.notifyAll();
+                                                }
+                                            });
+                                }
+
+                                @Override
+                                public void onNext(
+                                        crawlercommons.urlfrontier.Urlfrontier.AckMessage value) {
+                                    // receives confirmation that the value has been received
+                                    streamAcked.incrementAndGet();
+                                    acked.addAndGet(1);
+                                    if (value.getStatus().equals(AckMessage.Status.SKIPPED)) {
+                                        skipped.getAndIncrement();
+                                    } else if (value.getStatus().equals(AckMessage.Status.FAIL)) {
+                                        failed.getAndIncrement();
+                                    } else if (value.getStatus().equals(AckMessage.Status.OK)) {
+                                        ok.getAndIncrement();
+                                    }
+                                    synchronized (flow) {
+                                        flow.notifyAll();
+                                    }
+                                }
+
+                                @Override
+                                public void onError(Throwable t) {
+                                    thisStreamFailed.set(true);
+                                    streamError.set(true);
+                                    System.err.println(
+                                            "Error while sending the URLs: " + t.getMessage());
+                                    finished.countDown();
+                                    synchronized (flow) {
+                                        flow.notifyAll();
+                                    }
+                                }
+
+                                @Override
+                                public void onCompleted() {
+                                    finished.countDown();
+                                    synchronized (flow) {
+                                        flow.notifyAll();
+                                    }
+                                }
+                            };
 
             final StreamObserver<URLItem> streamObserver = stub.putURLs(responseObserver);
 
@@ -280,16 +314,23 @@ public class PutURLs implements Callable<Integer> {
                         continue;
                     }
 
-                    // don't sent too many in one go
-                    while (streamSent.get() > streamAcked.get() + window
-                            && !thisStreamFailed.get()) {
-                        try {
-                            Thread.sleep(10);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                            interrupted = true;
-                            break outer;
+                    // don't send too many in one go: wait for room in the window and
+                    // for the transport to be able to take the item without buffering
+                    // it, woken by the acks and by the transport itself. The timeout is
+                    // a backstop, not a poll interval.
+                    try {
+                        final ClientCallStreamObserver<URLItem> transport = requestStream.get();
+                        synchronized (flow) {
+                            while (!thisStreamFailed.get()
+                                    && (streamSent.get() > streamAcked.get() + window
+                                            || (transport != null && !transport.isReady()))) {
+                                flow.wait(100);
+                            }
                         }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        interrupted = true;
+                        break outer;
                     }
 
                     if (thisStreamFailed.get()) {

--- a/service/config.ini
+++ b/service/config.ini
@@ -11,6 +11,13 @@ implementation = crawlercommons.urlfrontier.service.rocksdb.RocksDBService
 # the default value is the number of processors / 4
 # read.thread.num = 3
 
+# maximum number of URLs a putURLs stream may have in flight (received but not
+# yet acked) before the server stops reading from it; the excess stays on the
+# wire, where HTTP/2 flow control pushes back onto the sender. Protects the
+# service from clients sending faster than the URLs can be written. Set to 0
+# to let the clients send at will, as the service did historically.
+# putURLs.max.inflight = 1024
+
 rocksdb.path = /data/crawl/rocksdb
 # rocksdb.purge = true
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,6 +21,8 @@
 		<mockito.version>5.13.0</mockito.version>
 		<commons.io.version>2.20.0</commons.io.version>
 		<commons.lang.version>3.19.0</commons.lang.version>
+		<!-- keep in line with grpc.version in the API module -->
+		<grpc.version>1.76.0</grpc.version>
 	</properties>
 
 	<build>
@@ -114,6 +116,14 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- lets the tests run gRPC calls against the service without a socket -->
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-inprocess</artifactId>
+			<version>${grpc.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -27,6 +27,7 @@ import crawlercommons.urlfrontier.Urlfrontier.StringList;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Summary;
@@ -132,6 +133,10 @@ public abstract class AbstractFrontierService
     protected final ExecutorService readExecutorService;
     protected final ExecutorService writeExecutorService;
 
+    // how many URLs a putURLs stream may have in flight before the server stops
+    // reading from it, 0 or less to let the client send as fast as it likes
+    protected final int putURLsMaxInFlight;
+
     protected AbstractFrontierService(String host, int port) {
         this(Collections.emptyMap(), host, port);
     }
@@ -152,6 +157,11 @@ public abstract class AbstractFrontierService
                         configuration.getOrDefault("write.thread.num", defaultParallelism));
         writeExecutorService = Executors.newFixedThreadPool(wthreadNum);
         LOG.info("Using {} threads for writing to queues", wthreadNum);
+        putURLsMaxInFlight =
+                Integer.parseInt(configuration.getOrDefault("putURLs.max.inflight", "1024"));
+        if (putURLsMaxInFlight > 0) {
+            LOG.info("Limiting putURLs streams to {} URLs in flight", putURLsMaxInFlight);
+        }
     }
 
     public ConcurrentInsertionOrderMap<QueueWithinCrawl, QueueInterface> getQueues() {
@@ -847,6 +857,52 @@ public abstract class AbstractFrontierService
         responseObserver.onCompleted();
     }
 
+    /**
+     * Caps the number of URLs a stream may have in flight by taking over its inbound flow control:
+     * the call starts with a budget of maxInFlight messages and every ack sent releases one more.
+     * Without this a client can send faster than the write threads drain and the backlog
+     * accumulates on the heap; with it the excess stays on the wire, where HTTP/2 flow control
+     * pushes back onto the sender.
+     *
+     * <p>Returns the observer the acks must be sent through: an ack bypassing it would not
+     * replenish the budget and the stream would eventually starve. Observers which do not belong to
+     * a gRPC call, as used by the tests, are returned unchanged, as is everything when maxInFlight
+     * is 0 or less.
+     */
+    protected static StreamObserver<AckMessage> limitInFlight(
+            StreamObserver<AckMessage> responseObserver, int maxInFlight) {
+        if (maxInFlight <= 0 || !(responseObserver instanceof ServerCallStreamObserver)) {
+            return responseObserver;
+        }
+        final ServerCallStreamObserver<AckMessage> call =
+                (ServerCallStreamObserver<AckMessage>) responseObserver;
+        call.disableAutoRequest();
+        call.request(maxInFlight);
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(AckMessage value) {
+                call.onNext(value);
+                // the ack releases one more URL from the stream; the client may
+                // have gone away in the meantime, which is its problem, not ours
+                try {
+                    call.request(1);
+                } catch (RuntimeException e) {
+                    LOG.debug("request() on a terminated call", e);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                call.onError(t);
+            }
+
+            @Override
+            public void onCompleted() {
+                call.onCompleted();
+            }
+        };
+    }
+
     @Override
     public StreamObserver<URLItem> putURLs(
             StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage> responseObserver) {
@@ -854,7 +910,8 @@ public abstract class AbstractFrontierService
         putURLs_calls.inc();
 
         StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage> sso =
-                SynchronizedStreamObserver.wrapping(responseObserver, -1);
+                SynchronizedStreamObserver.wrapping(
+                        limitInFlight(responseObserver, putURLsMaxInFlight), -1);
 
         return new StreamObserver<URLItem>() {
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -730,8 +730,12 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                             LOG.error("Client cancelled");
                         });
 
-        // wrap the response observer as a synchronized one
-        StreamObserver<AckMessage> sso = SynchronizedStreamObserver.wrapping(responseObserver, -1);
+        // wrap the response observer as a synchronized one; the in-flight budget
+        // counts items forwarded to other nodes too, since their ack - and therefore
+        // the next request - only comes once the remote node has answered
+        StreamObserver<AckMessage> sso =
+                SynchronizedStreamObserver.wrapping(
+                        limitInFlight(responseObserver, putURLsMaxInFlight), -1);
 
         return new StreamObserver<URLItem>() {
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/PutURLsBackpressureTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/PutURLsBackpressureTest.java
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The server must stop reading from a putURLs stream once putURLs.max.inflight URLs have been
+ * received but not acked, and read one more for every ack sent. Runs real gRPC calls over the
+ * in-process transport, which honours the same flow control requests as a socket.
+ */
+class PutURLsBackpressureTest {
+
+    /** A frontier whose writes block until the test releases them */
+    private static final class BlockedFrontier extends MemoryFrontierService {
+
+        final CountDownLatch release = new CountDownLatch(1);
+
+        BlockedFrontier(Map<String, String> conf) {
+            super(conf, "localhost", 0);
+        }
+
+        @Override
+        protected Status putURLItem(URLItem value) {
+            try {
+                release.await(30, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return super.putURLItem(value);
+        }
+    }
+
+    private Server server;
+    private ManagedChannel channel;
+    private BlockedFrontier frontier;
+
+    @AfterEach
+    void teardown() throws Exception {
+        frontier.release.countDown();
+        if (channel != null) {
+            channel.shutdownNow();
+        }
+        if (server != null) {
+            server.shutdownNow();
+        }
+        frontier.close();
+    }
+
+    /** Counts the messages gRPC hands over to the service, i.e. the requests it granted */
+    private static ServerInterceptor countingDeliveries(AtomicInteger delivered) {
+        return new ServerInterceptor() {
+            @Override
+            public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                    ServerCall<ReqT, RespT> call,
+                    Metadata headers,
+                    ServerCallHandler<ReqT, RespT> next) {
+                return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
+                        next.startCall(call, headers)) {
+                    @Override
+                    public void onMessage(ReqT message) {
+                        delivered.incrementAndGet();
+                        super.onMessage(message);
+                    }
+                };
+            }
+        };
+    }
+
+    private URLFrontierStub startAndConnect(int maxInFlight, AtomicInteger delivered)
+            throws Exception {
+        final Map<String, String> conf = new HashMap<>();
+        conf.put("putURLs.max.inflight", Integer.toString(maxInFlight));
+        conf.put("write.thread.num", "2");
+        frontier = new BlockedFrontier(conf);
+
+        final String name = InProcessServerBuilder.generateName();
+        server =
+                InProcessServerBuilder.forName(name)
+                        .addService(
+                                ServerInterceptors.intercept(
+                                        frontier, countingDeliveries(delivered)))
+                        .build()
+                        .start();
+        channel = InProcessChannelBuilder.forName(name).build();
+        return URLFrontierGrpc.newStub(channel);
+    }
+
+    private static URLItem item(int i) {
+        return URLItem.newBuilder()
+                .setDiscovered(
+                        DiscoveredURLItem.newBuilder()
+                                .setInfo(
+                                        URLInfo.newBuilder()
+                                                .setUrl("http://host" + i + ".com/page")
+                                                .build())
+                                .build())
+                .build();
+    }
+
+    /** Waits until the value stops changing for a little while and returns it */
+    private static int settle(AtomicInteger value) throws InterruptedException {
+        int last = -1;
+        for (int i = 0; i < 50; i++) {
+            int current = value.get();
+            if (current == last) {
+                return current;
+            }
+            last = current;
+            Thread.sleep(100);
+        }
+        return last;
+    }
+
+    @Test
+    void deliveriesStopAtTheBudgetAndResumeWithTheAcks() throws Exception {
+
+        final int maxInFlight = 8;
+        final int total = 100;
+
+        final AtomicInteger delivered = new AtomicInteger();
+        final URLFrontierStub stub = startAndConnect(maxInFlight, delivered);
+
+        final CountDownLatch completed = new CountDownLatch(1);
+        final AtomicInteger acked = new AtomicInteger();
+
+        final StreamObserver<URLItem> stream =
+                stub.putURLs(
+                        new StreamObserver<AckMessage>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                completed.countDown();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                completed.countDown();
+                            }
+                        });
+
+        for (int i = 0; i < total; i++) {
+            stream.onNext(item(i));
+        }
+        stream.onCompleted();
+
+        // with every write blocked no ack can go out, so the server must stop
+        // accepting once it holds maxInFlight URLs; the rest stays undelivered
+        assertEquals(maxInFlight, settle(delivered));
+        assertEquals(0, acked.get());
+
+        // each ack now releases one more, until everything has been processed
+        frontier.release.countDown();
+
+        assertTrue(completed.await(30, TimeUnit.SECONDS), "stream did not complete");
+        assertEquals(total, delivered.get());
+        assertEquals(total, acked.get());
+    }
+
+    @Test
+    void zeroDisablesTheLimit() throws Exception {
+
+        final int total = 100;
+
+        final AtomicInteger delivered = new AtomicInteger();
+        final URLFrontierStub stub = startAndConnect(0, delivered);
+
+        final CountDownLatch completed = new CountDownLatch(1);
+        final AtomicInteger acked = new AtomicInteger();
+
+        final StreamObserver<URLItem> stream =
+                stub.putURLs(
+                        new StreamObserver<AckMessage>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                completed.countDown();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                completed.countDown();
+                            }
+                        });
+
+        for (int i = 0; i < total; i++) {
+            stream.onNext(item(i));
+        }
+        stream.onCompleted();
+
+        // without a limit the server keeps reading even though nothing is acked
+        assertEquals(total, settle(delivered));
+        assertEquals(0, acked.get());
+
+        frontier.release.countDown();
+        assertTrue(completed.await(30, TimeUnit.SECONDS), "stream did not complete");
+        assertEquals(total, acked.get());
+    }
+}


### PR DESCRIPTION
The server used to keep reading from a `putURLs` stream regardless of how fast the write threads drained, buffering the backlog on the heap — a client sending faster than the URLs could be written would eventually take the service down with GC pressure and then OOM. This became easier to trigger since #190 made the client multi-threaded.

**Server (first commit).** The stream's inbound flow control is taken over via `ServerCallStreamObserver.disableAutoRequest()`: a call starts with a budget of `putURLs.max.inflight` messages (default 1024, `0` restores the historical unbounded behaviour) and every ack sent releases one more, so the pairing is exact and lives in one place, inside the observer the acks already funnel through. The excess stays on the wire, where HTTP/2 flow control pushes back onto the sender.

- **No wire or API change**: any gRPC client in any language keeps working unmodified. Clients that bound their in-flight URLs by counting acks (like `PutURLs -w`) see no difference; clients that blast without bounding now buffer in their own channel instead of in the server's heap.
- **Cluster mode**: the budget also covers items forwarded to other nodes, whose ack comes back from the remote shard — the backpressure of a slow shard therefore propagates to the crawler instead of ballooning the forwarding node's buffers.
- Tested with real gRPC calls over the in-process transport (new test-scoped `grpc-inprocess` dependency): with writes blocked, delivery stops at exactly the budget, resumes one-per-ack, and `0` disables the cap.

**Client (second commit).** `PutURLs` used to poll its ack window with a 10ms sleep, capping a serial stream (`-w 1`) at ~100 URLs/sec and masking any server latency below that in benchmarks. It now waits on a monitor notified by the acks and by the transport's `onReady` signal, and checks `isReady()` so items are not buffered in the channel when the server pushes back. Measured serial throughput went from ~190 to ~3200 URLs/sec against a local Frontier.

**End-to-end check**: with a deliberately small budget of 64, 100k URLs on 2 streams were all acked OK at ~41k OPS — the budget is far above what the measured ~200µs round trip needs, so throughput is unaffected in normal operation.

Reviewer notes:
- Commits are signed off; kept separate on purpose (server and client are independent changes).
- 122 service + 4 client tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)