### PR TITLE
PutDiscovered: batch endpoint for discovered URLs

### DIFF
--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -42,6 +42,13 @@ service URLFrontier {
      /** Push URL items to the server; they get created (if they don't already exist) in case of DiscoveredURLItems or updated if KnownURLItems **/
      rpc PutURLs(stream URLItem) returns (stream AckMessage) {}
 
+     /** Push batches of discovered URLs to the server; a URL gets created unless it is already known, in which case it is ignored.
+      The outlinks of a page form a natural batch. Sending them in one message rather than one each amortises the per-message cost,
+      which is what limits the ingestion rate: use this for the discovered URLs, which are the bulk of what a crawl writes, and
+      PutURLs for the updates of URLs which have been fetched. Each batch is acked as a whole, with one status per URL in the same
+      order as the batch. **/
+     rpc PutDiscovered(stream DiscoveredBatch) returns (stream BatchAck) {}
+
      /** Return stats for a specific queue or an entire crawl. Does not aggregate the stats across different crawlids. **/
      rpc GetStats(QueueWithinCrawlParams) returns (Stats) {}
      
@@ -285,6 +292,24 @@ message KnownURLItem {
 **/
 message DiscoveredURLItem {
   URLInfo info = 1;
+}
+
+/**
+ A batch of URLs discovered during the crawl, typically the outlinks of one page.
+ Each of them might already be known in the URL Frontier or not.
+**/
+message DiscoveredBatch {
+  /** Identifier specified by the client, echoed in the BatchAck **/
+  string ID = 1;
+  repeated URLInfo items = 2;
+}
+
+/** Acknowledges a whole DiscoveredBatch **/
+message BatchAck {
+  /** ID which had been specified by the client **/
+  string ID = 1;
+  /** one status per URL of the batch, in the order they were sent **/
+  repeated AckMessage.Status statuses = 2;
 }
 
 /**

--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -9,6 +9,8 @@ import crawlercommons.urlfrontier.CrawlID;
 import crawlercommons.urlfrontier.URLFrontierGrpc;
 import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.BatchAck;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredBatch;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
@@ -77,10 +79,32 @@ public class PutURLs implements Callable<Integer> {
                             + " (default to 10000)")
     private int inFlight;
 
+    @Option(
+            names = {"-b", "--batch"},
+            defaultValue = "0",
+            paramLabel = "NUM",
+            description =
+                    "number of discovered URLs to send per message through the PutDiscovered"
+                            + " endpoint, which amortises the per-message cost (default to 0,"
+                            + " i.e. every URL is sent individually through PutURLs). Known URLs"
+                            + " always go through PutURLs. Falls back to sending everything"
+                            + " individually if the server has no PutDiscovered.")
+    private int batch;
+
+    /** value of {@link #batch} actually applied, 0 when the server has no PutDiscovered */
+    private int effectiveBatch;
+
     @Override
     public Integer call() {
 
         final int streams = Math.max(1, threads);
+
+        effectiveBatch = batch;
+        if (effectiveBatch > 0 && !serverSupportsPutDiscovered()) {
+            System.err.println(
+                    "Server does not support PutDiscovered - sending the URLs individually");
+            effectiveBatch = 0;
+        }
 
         final AtomicInteger sent = new AtomicInteger(0);
         final AtomicInteger acked = new AtomicInteger(0);
@@ -185,6 +209,103 @@ public class PutURLs implements Callable<Integer> {
     }
 
     /**
+     * Probes the server with an empty batch: an old server answers the call itself with
+     * UNIMPLEMENTED, a current one acks it.
+     */
+    private boolean serverSupportsPutDiscovered() {
+        final ManagedChannel channel =
+                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
+                        .usePlaintext()
+                        .build();
+        try {
+            final CountDownLatch done = new CountDownLatch(1);
+            final AtomicBoolean supported = new AtomicBoolean(false);
+            StreamObserver<DiscoveredBatch> stream =
+                    URLFrontierGrpc.newStub(channel)
+                            .putDiscovered(
+                                    new StreamObserver<BatchAck>() {
+                                        @Override
+                                        public void onNext(BatchAck value) {
+                                            supported.set(true);
+                                        }
+
+                                        @Override
+                                        public void onError(Throwable t) {
+                                            done.countDown();
+                                        }
+
+                                        @Override
+                                        public void onCompleted() {
+                                            done.countDown();
+                                        }
+                                    });
+            try {
+                stream.onNext(DiscoveredBatch.newBuilder().setID("probe").build());
+                stream.onCompleted();
+            } catch (IllegalStateException e) {
+                // the call got terminated straight away
+            }
+            try {
+                done.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return supported.get();
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+
+    /**
+     * Waits for room in the window and for the transport, then sends the buffered items as one
+     * batch. Returns false when the stream died or the thread got interrupted.
+     */
+    private static boolean flushBatch(
+            final List<URLInfo> buffer,
+            final StreamObserver<DiscoveredBatch> batchStream,
+            final ClientCallStreamObserver<DiscoveredBatch> transport,
+            final Object flow,
+            final int window,
+            final AtomicInteger streamSent,
+            final AtomicInteger streamAcked,
+            final AtomicInteger sent,
+            final AtomicBoolean thisStreamFailed,
+            final AtomicInteger batchSequence) {
+        if (buffer.isEmpty()) {
+            return true;
+        }
+        try {
+            synchronized (flow) {
+                while (!thisStreamFailed.get()
+                        && (streamSent.get() > streamAcked.get() + window
+                                || (transport != null && !transport.isReady()))) {
+                    flow.wait(100);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+        if (thisStreamFailed.get()) {
+            return false;
+        }
+        try {
+            batchStream.onNext(
+                    DiscoveredBatch.newBuilder()
+                            .setID(Integer.toString(batchSequence.incrementAndGet()))
+                            .addAllItems(buffer)
+                            .build());
+            streamSent.addAndGet(buffer.size());
+            sent.addAndGet(buffer.size());
+            buffer.clear();
+            return true;
+        } catch (IllegalStateException e) {
+            // the stream got terminated while we were sending
+            return false;
+        }
+    }
+
+    /**
      * Sends URLs taken from the shared source on a stream of its own until the source is exhausted,
      * then waits for the Frontier to confirm every one of them.
      */
@@ -212,9 +333,9 @@ public class PutURLs implements Callable<Integer> {
             final AtomicInteger streamSent = new AtomicInteger(0);
             final AtomicInteger streamAcked = new AtomicInteger(0);
 
-            // counted down when the Frontier closes the stream, which it only does once
+            // counted down when the Frontier closes the streams, which it only does once
             // everything it received has been acked
-            final CountDownLatch finished = new CountDownLatch(1);
+            final CountDownLatch finished = new CountDownLatch(effectiveBatch > 0 ? 2 : 1);
 
             // errors on this stream only, the shared flag is for the exit code
             final AtomicBoolean thisStreamFailed = new AtomicBoolean(false);
@@ -284,6 +405,72 @@ public class PutURLs implements Callable<Integer> {
 
             final StreamObserver<URLItem> streamObserver = stub.putURLs(responseObserver);
 
+            // the discovered URLs accumulate here and leave as one message per batch
+            // on a PutDiscovered stream of their own; known URLs keep using PutURLs
+            final List<URLInfo> buffer = new ArrayList<>(Math.max(1, effectiveBatch));
+            final AtomicInteger batchSequence = new AtomicInteger();
+            final AtomicReference<ClientCallStreamObserver<DiscoveredBatch>> batchTransport =
+                    new AtomicReference<>();
+
+            StreamObserver<DiscoveredBatch> batchStream = null;
+            if (effectiveBatch > 0) {
+                batchStream =
+                        stub.putDiscovered(
+                                new ClientResponseObserver<DiscoveredBatch, BatchAck>() {
+
+                                    @Override
+                                    public void beforeStart(
+                                            ClientCallStreamObserver<DiscoveredBatch> stream) {
+                                        batchTransport.set(stream);
+                                        stream.setOnReadyHandler(
+                                                () -> {
+                                                    synchronized (flow) {
+                                                        flow.notifyAll();
+                                                    }
+                                                });
+                                    }
+
+                                    @Override
+                                    public void onNext(BatchAck value) {
+                                        final int n = value.getStatusesCount();
+                                        streamAcked.addAndGet(n);
+                                        acked.addAndGet(n);
+                                        for (AckMessage.Status status : value.getStatusesList()) {
+                                            if (status.equals(AckMessage.Status.SKIPPED)) {
+                                                skipped.getAndIncrement();
+                                            } else if (status.equals(AckMessage.Status.FAIL)) {
+                                                failed.getAndIncrement();
+                                            } else if (status.equals(AckMessage.Status.OK)) {
+                                                ok.getAndIncrement();
+                                            }
+                                        }
+                                        synchronized (flow) {
+                                            flow.notifyAll();
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        thisStreamFailed.set(true);
+                                        streamError.set(true);
+                                        System.err.println(
+                                                "Error while sending the URLs: " + t.getMessage());
+                                        finished.countDown();
+                                        synchronized (flow) {
+                                            flow.notifyAll();
+                                        }
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        finished.countDown();
+                                        synchronized (flow) {
+                                            flow.notifyAll();
+                                        }
+                                    }
+                                });
+            }
+
             boolean interrupted = false;
 
             outer:
@@ -311,6 +498,27 @@ public class PutURLs implements Callable<Integer> {
                     URLItem item = parse(chunk.lines.get(i), crawl);
                     if (item == null) {
                         System.err.println("Invalid input line " + (chunk.firstLineNumber + i));
+                        continue;
+                    }
+
+                    // discovered URLs travel in batches when the option is on
+                    if (effectiveBatch > 0 && item.hasDiscovered()) {
+                        buffer.add(item.getDiscovered().getInfo());
+                        if (buffer.size() >= effectiveBatch
+                                && !flushBatch(
+                                        buffer,
+                                        batchStream,
+                                        batchTransport.get(),
+                                        flow,
+                                        window,
+                                        streamSent,
+                                        streamAcked,
+                                        sent,
+                                        thisStreamFailed,
+                                        batchSequence)) {
+                            interrupted = Thread.currentThread().isInterrupted();
+                            break outer;
+                        }
                         continue;
                     }
 
@@ -348,11 +556,33 @@ public class PutURLs implements Callable<Integer> {
                 }
             }
 
-            // the server has already terminated the stream on error
-            if (!thisStreamFailed.get()) {
+            // whatever remains in the buffer goes out before the streams are closed
+            if (effectiveBatch > 0 && !interrupted) {
+                flushBatch(
+                        buffer,
+                        batchStream,
+                        batchTransport.get(),
+                        flow,
+                        window,
+                        streamSent,
+                        streamAcked,
+                        sent,
+                        thisStreamFailed,
+                        batchSequence);
+            }
+
+            // both streams are completed even if one of them failed: the healthy one
+            // only counts the latch down once the server has closed it, which the
+            // server only does after everything it received has been acked
+            try {
+                streamObserver.onCompleted();
+            } catch (RuntimeException e) {
+                // the stream got terminated in the meantime
+            }
+            if (batchStream != null) {
                 try {
-                    streamObserver.onCompleted();
-                } catch (IllegalStateException e) {
+                    batchStream.onCompleted();
+                } catch (RuntimeException e) {
                     // the stream got terminated in the meantime
                 }
             }

--- a/service/config.ini
+++ b/service/config.ini
@@ -18,6 +18,10 @@ implementation = crawlercommons.urlfrontier.service.rocksdb.RocksDBService
 # to let the clients send at will, as the service did historically.
 # putURLs.max.inflight = 1024
 
+# same thing for the putDiscovered streams, counted in batches rather than
+# URLs. Set to 0 to disable.
+# putDiscovered.max.inflight = 16
+
 rocksdb.path = /data/crawl/rocksdb
 # rocksdb.purge = true
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -10,10 +10,13 @@ import crawlercommons.urlfrontier.Urlfrontier;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Builder;
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
+import crawlercommons.urlfrontier.Urlfrontier.BatchAck;
 import crawlercommons.urlfrontier.Urlfrontier.BlockQueueParams;
 import crawlercommons.urlfrontier.Urlfrontier.Boolean;
 import crawlercommons.urlfrontier.Urlfrontier.CountUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.CrawlLimitParams;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredBatch;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.Empty;
 import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
@@ -87,6 +90,12 @@ public abstract class AbstractFrontierService
                     .help("Number of times putURLs has been called.")
                     .register();
 
+    protected static final Counter putDiscovered_calls =
+            Counter.build()
+                    .name("frontier_putDiscovered_calls_total")
+                    .help("Number of times putDiscovered has been called.")
+                    .register();
+
     protected static final Counter putURLs_urls_count =
             Counter.build()
                     .name("frontier_putURLs_total")
@@ -137,6 +146,9 @@ public abstract class AbstractFrontierService
     // reading from it, 0 or less to let the client send as fast as it likes
     protected final int putURLsMaxInFlight;
 
+    // same thing for putDiscovered, counted in batches rather than URLs
+    protected final int putDiscoveredMaxInFlight;
+
     protected AbstractFrontierService(String host, int port) {
         this(Collections.emptyMap(), host, port);
     }
@@ -161,6 +173,13 @@ public abstract class AbstractFrontierService
                 Integer.parseInt(configuration.getOrDefault("putURLs.max.inflight", "1024"));
         if (putURLsMaxInFlight > 0) {
             LOG.info("Limiting putURLs streams to {} URLs in flight", putURLsMaxInFlight);
+        }
+        putDiscoveredMaxInFlight =
+                Integer.parseInt(configuration.getOrDefault("putDiscovered.max.inflight", "16"));
+        if (putDiscoveredMaxInFlight > 0) {
+            LOG.info(
+                    "Limiting putDiscovered streams to {} batches in flight",
+                    putDiscoveredMaxInFlight);
         }
     }
 
@@ -869,20 +888,19 @@ public abstract class AbstractFrontierService
      * a gRPC call, as used by the tests, are returned unchanged, as is everything when maxInFlight
      * is 0 or less.
      */
-    protected static StreamObserver<AckMessage> limitInFlight(
-            StreamObserver<AckMessage> responseObserver, int maxInFlight) {
+    protected static <V> StreamObserver<V> limitInFlight(
+            StreamObserver<V> responseObserver, int maxInFlight) {
         if (maxInFlight <= 0 || !(responseObserver instanceof ServerCallStreamObserver)) {
             return responseObserver;
         }
-        final ServerCallStreamObserver<AckMessage> call =
-                (ServerCallStreamObserver<AckMessage>) responseObserver;
+        final ServerCallStreamObserver<V> call = (ServerCallStreamObserver<V>) responseObserver;
         call.disableAutoRequest();
         call.request(maxInFlight);
         return new StreamObserver<>() {
             @Override
-            public void onNext(AckMessage value) {
+            public void onNext(V value) {
                 call.onNext(value);
-                // the ack releases one more URL from the stream; the client may
+                // the ack releases one more message from the stream; the client may
                 // have gone away in the meantime, which is its problem, not ours
                 try {
                     call.request(1);
@@ -994,6 +1012,121 @@ public abstract class AbstractFrontierService
      * succeeded
      */
     protected abstract AckMessage.Status putURLItem(URLItem value);
+
+    @Override
+    public StreamObserver<DiscoveredBatch> putDiscovered(
+            StreamObserver<BatchAck> responseObserver) {
+
+        putDiscovered_calls.inc();
+
+        final StreamObserver<BatchAck> sso =
+                SynchronizedStreamObserver.wrapping(
+                        limitInFlight(responseObserver, putDiscoveredMaxInFlight), -1);
+
+        return new StreamObserver<>() {
+
+            // closes the response once the client has stopped sending and every batch
+            // handed to the write executor has been acked
+            final AsyncCompletion completion = new AsyncCompletion(sso::onCompleted);
+
+            @Override
+            public void onNext(DiscoveredBatch batch) {
+
+                final BatchAck.Builder ack = BatchAck.newBuilder().setID(batch.getID());
+
+                // do not add new stuff if we are in the process of closing
+                if (isClosing()) {
+                    for (int i = 0; i < batch.getItemsCount(); i++) {
+                        ack.addStatuses(Status.FAIL);
+                    }
+                    sso.onNext(ack.build());
+                    return;
+                }
+
+                completion.taskStarted();
+
+                try {
+                    writeExecutorService.execute(
+                            () -> {
+                                try {
+                                    for (Status status : putDiscoveredItems(batch.getItemsList())) {
+                                        ack.addStatuses(status);
+                                    }
+                                } catch (RuntimeException e) {
+                                    LOG.error(
+                                            "Caught exception while adding a batch of {} URLs",
+                                            batch.getItemsCount(),
+                                            e);
+                                    ack.clearStatuses();
+                                    for (int i = 0; i < batch.getItemsCount(); i++) {
+                                        ack.addStatuses(Status.FAIL);
+                                    }
+                                } finally {
+                                    // the ack must go out whatever happened or the stream
+                                    // never gets closed and its budget never replenished
+                                    try {
+                                        sso.onNext(ack.build());
+                                    } finally {
+                                        completion.taskDone();
+                                    }
+                                }
+                            });
+                } catch (RejectedExecutionException e) {
+                    // the task never started: tell the client instead of leaving it waiting
+                    LOG.error(
+                            "Executor rejected putDiscovered batch of {} URLs",
+                            batch.getItemsCount(),
+                            e);
+                    for (int i = 0; i < batch.getItemsCount(); i++) {
+                        ack.addStatuses(Status.FAIL);
+                    }
+                    sso.onNext(ack.build());
+                    completion.taskDone();
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                if (t instanceof StatusRuntimeException) {
+                    // ignore messages about the client having cancelled
+                    if (((StatusRuntimeException) t)
+                            .getStatus()
+                            .getCode()
+                            .equals(io.grpc.Status.Code.CANCELLED)) {
+                        return;
+                    }
+                }
+                LOG.error("Error reported {}", t.getMessage());
+            }
+
+            @Override
+            public void onCompleted() {
+                // the response is closed here if all the work for this stream has already
+                // ended, or by the last batch to be acked otherwise
+                completion.noMoreTasks();
+            }
+        };
+    }
+
+    /**
+     * Processes a batch of discovered URLs and returns one status per item, in the order they were
+     * given. This default goes through {@link #putURLItem(URLItem)} one URL at a time;
+     * implementations can override it to share work across the batch.
+     */
+    protected Status[] putDiscoveredItems(List<URLInfo> items) {
+        final Status[] statuses = new Status[items.size()];
+        for (int i = 0; i < items.size(); i++) {
+            statuses[i] =
+                    putURLItem(
+                            URLItem.newBuilder()
+                                    .setDiscovered(
+                                            DiscoveredURLItem.newBuilder()
+                                                    .setInfo(items.get(i))
+                                                    .build())
+                                    .build());
+        }
+        return statuses;
+    }
 
     @Override
     public void close() throws IOException {

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -884,4 +884,26 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     }
 
     protected abstract Status putURLItem(URLItem item);
+
+    /**
+     * A batch typically spans several partitions and would have to be split and re-batched per
+     * node, which is not implemented yet: clients fall back to the per-URL stream instead.
+     */
+    @Override
+    public io.grpc.stub.StreamObserver<crawlercommons.urlfrontier.Urlfrontier.DiscoveredBatch>
+            putDiscovered(
+                    io.grpc.stub.StreamObserver<crawlercommons.urlfrontier.Urlfrontier.BatchAck>
+                            responseObserver) {
+        responseObserver.onError(io.grpc.Status.UNIMPLEMENTED.asRuntimeException());
+        return new io.grpc.stub.StreamObserver<>() {
+            @Override
+            public void onNext(crawlercommons.urlfrontier.Urlfrontier.DiscoveredBatch value) {}
+
+            @Override
+            public void onError(Throwable t) {}
+
+            @Override
+            public void onCompleted() {}
+        };
+    }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -572,6 +572,169 @@ public class RocksDBService extends AbstractFrontierService {
     }
 
     /**
+     * Writes a whole batch of discovered URLs as a single RocksDB write, which amortises the
+     * per-write overhead the individual puts pay.
+     *
+     * <p>The stripe locks of every URL in the batch are taken upfront, in the deadlock-free order
+     * provided by the striped collection, and held until the write has landed: this is what stops
+     * another thread from concluding in the meantime that one of these URLs is unknown, the same
+     * guarantee the lock held across get-then-write gives the individual puts. A batch holds many
+     * of the 128 stripes at once, so concurrent writers serialise against it, which costs little:
+     * the write threads spend most of their time idle.
+     */
+    @Override
+    protected Status[] putDiscoveredItems(List<URLInfo> items) {
+
+        final Status[] statuses = new Status[items.size()];
+
+        if (isClosing()) {
+            Arrays.fill(statuses, Status.FAIL);
+            return statuses;
+        }
+
+        putURLs_urls_count.inc(items.size());
+        putURLs_discovered_count.labels("true").inc(items.size());
+
+        // worked out upfront so that the locks can be taken in bulk
+        final URLInfo[] infos = new URLInfo[items.size()];
+        final QueueWithinCrawl[] queueKeys = new QueueWithinCrawl[items.size()];
+        final String[] existenceKeys = new String[items.size()];
+        final List<String> lockKeys = new ArrayList<>(items.size());
+
+        for (int i = 0; i < items.size(); i++) {
+            URLInfo info = items.get(i);
+            String Qkey = info.getKey();
+            final String url = info.getUrl();
+            final String crawlID = CrawlID.normaliseCrawlID(info.getCrawlID());
+
+            // has a queue key been defined? if not use the hostname
+            if (Qkey.equals("")) {
+                LOG.debug("key missing for {}", url);
+                Qkey = provideMissingKey(url);
+                if (Qkey == null) {
+                    LOG.error("Malformed URL {}", url);
+                    statuses[i] = Status.SKIPPED;
+                    continue;
+                }
+                info = URLInfo.newBuilder(info).setKey(Qkey).setCrawlID(crawlID).build();
+            }
+
+            // check that the key is not too long
+            if (Qkey.length() > 255) {
+                LOG.error("Key too long: {}", Qkey);
+                statuses[i] = Status.SKIPPED;
+                continue;
+            }
+
+            final QueueWithinCrawl qk = QueueWithinCrawl.get(Qkey, crawlID);
+
+            // ignore this url if the queue is being deleted
+            if (queuesBeingDeleted.contains(qk)) {
+                LOG.info("Not adding {} as its queue {} is being deleted", url, Qkey);
+                statuses[i] = Status.SKIPPED;
+                continue;
+            }
+
+            infos[i] = info;
+            queueKeys[i] = qk;
+            existenceKeys[i] = qk.toString() + "_" + url;
+            lockKeys.add(existenceKeys[i]);
+        }
+
+        final List<Lock> locks = new ArrayList<>();
+        for (Lock lock : STRIPED_LOCKS.bulkGet(lockKeys)) {
+            locks.add(lock);
+        }
+        for (Lock lock : locks) {
+            lock.lock();
+        }
+
+        try (final WriteBatch writeBatch = new WriteBatch()) {
+
+            // the DB cannot see the entries accumulated in the batch, so a URL sent
+            // twice in it has to be caught here
+            final Set<String> seenInBatch = new HashSet<>();
+            // indices of the URLs the batch holds a write for, only OK once it lands
+            final List<Integer> written = new ArrayList<>(items.size());
+            // queues to update, applied only once the write has succeeded
+            final List<QueueWithinCrawl> increments = new ArrayList<>(items.size());
+
+            final long now = Instant.now().getEpochSecond();
+            final String paddedNow = paddedDate(now);
+            final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+            buffer.putLong(now);
+            // the JNI layer copies the arrays handed to the batch, reusing them is fine
+            final byte[] creationDate = buffer.array();
+
+            for (int i = 0; i < items.size(); i++) {
+                if (statuses[i] != null) {
+                    continue;
+                }
+                if (isClosing()) {
+                    statuses[i] = Status.FAIL;
+                    continue;
+                }
+
+                final String existenceKeyString = existenceKeys[i];
+                if (!seenInBatch.add(existenceKeyString)) {
+                    putURLs_alreadyknown_count.inc();
+                    statuses[i] = Status.SKIPPED;
+                    continue;
+                }
+
+                final byte[] existenceKey = existenceKeyString.getBytes(StandardCharsets.UTF_8);
+
+                // is this URL already known?
+                if (rocksDB.get(existenceKey) != null) {
+                    putURLs_alreadyknown_count.inc();
+                    statuses[i] = Status.SKIPPED;
+                    continue;
+                }
+
+                final byte[] schedulingKey =
+                        (queueKeys[i].toString() + "_" + paddedNow + "_" + infos[i].getUrl())
+                                .getBytes(StandardCharsets.UTF_8);
+
+                writeBatch.put(
+                        columnFamilyHandleList.get(1), schedulingKey, infos[i].toByteArray());
+                writeBatch.put(columnFamilyHandleList.get(0), existenceKey, schedulingKey);
+                writeBatch.put(columnFamilyHandleList.get(3), existenceKey, creationDate);
+
+                written.add(i);
+                increments.add(queueKeys[i]);
+            }
+
+            if (!written.isEmpty()) {
+                rocksDB.write(writeOptions, writeBatch);
+            }
+
+            for (int idx : written) {
+                statuses[idx] = Status.OK;
+            }
+            for (QueueWithinCrawl qk : increments) {
+                ((QueueMetadata) getQueues().computeIfAbsent(qk, s -> new QueueMetadata()))
+                        .incrementActive();
+            }
+
+        } catch (RocksDBException e) {
+            LOG.error("RocksDB exception", e);
+        } finally {
+            for (Lock lock : locks) {
+                lock.unlock();
+            }
+        }
+
+        // covers the URLs whose write never landed
+        for (int i = 0; i < statuses.length; i++) {
+            if (statuses[i] == null) {
+                statuses[i] = Status.FAIL;
+            }
+        }
+
+        return statuses;
+    }
+
+    /**
      *
      *
      * <pre>

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -575,12 +575,13 @@ public class RocksDBService extends AbstractFrontierService {
      * Writes a whole batch of discovered URLs as a single RocksDB write, which amortises the
      * per-write overhead the individual puts pay.
      *
-     * <p>The stripe locks of every URL in the batch are taken upfront, in the deadlock-free order
-     * provided by the striped collection, and held until the write has landed: this is what stops
-     * another thread from concluding in the meantime that one of these URLs is unknown, the same
-     * guarantee the lock held across get-then-write gives the individual puts. A batch holds many
-     * of the 128 stripes at once, so concurrent writers serialise against it, which costs little:
-     * the write threads spend most of their time idle.
+     * <p>The existence checks run first, without any lock: a large share of what a crawl discovers
+     * is already known, and finding that out is the expensive part of the job - it reads data
+     * blocks - so it must stay parallel across the writer threads. Only the URLs which look new
+     * then take their stripe locks, in the deadlock-free order provided by the striped collection,
+     * and get checked again: the blocks are warm by then, so the re-check is cheap, and the locks
+     * are held until the write has landed, which is the same guarantee the lock held across
+     * get-then-write gives the individual puts.
      */
     @Override
     protected Status[] putDiscoveredItems(List<URLInfo> items) {
@@ -595,11 +596,14 @@ public class RocksDBService extends AbstractFrontierService {
         putURLs_urls_count.inc(items.size());
         putURLs_discovered_count.labels("true").inc(items.size());
 
-        // worked out upfront so that the locks can be taken in bulk
         final URLInfo[] infos = new URLInfo[items.size()];
         final QueueWithinCrawl[] queueKeys = new QueueWithinCrawl[items.size()];
         final String[] existenceKeys = new String[items.size()];
-        final List<String> lockKeys = new ArrayList<>(items.size());
+        final byte[][] existenceKeyBytes = new byte[items.size()][];
+
+        // the DB cannot see the entries accumulated in the batch, so a URL sent
+        // twice in it has to be caught here
+        final Set<String> seenInBatch = new HashSet<>();
 
         for (int i = 0; i < items.size(); i++) {
             URLInfo info = items.get(i);
@@ -635,10 +639,54 @@ public class RocksDBService extends AbstractFrontierService {
                 continue;
             }
 
+            final String existenceKeyString = qk.toString() + "_" + url;
+            if (!seenInBatch.add(existenceKeyString)) {
+                putURLs_alreadyknown_count.inc();
+                statuses[i] = Status.SKIPPED;
+                continue;
+            }
+
             infos[i] = info;
             queueKeys[i] = qk;
-            existenceKeys[i] = qk.toString() + "_" + url;
-            lockKeys.add(existenceKeys[i]);
+            existenceKeys[i] = existenceKeyString;
+            existenceKeyBytes[i] = existenceKeyString.getBytes(StandardCharsets.UTF_8);
+        }
+
+        // first pass, without any lock: weed out the URLs which are already known,
+        // in one multiGet for the whole batch
+        final List<Integer> candidates = new ArrayList<>(items.size());
+        final List<byte[]> keysToCheck = new ArrayList<>(items.size());
+        for (int i = 0; i < items.size(); i++) {
+            if (statuses[i] == null) {
+                candidates.add(i);
+                keysToCheck.add(existenceKeyBytes[i]);
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return statuses;
+        }
+
+        final List<String> lockKeys = new ArrayList<>(candidates.size());
+        try {
+            final List<byte[]> found = rocksDB.multiGetAsList(keysToCheck);
+            for (int c = candidates.size() - 1; c >= 0; c--) {
+                if (found.get(c) != null) {
+                    putURLs_alreadyknown_count.inc();
+                    statuses[candidates.get(c)] = Status.SKIPPED;
+                    candidates.remove(c);
+                }
+            }
+        } catch (RocksDBException e) {
+            LOG.error("RocksDB exception", e);
+            for (int idx : candidates) {
+                statuses[idx] = Status.FAIL;
+            }
+            return statuses;
+        }
+
+        for (int idx : candidates) {
+            lockKeys.add(existenceKeys[idx]);
         }
 
         final List<Lock> locks = new ArrayList<>();
@@ -651,13 +699,10 @@ public class RocksDBService extends AbstractFrontierService {
 
         try (final WriteBatch writeBatch = new WriteBatch()) {
 
-            // the DB cannot see the entries accumulated in the batch, so a URL sent
-            // twice in it has to be caught here
-            final Set<String> seenInBatch = new HashSet<>();
             // indices of the URLs the batch holds a write for, only OK once it lands
-            final List<Integer> written = new ArrayList<>(items.size());
+            final List<Integer> written = new ArrayList<>(candidates.size());
             // queues to update, applied only once the write has succeeded
-            final List<QueueWithinCrawl> increments = new ArrayList<>(items.size());
+            final List<QueueWithinCrawl> increments = new ArrayList<>(candidates.size());
 
             final long now = Instant.now().getEpochSecond();
             final String paddedNow = paddedDate(now);
@@ -666,26 +711,15 @@ public class RocksDBService extends AbstractFrontierService {
             // the JNI layer copies the arrays handed to the batch, reusing them is fine
             final byte[] creationDate = buffer.array();
 
-            for (int i = 0; i < items.size(); i++) {
-                if (statuses[i] != null) {
-                    continue;
-                }
+            for (int i : candidates) {
                 if (isClosing()) {
                     statuses[i] = Status.FAIL;
                     continue;
                 }
 
-                final String existenceKeyString = existenceKeys[i];
-                if (!seenInBatch.add(existenceKeyString)) {
-                    putURLs_alreadyknown_count.inc();
-                    statuses[i] = Status.SKIPPED;
-                    continue;
-                }
-
-                final byte[] existenceKey = existenceKeyString.getBytes(StandardCharsets.UTF_8);
-
-                // is this URL already known?
-                if (rocksDB.get(existenceKey) != null) {
+                // another thread may have added it between the unlocked check and
+                // the lock; the blocks are warm now, this get is cheap
+                if (rocksDB.get(existenceKeyBytes[i]) != null) {
                     putURLs_alreadyknown_count.inc();
                     statuses[i] = Status.SKIPPED;
                     continue;
@@ -697,8 +731,8 @@ public class RocksDBService extends AbstractFrontierService {
 
                 writeBatch.put(
                         columnFamilyHandleList.get(1), schedulingKey, infos[i].toByteArray());
-                writeBatch.put(columnFamilyHandleList.get(0), existenceKey, schedulingKey);
-                writeBatch.put(columnFamilyHandleList.get(3), existenceKey, creationDate);
+                writeBatch.put(columnFamilyHandleList.get(0), existenceKeyBytes[i], schedulingKey);
+                writeBatch.put(columnFamilyHandleList.get(3), existenceKeyBytes[i], creationDate);
 
                 written.add(i);
                 increments.add(queueKeys[i]);

--- a/service/src/test/java/crawlercommons/urlfrontier/service/PutDiscoveredTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/PutDiscoveredTest.java
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage.Status;
+import crawlercommons.urlfrontier.Urlfrontier.BatchAck;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredBatch;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.service.rocksdb.RocksDBService;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Exercises the batched ingestion of discovered URLs on the RocksDB implementation */
+class PutDiscoveredTest {
+
+    private static final String ROCKSDB_PATH = "./target/rocksdb-putdiscovered";
+
+    private RocksDBService frontier;
+
+    @BeforeEach
+    void setup() {
+        FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", ROCKSDB_PATH);
+        frontier = new RocksDBService(conf, "localhost", 7071);
+    }
+
+    @AfterEach
+    void teardown() throws IOException {
+        frontier.close();
+        FileUtils.deleteQuietly(new File(ROCKSDB_PATH));
+    }
+
+    private static URLInfo info(String url) {
+        return URLInfo.newBuilder().setUrl(url).build();
+    }
+
+    /** Sends one batch and returns its ack once the stream has completed */
+    private BatchAck send(String id, List<URLInfo> items) throws InterruptedException {
+
+        final List<BatchAck> acks = new ArrayList<>();
+        final CountDownLatch finished = new CountDownLatch(1);
+
+        StreamObserver<DiscoveredBatch> stream =
+                frontier.putDiscovered(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(BatchAck value) {
+                                acks.add(value);
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                finished.countDown();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                finished.countDown();
+                            }
+                        });
+
+        stream.onNext(DiscoveredBatch.newBuilder().setID(id).addAllItems(items).build());
+        stream.onCompleted();
+
+        assertTrue(finished.await(30, TimeUnit.SECONDS), "stream did not complete");
+        assertEquals(1, acks.size());
+        return acks.get(0);
+    }
+
+    @Test
+    void newURLsAreCreated() throws Exception {
+        BatchAck ack =
+                send(
+                        "b1",
+                        List.of(
+                                info("http://a.com/1"),
+                                info("http://b.com/1"),
+                                info("http://a.com/2")));
+
+        assertEquals("b1", ack.getID());
+        assertEquals(List.of(Status.OK, Status.OK, Status.OK), ack.getStatusesList());
+        assertEquals(2, frontier.getQueues().size());
+
+        int active = 0;
+        for (QueueInterface q : frontier.getQueues().values()) {
+            active += q.countActive();
+        }
+        assertEquals(3, active);
+    }
+
+    @Test
+    void duplicateWithinTheBatchIsSkipped() throws Exception {
+        BatchAck ack = send("b1", List.of(info("http://a.com/1"), info("http://a.com/1")));
+
+        assertEquals(List.of(Status.OK, Status.SKIPPED), ack.getStatusesList());
+        assertEquals(1, frontier.getQueues().values().iterator().next().countActive());
+    }
+
+    @Test
+    void knownURLIsSkipped() throws Exception {
+        assertEquals(
+                List.of(Status.OK), send("b1", List.of(info("http://a.com/1"))).getStatusesList());
+        assertEquals(
+                List.of(Status.SKIPPED),
+                send("b2", List.of(info("http://a.com/1"))).getStatusesList());
+        assertEquals(1, frontier.getQueues().values().iterator().next().countActive());
+    }
+
+    @Test
+    void malformedURLIsSkippedOthersGoThrough() throws Exception {
+        // no hostname can be derived from an empty URL
+        BatchAck ack = send("b1", List.of(info(""), info("http://a.com/1")));
+        assertEquals(List.of(Status.SKIPPED, Status.OK), ack.getStatusesList());
+    }
+
+    /** An empty batch works and echoes the ID: clients use it to probe for support */
+    @Test
+    void emptyBatchIsAcked() throws Exception {
+        BatchAck ack = send("probe", List.of());
+        assertEquals("probe", ack.getID());
+        assertEquals(0, ack.getStatusesCount());
+    }
+}


### PR DESCRIPTION
> Draft; stacks on #192 (the first two commits in the diff belong to it and will drop out once it merges).

Adds a batch variant of the ingestion path to the API. The measurements behind #192 showed that the per-message cost of the gRPC path is what limits the ingestion rate. The only lever that reduces the per-URL message count is the protocol, and the crawl provides a natural batch boundary: the outlinks of a fetched page.

**API** (`PutDiscovered(stream DiscoveredBatch) returns (stream BatchAck)`): discovered URLs travel as `repeated URLInfo` in one message per batch, acked as a whole with one status per URL in order (packed enum, ~1 byte per URL). Known URLs keep using `PutURLs` unchanged. A new RPC rather than a new field on `URLItem` gives clean version negotiation: clients probe with an empty batch and fall back to the per-URL stream on `UNIMPLEMENTED`.

**Server**: the default implementation feeds batches through `putURLItem` one URL at a time, so every backend gets the endpoint for free. The RocksDB implementation overrides it: the existence checks run first without any lock, as one `multiGet` for the whole batch — on real crawl data a large share of discovered URLs are duplicates, and finding that out reads data blocks, so it must stay parallel across writer threads. Only the URLs that look new then take their stripe locks (deadlock-free bulk order), get re-checked warm, and are committed as a single `WriteBatch` with the locks held until the write lands — the same dedup guarantee the per-URL path gets from its lock held across get-then-write. Queue counters apply only after a successful commit. The in-flight budget from #192 applies per batch (`putDiscovered.max.inflight`, default 16). The sharded service answers `UNIMPLEMENTED` for now: batches span partitions and would have to be split and re-batched per node — left for a follow-up.

**Client**: `PutURLs --batch N` buffers discovered URLs and sends them N at a time on a `PutDiscovered` stream, known URLs staying on the per-URL stream; the `-w` window applies across both, counted in URLs. Probed fallback verified against a server built before this change.

**Measured on real crawl data** (2M discovered URLs from a host-sorted dump, 45% already known, 2 streams, fresh DB, same loaded laptop for every run):

| config | OPS | server CPU |
|---|---|---|
| master, per-URL | 51.7k | 267s |
| this branch, per-URL (`-b 0`) | 52–54k | 252–268s |
| `-b 64` | 46.8k | 102s |
| `-b 256` | 56–57k | 75–84s |
| `-b 512` | 62.8k | 71s |

Per-URL parity with master was also checked on a 2M slice of known URLs: 58,632 vs 58,649 OPS — the endpoint costs nothing when unused. **Batch size matters on real data**: small batches carry too much locking overlap relative to their work, so 256+ is the recommendation — at 512 the batch path is +21% throughput over master with the server CPU divided by 3.8. (An earlier revision of this PR measured 2x throughput at `-b 256` on synthetic all-new URLs — real data with its duplicate share is the honest benchmark, which is also what motivated the unlocked multiGet pre-check commit.)

The CPU reduction is the headline for co-located deployments: same ingest, roughly a quarter of the CPU.

Remaining before undrafting:
- [ ] cluster-mode implementation (split batches per partition) or an agreed decision to keep the fallback
- [ ] StormCrawler connector adoption is a follow-up in that repo

Commits are signed off and kept separate (API+server / RocksDB write path / client / multiGet pre-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)