### PR TITLE
Give the queues map a real concurrency contract

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -251,10 +251,7 @@ public abstract class AbstractFrontierService
 
             final Set<QueueWithinCrawl> toDelete = new HashSet<>();
 
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                    getQueues().entrySet().iterator();
-            while (iterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
+            for (Entry<QueueWithinCrawl, QueueInterface> e : getQueues().unorderedEntries()) {
                 QueueWithinCrawl qwc = e.getKey();
                 if (qwc.getCrawlid().equals(normalisedCrawlID)) {
                     toDelete.add(qwc);
@@ -1232,47 +1229,54 @@ public abstract class AbstractFrontierService
         // Cutoff date  = now - number of days we want to keep
         Instant cutoff = Instant.now().minus(Period.ofDays(days));
 
-        synchronized (getQueues()) {
-            Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                    getQueues().entrySet().iterator();
+        for (Entry<QueueWithinCrawl, QueueInterface> e : getQueues().unorderedEntries()) {
 
-            while (qiterator.hasNext()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
-
-                // check that it is within the right crawlID
-                if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
-                    continue;
-                }
-
-                // check that it is within the right key/queue
-                if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
-                    continue;
-                }
-
-                try (CloseableIterator<URLItem> urliter = urlIterator(e)) {
-                    List<URLItem> toDelete = new ArrayList<>();
-
-                    while (urliter.hasNext()) {
-                        URLItem cur = urliter.next();
-
-                        if (Instant.ofEpochSecond(cur.getCreationDate()).isBefore(cutoff)) {
-                            // Add to deletion list (should not delete while iterating URLItem in
-                            // queue)
-                            toDelete.add(cur);
-                            deletedCount++;
-                        }
-                    }
-
-                    toDelete.stream().forEach(x -> deleteURLItem(x));
-
-                } catch (Exception e1) {
-                    LOG.warn(e1.getMessage(), e1);
-                }
+            // check that it is within the right crawlID
+            if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
+                continue;
             }
+
+            // check that it is within the right key/queue
+            if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
+                continue;
+            }
+
+            deletedCount += purgeQueue(e, cutoff);
         }
 
         responseObserver.onNext(Urlfrontier.Long.newBuilder().setValue(deletedCount).build());
         responseObserver.onCompleted();
+    }
+
+    /**
+     * Purges the stale URLs of a single queue: scans, collects, then deletes. Backends that need
+     * the scan and the deletions to be atomic against their writers (see the memory backend, where
+     * URL equality ignores the version) override this and wrap it in the queue's monitor.
+     *
+     * @return the number of URLs deleted
+     */
+    protected long purgeQueue(Entry<QueueWithinCrawl, QueueInterface> e, Instant cutoff) {
+        long deletedCount = 0;
+        try (CloseableIterator<URLItem> urliter = urlIterator(e)) {
+            List<URLItem> toDelete = new ArrayList<>();
+
+            while (urliter.hasNext()) {
+                URLItem cur = urliter.next();
+
+                if (Instant.ofEpochSecond(cur.getCreationDate()).isBefore(cutoff)) {
+                    // Add to deletion list (should not delete while iterating URLItem in
+                    // queue)
+                    toDelete.add(cur);
+                    deletedCount++;
+                }
+            }
+
+            toDelete.stream().forEach(x -> deleteURLItem(x));
+
+        } catch (Exception e1) {
+            LOG.warn(e1.getMessage(), e1);
+        }
+        return deletedCount;
     }
 
     /**

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -741,21 +741,18 @@ public abstract class AbstractFrontierService
             final QueueInterface currentQueue;
             final QueueWithinCrawl currentCrawlQueue;
 
-            synchronized (getQueues()) {
-                Entry<QueueWithinCrawl, QueueInterface> e = getQueues().firstEntry();
-                currentQueue = e.getValue();
-                currentCrawlQueue = e.getKey();
+            Entry<QueueWithinCrawl, QueueInterface> rotated = getQueues().rotateFirstEntry();
+            if (rotated == null) {
+                break;
+            }
+            currentQueue = rotated.getValue();
+            currentCrawlQueue = rotated.getKey();
 
-                // to make sure we don't loop over the ones we already processed
-                if (firstCrawlQueue == null) {
-                    firstCrawlQueue = currentCrawlQueue;
-                } else if (firstCrawlQueue.equals(currentCrawlQueue)) {
-                    break;
-                }
-
-                // We remove the entry and put it at the end of the map
-                Entry<QueueWithinCrawl, QueueInterface> first = getQueues().pollFirstEntry();
-                getQueues().put(first.getKey(), first.getValue());
+            // to make sure we don't loop over the ones we already processed
+            if (firstCrawlQueue == null) {
+                firstCrawlQueue = currentCrawlQueue;
+            } else if (firstCrawlQueue.equals(currentCrawlQueue)) {
+                break;
             }
 
             // if a crawlID has been specified make sure it matches

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -14,7 +14,8 @@ import java.util.concurrent.ConcurrentMap;
  *
  * <p>Per-key operations are atomic. Ordered views are backed by the insertion-order index and are
  * weakly consistent: they may miss keys rotated concurrently, and they do not become atomic if the
- * map instance is wrapped in external {@code synchronized} blocks.
+ * map instance is wrapped in external {@code synchronized} blocks. Use {@link #unorderedEntries()}
+ * for complete scans that do not care about insertion order.
  *
  * @param <K>
  * @param <V>
@@ -34,6 +35,14 @@ public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
      * if the map is empty.
      */
     Entry<K, V> rotateFirstEntry();
+
+    /**
+     * Returns a weakly consistent live view backed by the value map.
+     *
+     * <p>Unlike ordered iteration, this view is unaffected by {@link #rotateFirstEntry()} because
+     * rotation does not remove the mapping from the value map.
+     */
+    Iterable<Map.Entry<K, V>> unorderedEntries();
 
     /**
      * Returns a set containing the keys in this map. The iterator returned by this set is weakly

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentInsertionOrderMap.java
@@ -9,8 +9,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Interface for a Concurrent Map which preserves insertion order and allows to retrieve its first
- * element.
+ * Interface for a concurrent map which preserves insertion order and exposes weakly consistent
+ * ordered iteration.
+ *
+ * <p>Per-key operations are atomic. Ordered views are backed by the insertion-order index and are
+ * weakly consistent: they may miss keys rotated concurrently, and they do not become atomic if the
+ * map instance is wrapped in external {@code synchronized} blocks.
  *
  * @param <K>
  * @param <V>
@@ -22,6 +26,14 @@ public interface ConcurrentInsertionOrderMap<K, V> extends ConcurrentMap<K, V> {
 
     /** Remove and returns the first entry according to insertion order */
     Entry<K, V> pollFirstEntry();
+
+    /**
+     * Atomically moves the first entry to the tail and returns it.
+     *
+     * <p>The mapping stays present in the value map for the whole operation. Returns {@code null}
+     * if the map is empty.
+     */
+    Entry<K, V> rotateFirstEntry();
 
     /**
      * Returns a set containing the keys in this map. The iterator returned by this set is weakly

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -508,4 +508,24 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
             }
         };
     }
+
+    @Override
+    public Iterable<Map.Entry<K, V>> unorderedEntries() {
+        return () ->
+                new Iterator<>() {
+                    final Iterator<Entry<K, ValueEntry>> iterator = valueMap.entrySet().iterator();
+
+                    @Override
+                    public boolean hasNext() {
+                        return iterator.hasNext();
+                    }
+
+                    @Override
+                    public Map.Entry<K, V> next() {
+                        Entry<K, ValueEntry> entry = iterator.next();
+                        return new AbstractMap.SimpleImmutableEntry<>(
+                                entry.getKey(), entry.getValue().value);
+                    }
+                };
+    }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMap.java
@@ -21,12 +21,16 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.LoggerFactory;
 
 /**
- * Concurrent version of LinkedHashMap Design goal is the same as for ConcurrentHashMap: Maintain
- * concurrent readability (typically method get(), but also iterators and related methods) while
- * minimizing update contention.
+ * Concurrent version of LinkedHashMap. The design goal is the same as for ConcurrentHashMap:
+ * maintain concurrent readability (typically method get(), but also iterators and related methods)
+ * while minimizing update contention.
  *
- * <p>This implementation is based on ConcurrentSkipListMap for order preservation and Guava Striped
+ * <p>This implementation is based on ConcurrentSkipListMap for order preservation and Guava striped
  * locks for concurrency.
+ *
+ * <p>Atomicity is per key. Ordered views are weakly consistent and may miss keys rotated
+ * concurrently because rotation only changes the position in the order index. External
+ * synchronization on the map instance does not provide a map-wide lock for compound actions.
  *
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values
@@ -48,6 +52,8 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
     private static final int DEFAULT_SIZE = DEFAULT_CONCURRENCY * 16;
 
     private final Striped<Lock> striped;
+
+    private final ReentrantLock orderMutationLock = new ReentrantLock();
 
     class ValueEntry {
         public ValueEntry(V v, long o) {
@@ -74,6 +80,22 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
 
     private Lock getStripe(Object key) {
         return striped.get(Objects.hashCode(key));
+    }
+
+    private ValueEntry pollFirstLiveValueEntry(Entry<Long, K> removed) {
+        K key = removed.getValue();
+        Lock stripe = getStripe(key);
+        stripe.lock();
+        try {
+            ValueEntry valueEntry = valueMap.get(key);
+            if (valueEntry == null || valueEntry.order != removed.getKey()) {
+                return null;
+            }
+            valueMap.remove(key);
+            return valueEntry;
+        } finally {
+            stripe.unlock();
+        }
     }
 
     private void lockAllStripes() {
@@ -242,7 +264,8 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
         try {
             valueMap.clear();
             insertionOrderMap.clear();
-            insertionCounter.set(0);
+            // the counter is deliberately NOT reset: insertion-order numbers double as
+            // version stamps for rotateFirstEntry/pollFirstEntry and must never be reused
 
         } finally {
             unlockAllStripes();
@@ -349,32 +372,55 @@ public class ConcurrentOrderedMap<K, V> implements ConcurrentInsertionOrderMap<K
     /*
      * Remove & Returns the first entry according to insertion order
      */
-    public synchronized Entry<K, V> pollFirstEntry() {
-        K key;
-
-        Entry<Long, K> removed = insertionOrderMap.pollFirstEntry();
-        if (removed == null) {
-            return null;
-        }
-
-        // Get and remove from value map
-        key = removed.getValue();
-
-        Lock stripe = getStripe(key);
-        stripe.lock();
-
+    public Entry<K, V> pollFirstEntry() {
+        orderMutationLock.lock();
         try {
-            ValueEntry valueEntry = valueMap.remove(key);
-            if (valueEntry == null) {
-                LOG.error(
-                        "Inconsistent state (pollFirstEntry): key {} exists in order map but not in value map",
-                        key);
-                return null;
-            }
+            while (true) {
+                Entry<Long, K> removed = insertionOrderMap.pollFirstEntry();
+                if (removed == null) {
+                    return null;
+                }
 
-            return new AbstractMap.SimpleImmutableEntry<>(key, valueEntry.value);
+                ValueEntry valueEntry = pollFirstLiveValueEntry(removed);
+                if (valueEntry != null) {
+                    return new AbstractMap.SimpleImmutableEntry<>(
+                            removed.getValue(), valueEntry.value);
+                }
+            }
         } finally {
-            stripe.unlock();
+            orderMutationLock.unlock();
+        }
+    }
+
+    @Override
+    public Entry<K, V> rotateFirstEntry() {
+        orderMutationLock.lock();
+        try {
+            while (true) {
+                Entry<Long, K> first = insertionOrderMap.pollFirstEntry();
+                if (first == null) {
+                    return null;
+                }
+
+                K key = first.getValue();
+                Lock stripe = getStripe(key);
+                stripe.lock();
+                try {
+                    ValueEntry valueEntry = valueMap.get(key);
+                    if (valueEntry == null || valueEntry.order != first.getKey()) {
+                        continue;
+                    }
+
+                    long newOrder = insertionCounter.getAndIncrement();
+                    valueEntry.order = newOrder;
+                    insertionOrderMap.put(newOrder, key);
+                    return new AbstractMap.SimpleImmutableEntry<>(key, valueEntry.value);
+                } finally {
+                    stripe.unlock();
+                }
+            }
+        } finally {
+            orderMutationLock.unlock();
         }
     }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -128,24 +128,26 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
         QueueWithinCrawl qk = QueueWithinCrawl.get(key, iu.crawlID);
 
-        // get the priority queue or create one
-        synchronized (getQueues()) {
-            URLQueue queue = (URLQueue) getQueues().get(qk);
-            if (queue == null) {
-                queue = new URLQueue(iu);
-                getQueues().put(qk, queue);
-                creationDates.put(iu.url, Instant.now().getEpochSecond());
-
-                // If known and nextFetchDate, set to completed
-                if (!discovered && iu.nextFetchDate == 0) {
-                    queue.remove(iu);
-                    putURLs_completed_count.inc();
-                    queue.addToCompleted(iu.url);
-                }
-
-                return Status.OK;
+        URLQueue queue = (URLQueue) getQueues().get(qk);
+        if (queue == null) {
+            URLQueue created = new URLQueue(iu);
+            if (!discovered && iu.nextFetchDate == 0) {
+                created.remove(iu);
+                created.addToCompleted(iu.url);
             }
 
+            URLQueue existing = (URLQueue) getQueues().putIfAbsent(qk, created);
+            if (existing == null) {
+                creationDates.put(iu.url, Instant.now().getEpochSecond());
+                if (!discovered && iu.nextFetchDate == 0) {
+                    putURLs_completed_count.inc();
+                }
+                return Status.OK;
+            }
+            queue = existing;
+        }
+
+        synchronized (queue) {
             // check whether the URL already exists
             if (queue.contains(iu)) {
                 if (discovered) {
@@ -350,9 +352,8 @@ public class MemoryFrontierService extends AbstractFrontierService {
         InternalURL iu = (InternalURL) parsed[2];
 
         final QueueWithinCrawl qwc = QueueWithinCrawl.get(info.getKey(), info.getCrawlID());
-        synchronized (getQueues()) {
-            URLQueue queue = (URLQueue) getQueues().get(qwc);
-
+        URLQueue queue = (URLQueue) getQueues().get(qwc);
+        synchronized (queue) {
             if (queue.isCompleted(info.getUrl())) {
                 queue.getCompleted().remove(info.getUrl());
                 creationDates.remove(info.getUrl());

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -17,6 +17,7 @@ import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
 import io.grpc.stub.StreamObserver;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -270,8 +271,13 @@ public class MemoryFrontierService extends AbstractFrontierService {
             this.qentry = qentry;
             this.start = start;
             this.maxURLs = maxURLs;
-            iter = ((URLQueue) qentry.getValue()).iterator();
-            iterCompleted = ((URLQueue) qentry.getValue()).getCompleted().iterator();
+            URLQueue queue = (URLQueue) qentry.getValue();
+            InternalURL[] activeSnapshot;
+            synchronized (queue) {
+                activeSnapshot = queue.toArray(new InternalURL[0]);
+            }
+            iter = Arrays.asList(activeSnapshot).iterator();
+            iterCompleted = queue.getCompleted().iterator();
         }
 
         @Override

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -363,4 +363,13 @@ public class MemoryFrontierService extends AbstractFrontierService {
             }
         }
     }
+
+    @Override
+    protected long purgeQueue(Entry<QueueWithinCrawl, QueueInterface> e, Instant cutoff) {
+        // scan+delete must be atomic against this queue's writers: InternalURL equality is
+        // by URL only, so a URL refreshed after the purge decision would be deleted
+        synchronized (e.getValue()) {
+            return super.purgeQueue(e, cutoff);
+        }
+    }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -723,19 +723,17 @@ public class RocksDBService extends AbstractFrontierService {
         int queuesWritten = 0;
         if (!getQueues().isEmpty()) {
             ByteBuffer bb = ByteBuffer.allocate(8);
-            synchronized (getQueues()) {
-                for (Entry<QueueWithinCrawl, QueueInterface> entry : getQueues().entrySet()) {
-                    queuesWritten++;
-                    int active = entry.getValue().countActive();
-                    int completed = entry.getValue().getCountCompleted();
-                    bb.putInt(active);
-                    bb.putInt(completed);
-                    rocksDB.put(
-                            columnFamilyHandleList.get(2),
-                            entry.getKey().toString().getBytes(),
-                            bb.array());
-                    bb.clear();
-                }
+            for (Entry<QueueWithinCrawl, QueueInterface> entry : getQueues().unorderedEntries()) {
+                queuesWritten++;
+                int active = entry.getValue().countActive();
+                int completed = entry.getValue().getCountCompleted();
+                bb.putInt(active);
+                bb.putInt(completed);
+                rocksDB.put(
+                        columnFamilyHandleList.get(2),
+                        entry.getKey().toString().getBytes(),
+                        bb.array());
+                bb.clear();
             }
         }
         long end = System.currentTimeMillis();
@@ -807,59 +805,61 @@ public class RocksDBService extends AbstractFrontierService {
 
         final Set<QueueWithinCrawl> toDelete = new HashSet<>();
 
-        synchronized (getQueues()) {
+        ArrayList<QueueWithinCrawl> queues = new ArrayList<>();
+        for (Entry<QueueWithinCrawl, QueueInterface> entry : getQueues().unorderedEntries()) {
+            queues.add(entry.getKey());
+        }
 
-            // find the crawlIDs
-            QueueWithinCrawl[] array = getQueues().keySet().toArray(new QueueWithinCrawl[0]);
-            Arrays.sort(array);
+        // find the crawlIDs
+        QueueWithinCrawl[] array = queues.toArray(new QueueWithinCrawl[0]);
+        Arrays.sort(array);
 
-            byte[] startKey = null;
-            byte[] endKey = null;
-            for (QueueWithinCrawl prefixed_queue : array) {
-                boolean samePrefix = prefixed_queue.getCrawlid().equals(normalisedCrawlID);
-                if (samePrefix) {
-                    if (startKey == null) {
-                        startKey =
-                                (prefixed_queue.getCrawlid().replace("_", "%5F") + "_")
-                                        .getBytes(StandardCharsets.UTF_8);
-                    }
-                    toDelete.add(prefixed_queue);
-                } else if (startKey != null) {
-                    endKey =
+        byte[] startKey = null;
+        byte[] endKey = null;
+        for (QueueWithinCrawl prefixed_queue : array) {
+            boolean samePrefix = prefixed_queue.getCrawlid().equals(normalisedCrawlID);
+            if (samePrefix) {
+                if (startKey == null) {
+                    startKey =
                             (prefixed_queue.getCrawlid().replace("_", "%5F") + "_")
                                     .getBytes(StandardCharsets.UTF_8);
-                    break;
                 }
+                toDelete.add(prefixed_queue);
+            } else if (startKey != null) {
+                endKey =
+                        (prefixed_queue.getCrawlid().replace("_", "%5F") + "_")
+                                .getBytes(StandardCharsets.UTF_8);
+                break;
             }
+        }
 
-            // no queues found - nothing to delete
-            if (startKey == null) {
-                return 0;
+        // no queues found - nothing to delete
+        if (startKey == null) {
+            return 0;
+        }
+
+        try {
+            deleteRanges(startKey, endKey);
+        } catch (RocksDBException e) {
+            LOG.error(
+                    "Exception caught when deleting ranges - {} - {}",
+                    asString(startKey),
+                    asString(endKey),
+                    e);
+        }
+
+        for (QueueWithinCrawl quid : toDelete) {
+            // already being deleted by another thread?
+            if (!queuesBeingDeleted.add(quid)) {
+                continue;
             }
 
             try {
-                deleteRanges(startKey, endKey);
-            } catch (RocksDBException e) {
-                LOG.error(
-                        "Exception caught when deleting ranges - {} - {}",
-                        asString(startKey),
-                        asString(endKey),
-                        e);
-            }
-
-            for (QueueWithinCrawl quid : toDelete) {
-                // already being deleted by another thread?
-                if (!queuesBeingDeleted.add(quid)) {
-                    continue;
-                }
-
-                try {
-                    QueueInterface q = getQueues().remove(quid);
-                    total += q.countActive();
-                    total += q.getCountCompleted();
-                } finally {
-                    queuesBeingDeleted.remove(quid);
-                }
+                QueueInterface q = getQueues().remove(quid);
+                total += q.countActive();
+                total += q.getCountCompleted();
+            } finally {
+                queuesBeingDeleted.remove(quid);
             }
         }
         return total;
@@ -1185,33 +1185,31 @@ public class RocksDBService extends AbstractFrontierService {
         final String existenceKeyString = (qk.toString() + "_" + info.getUrl());
         byte[] key = existenceKeyString.getBytes(StandardCharsets.UTF_8);
 
-        synchronized (getQueues()) {
-            try {
-                // Delete scheduling entry if exists
-                byte[] schedulingKey = rocksDB.get(columnFamilyHandleList.get(0), key);
+        try {
+            // Delete scheduling entry if exists
+            byte[] schedulingKey = rocksDB.get(columnFamilyHandleList.get(0), key);
 
-                // check the value - if it is an empty byte array it means that the URL has been
-                // processed and is not scheduled
-                // otherwise it is scheduled
-                boolean completed = schedulingKey.length == 0;
+            // check the value - if it is an empty byte array it means that the URL has been
+            // processed and is not scheduled
+            // otherwise it is scheduled
+            boolean completed = schedulingKey.length == 0;
 
-                QueueMetadata queueMD = (QueueMetadata) getQueues().get(qk);
+            QueueMetadata queueMD = (QueueMetadata) getQueues().get(qk);
 
-                if (!completed) {
-                    rocksDB.delete(columnFamilyHandleList.get(1), schedulingKey);
-                    queueMD.decrementActive();
-                } else {
-                    queueMD.decrementCompleted();
-                }
-
-                // Delete the creation date
-                rocksDB.delete(columnFamilyHandleList.get(3), key);
-
-                // Delete the existence key
-                rocksDB.delete(columnFamilyHandleList.get(0), key);
-            } catch (RocksDBException e1) {
-                LOG.error(e1.getMessage());
+            if (!completed) {
+                rocksDB.delete(columnFamilyHandleList.get(1), schedulingKey);
+                queueMD.decrementActive();
+            } else {
+                queueMD.decrementCompleted();
             }
+
+            // Delete the creation date
+            rocksDB.delete(columnFamilyHandleList.get(3), key);
+
+            // Delete the existence key
+            rocksDB.delete(columnFamilyHandleList.get(0), key);
+        } catch (RocksDBException e1) {
+            LOG.error(e1.getMessage());
         }
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -718,6 +718,9 @@ public class RocksDBService extends AbstractFrontierService {
      *
      * @throws RocksDBException
      */
+    // Persists the per-queue counts at shutdown. The unordered view guarantees every
+    // queue is visited even under concurrent rotation; counts racing an in-flight
+    // delete may be off by that delta, as they already were with puts before.
     private void writeQueueInfos() throws RocksDBException {
         long start = System.currentTimeMillis();
         int queuesWritten = 0;
@@ -1189,6 +1192,12 @@ public class RocksDBService extends AbstractFrontierService {
             // Delete scheduling entry if exists
             byte[] schedulingKey = rocksDB.get(columnFamilyHandleList.get(0), key);
 
+            // the URL is unknown, or a concurrent deleteCrawl/deleteQueue already
+            // removed its range: nothing left to delete
+            if (schedulingKey == null) {
+                return;
+            }
+
             // check the value - if it is an empty byte array it means that the URL has been
             // processed and is not scheduled
             // otherwise it is scheduled
@@ -1198,8 +1207,10 @@ public class RocksDBService extends AbstractFrontierService {
 
             if (!completed) {
                 rocksDB.delete(columnFamilyHandleList.get(1), schedulingKey);
-                queueMD.decrementActive();
-            } else {
+                if (queueMD != null) {
+                    queueMD.decrementActive();
+                }
+            } else if (queueMD != null) {
                 queueMD.decrementCompleted();
             }
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -483,6 +483,40 @@ class ConcurrentOrderedMapTest {
     }
 
     @Test
+    void testUnorderedEntriesSeeAllKeysWhileRotating() throws InterruptedException {
+        int keyCount = 16;
+        Set<String> expected = new HashSet<>();
+        for (int i = 0; i < keyCount; i++) {
+            String key = "key" + i;
+            expected.add(key);
+            map.put(key, "value" + i);
+        }
+
+        AtomicBoolean running = new AtomicBoolean(true);
+        Thread rotator =
+                new Thread(
+                        () -> {
+                            while (running.get()) {
+                                assertNotNull(map.rotateFirstEntry());
+                            }
+                        });
+        rotator.start();
+
+        try {
+            for (int pass = 0; pass < 200; pass++) {
+                Set<String> seen = new HashSet<>();
+                for (Map.Entry<String, String> entry : map.unorderedEntries()) {
+                    seen.add(entry.getKey());
+                }
+                assertEquals(expected, seen);
+            }
+        } finally {
+            running.set(false);
+            rotator.join();
+        }
+    }
+
+    @Test
     void testConcurrentRotateRemoveAndRecreateKeepsOneLiveEntryPerKey()
             throws InterruptedException {
         int keyCount = 8;

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ConcurrentOrderedMapTest.java
@@ -6,10 +6,19 @@ package crawlercommons.urlfrontier.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -363,5 +372,178 @@ class ConcurrentOrderedMapTest {
         // All entries should have been polled exactly once
         assertEquals(NUM_ITERATIONS, polledKeys.size());
         assertTrue(map.isEmpty());
+    }
+
+    @Test
+    void testRotateFirstEntryMovesHeadToTail() {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+
+        Map.Entry<String, String> rotated = map.rotateFirstEntry();
+
+        assertEquals("key1", rotated.getKey());
+        assertEquals("value1", rotated.getValue());
+
+        Iterator<String> iterator = map.keySet().iterator();
+        assertEquals("key2", iterator.next());
+        assertEquals("key3", iterator.next());
+        assertEquals("key1", iterator.next());
+    }
+
+    @Test
+    void testRotateFirstEntryOnEmptyMapReturnsNull() {
+        assertNull(map.rotateFirstEntry());
+    }
+
+    @Test
+    void testConcurrentRotateFirstEntryPreservesSequentialOrder() throws InterruptedException {
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("key3", "value3");
+
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Map.Entry<String, String>> first = new AtomicReference<>();
+        AtomicReference<Map.Entry<String, String>> second = new AtomicReference<>();
+
+        Thread t1 =
+                new Thread(
+                        () -> {
+                            await(start);
+                            first.set(map.rotateFirstEntry());
+                        });
+        Thread t2 =
+                new Thread(
+                        () -> {
+                            await(start);
+                            second.set(map.rotateFirstEntry());
+                        });
+
+        t1.start();
+        t2.start();
+        start.countDown();
+        t1.join();
+        t2.join();
+
+        Set<String> returned = Set.of(first.get().getKey(), second.get().getKey());
+        assertEquals(Set.of("key1", "key2"), returned);
+
+        Iterator<String> iterator = map.keySet().iterator();
+        assertEquals("key3", iterator.next());
+        assertEquals("key1", iterator.next());
+        assertEquals("key2", iterator.next());
+    }
+
+    @Test
+    void testSingleKeyConcurrentRotationsNeverReturnNull() throws Exception {
+        map.put("key1", "value1");
+
+        int threads = 2;
+        int iterations = 5_000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        List<Future<?>> futures = new ArrayList<>();
+        for (int t = 0; t < threads; t++) {
+            futures.add(
+                    pool.submit(
+                            () -> {
+                                for (int i = 0; i < iterations; i++) {
+                                    assertNotNull(map.rotateFirstEntry());
+                                }
+                            }));
+        }
+        for (Future<?> f : futures) {
+            f.get();
+        }
+        pool.shutdown();
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    void testGetNeverNullWhileRotating() throws Exception {
+        for (int i = 0; i < 8; i++) {
+            map.put("key" + i, "value" + i);
+        }
+        AtomicBoolean running = new AtomicBoolean(true);
+        Thread rotator =
+                new Thread(
+                        () -> {
+                            while (running.get()) {
+                                map.rotateFirstEntry();
+                            }
+                        });
+        rotator.start();
+        try {
+            for (int pass = 0; pass < 100_000; pass++) {
+                assertNotNull(map.get("key" + (pass % 8)));
+            }
+        } finally {
+            running.set(false);
+            rotator.join();
+        }
+    }
+
+    @Test
+    void testConcurrentRotateRemoveAndRecreateKeepsOneLiveEntryPerKey()
+            throws InterruptedException {
+        int keyCount = 8;
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < keyCount; i++) {
+            String key = "key" + i;
+            keys.add(key);
+            map.put(key, "value" + i);
+        }
+
+        AtomicBoolean running = new AtomicBoolean(true);
+        AtomicBoolean rotateReturnedNull = new AtomicBoolean(false);
+
+        Thread rotator =
+                new Thread(
+                        () -> {
+                            while (running.get()) {
+                                if (map.rotateFirstEntry() == null) {
+                                    rotateReturnedNull.set(true);
+                                }
+                            }
+                        });
+        Thread recreator =
+                new Thread(
+                        () -> {
+                            for (int i = 0; i < 10_000; i++) {
+                                String key = keys.get(i % keys.size());
+                                map.remove(key);
+                                map.putIfAbsent(key, "recreated-" + i);
+                            }
+                        });
+
+        rotator.start();
+        recreator.start();
+        recreator.join();
+        running.set(false);
+        rotator.join();
+
+        assertFalse(rotateReturnedNull.get(), "rotation returned null while the map stayed live");
+        assertEquals(keyCount, map.size());
+
+        Set<String> fromEntrySet = new HashSet<>();
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            assertTrue(
+                    fromEntrySet.add(entry.getKey()),
+                    "duplicate ordered entry for " + entry.getKey());
+        }
+
+        assertEquals(keyCount, fromEntrySet.size());
+        for (String key : keys) {
+            assertTrue(fromEntrySet.contains(key));
+            assertNotNull(map.get(key));
+        }
+    }
+
+    private static void await(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/GetURLsReservationTest.java
@@ -96,6 +96,70 @@ class GetURLsReservationTest {
         }
     }
 
+    static class SelfDeletingQueue implements QueueInterface {
+        private final MemoryFrontierService service;
+        private final QueueWithinCrawl qwc;
+        private final AtomicBoolean removed = new AtomicBoolean();
+        private volatile long lastProduced;
+
+        SelfDeletingQueue(MemoryFrontierService service, QueueWithinCrawl qwc) {
+            this.service = service;
+            this.qwc = qwc;
+        }
+
+        @Override
+        public long getBlockedUntil() {
+            if (removed.compareAndSet(false, true)) {
+                service.getQueues().remove(qwc);
+            }
+            return Long.MAX_VALUE;
+        }
+
+        @Override
+        public int getDelay() {
+            return 0;
+        }
+
+        @Override
+        public void setLastProduced(long lastProduced) {
+            this.lastProduced = lastProduced;
+        }
+
+        @Override
+        public long getLastProduced() {
+            return lastProduced;
+        }
+
+        @Override
+        public int getInProcess(long now) {
+            return 0;
+        }
+
+        @Override
+        public int getCountCompleted() {
+            return 0;
+        }
+
+        @Override
+        public int countActive() {
+            return 0;
+        }
+
+        @Override
+        public Boolean isLimitReached() {
+            return false;
+        }
+
+        @Override
+        public void setDelay(int delayRequestable) {}
+
+        @Override
+        public void setBlockedUntil(long until) {}
+
+        @Override
+        public void setCrawlLimit(int crawlLimit) {}
+    }
+
     /** Seeds two due URLs into KEY/CRAWL_ID and returns the queue with its delay set to 300s. */
     static QueueInterface seedQueue(InstrumentedMemoryService service) throws Exception {
         AtomicBoolean done = new AtomicBoolean(false);
@@ -298,6 +362,21 @@ class GetURLsReservationTest {
                 0,
                 service.sendInvocations.get(),
                 "a queue past its crawl limit must not be served on the keyed path");
+    }
+
+    @Test
+    void rotationPathHandlesQueueDeletedBetweenIterations() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        QueueWithinCrawl qwc = QueueWithinCrawl.get(KEY, CRAWL_ID);
+        service.getQueues().put(qwc, new SelfDeletingQueue(service, qwc));
+
+        GetParams request =
+                GetParams.newBuilder().setMaxUrlsPerQueue(1).setDelayRequestable(30).build();
+        CollectingObserver observer = new CollectingObserver();
+
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> service.getURLs(request, observer));
+        assertTrue(observer.completed.await(5, TimeUnit.SECONDS));
+        assertEquals(0, observer.received.get());
     }
 
     @Test

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
@@ -11,11 +11,14 @@ import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
 import crawlercommons.urlfrontier.service.memory.URLQueue;
 import io.grpc.stub.StreamObserver;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -152,6 +155,112 @@ class MemoryFrontierServiceConcurrencyTest {
         if (failure.get() != null) {
             fail(failure.get());
         }
+    }
+
+    @Test
+    void purgeNeverDeletesUrlsRefreshedDuringThePurge() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+
+        long future = Instant.now().getEpochSecond() + 3600;
+        for (int i = 0; i < 200; i++) {
+            putOne(service, known("https://example.com/stale-" + i, future));
+        }
+        // creation dates have second resolution: make the seeds strictly older than the cutoff
+        Thread.sleep(1100);
+
+        int refreshedCount = 20;
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread refresher =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                for (int round = 0; round < 30; round++) {
+                                    for (int i = 0; i < refreshedCount; i++) {
+                                        putOne(
+                                                service,
+                                                known("https://example.com/stale-" + i, future));
+                                    }
+                                }
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            }
+                        });
+
+        Thread purger =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                service.purgeURLs(
+                                        PurgeUrlParams.newBuilder()
+                                                .setCrawlID(CRAWL_ID)
+                                                .setKey(KEY)
+                                                .setDays(0)
+                                                .build(),
+                                        new StreamObserver<>() {
+                                            @Override
+                                            public void onNext(
+                                                    crawlercommons.urlfrontier.Urlfrontier.Long
+                                                            value) {}
+
+                                            @Override
+                                            public void onError(Throwable t) {
+                                                failure.compareAndSet(null, t);
+                                            }
+
+                                            @Override
+                                            public void onCompleted() {}
+                                        });
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            }
+                        });
+
+        refresher.start();
+        purger.start();
+        start.countDown();
+        refresher.join();
+        purger.join();
+
+        if (failure.get() != null) {
+            fail(failure.get());
+        }
+
+        // every refreshed URL was re-put with a creation date at or after the purge cutoff:
+        // with scan+delete atomic per queue none of them may end up deleted
+        for (int i = 0; i < refreshedCount; i++) {
+            assertTrue(
+                    urlIsKnown(service, "https://example.com/stale-" + i),
+                    "URL refreshed during the purge was deleted: stale-" + i);
+        }
+    }
+
+    private static boolean urlIsKnown(MemoryFrontierService service, String url) throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicBoolean found = new AtomicBoolean(false);
+        service.getURLStatus(
+                URLStatusRequest.newBuilder().setUrl(url).setKey(KEY).setCrawlID(CRAWL_ID).build(),
+                new StreamObserver<>() {
+                    @Override
+                    public void onNext(URLItem value) {
+                        found.set(true);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        done.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        done.countDown();
+                    }
+                });
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        return found.get();
     }
 
     private static URLItem discovered(String url) {

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
@@ -1,0 +1,138 @@
+// SPDX-FileCopyrightText: 2026 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class MemoryFrontierServiceConcurrencyTest {
+
+    private static final String CRAWL_ID = "crawl_id";
+    private static final String KEY = "queue_mysite";
+
+    @Test
+    void urlIteratorSnapshotSurvivesConcurrentQueueMutation() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        for (int i = 0; i < 50; i++) {
+            putOne(service, discovered("https://example.com/seed-" + i));
+        }
+
+        Map.Entry<QueueWithinCrawl, QueueInterface> entry =
+                service.getQueues().entrySet().iterator().next();
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread writer =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                for (int i = 0; i < 200; i++) {
+                                    putOne(service, discovered("https://example.com/live-" + i));
+                                }
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            } finally {
+                                running.set(false);
+                            }
+                        });
+        writer.start();
+        start.countDown();
+
+        try {
+            while (running.get()) {
+                try (CloseableIterator<URLItem> iterator = service.urlIterator(entry)) {
+                    while (iterator.hasNext()) {
+                        iterator.next();
+                    }
+                }
+            }
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+
+        writer.join();
+        if (failure.get() != null) {
+            fail(failure.get());
+        }
+    }
+
+    private static URLItem discovered(String url) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(CRAWL_ID).setKey(KEY).build();
+        return URLItem.newBuilder()
+                .setID(CRAWL_ID + "_" + url)
+                .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                .build();
+    }
+
+    private static URLItem known(String url, long nextFetchDate) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(CRAWL_ID).setKey(KEY).build();
+        return URLItem.newBuilder()
+                .setID(CRAWL_ID + "_" + url)
+                .setKnown(
+                        KnownURLItem.newBuilder()
+                                .setInfo(info)
+                                .setRefetchableFromDate(nextFetchDate)
+                                .build())
+                .build();
+    }
+
+    private static void putOneAfterStart(
+            MemoryFrontierService service,
+            URLItem item,
+            CountDownLatch start,
+            AtomicReference<Throwable> failure) {
+        try {
+            start.await();
+            putOne(service, item);
+        } catch (Throwable t) {
+            failure.compareAndSet(null, t);
+        }
+    }
+
+    private static void putOne(MemoryFrontierService service, URLItem item) {
+        AtomicBoolean completed = new AtomicBoolean(false);
+        AtomicInteger acked = new AtomicInteger();
+
+        StreamObserver<URLItem> stream =
+                service.putURLs(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                completed.set(true);
+                                fail(t);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                completed.set(true);
+                            }
+                        });
+
+        stream.onNext(item);
+        stream.onCompleted();
+        ServiceTestUtil.awaitStreamClosed(completed);
+        assertEquals(1, acked.get());
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
@@ -4,17 +4,21 @@
 package crawlercommons.urlfrontier.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
 import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import crawlercommons.urlfrontier.service.memory.URLQueue;
 import io.grpc.stub.StreamObserver;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -24,6 +28,83 @@ class MemoryFrontierServiceConcurrencyTest {
 
     private static final String CRAWL_ID = "crawl_id";
     private static final String KEY = "queue_mysite";
+
+    @Test
+    void concurrentPutUrlsOnANewKeyCreatesOneQueueAndKeepsBothUrls() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread t1 =
+                new Thread(
+                        () ->
+                                putOneAfterStart(
+                                        service,
+                                        discovered("https://example.com/a"),
+                                        start,
+                                        failure));
+        Thread t2 =
+                new Thread(
+                        () ->
+                                putOneAfterStart(
+                                        service,
+                                        discovered("https://example.com/b"),
+                                        start,
+                                        failure));
+
+        t1.start();
+        t2.start();
+        start.countDown();
+        t1.join();
+        t2.join();
+
+        if (failure.get() != null) {
+            fail(failure.get());
+        }
+
+        assertEquals(1, service.getQueues().size());
+        assertEquals(2, ServiceTestUtil.countAllURLs(service));
+        URLQueue queue = (URLQueue) service.getQueues().get(QueueWithinCrawl.get(KEY, CRAWL_ID));
+        assertEquals(2, queue.countActive());
+    }
+
+    @Test
+    void knownNeverUrlOnFreshQueueStartsCompletedAndIsNotServed() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        putOne(service, known("https://example.com/completed", 0));
+
+        URLQueue queue = (URLQueue) service.getQueues().get(QueueWithinCrawl.get(KEY, CRAWL_ID));
+        assertEquals(0, queue.countActive());
+        assertEquals(1, queue.getCountCompleted());
+
+        AtomicInteger received = new AtomicInteger();
+        CountDownLatch completed = new CountDownLatch(1);
+        service.getURLs(
+                GetParams.newBuilder()
+                        .setKey(KEY)
+                        .setCrawlID(CRAWL_ID)
+                        .setMaxUrlsPerQueue(1)
+                        .build(),
+                new StreamObserver<>() {
+                    @Override
+                    public void onNext(crawlercommons.urlfrontier.Urlfrontier.URLInfo value) {
+                        received.incrementAndGet();
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        completed.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        completed.countDown();
+                    }
+                });
+
+        assertTrue(completed.await(5, TimeUnit.SECONDS));
+        assertEquals(0, received.get());
+    }
 
     @Test
     void urlIteratorSnapshotSurvivesConcurrentQueueMutation() throws Exception {

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -1127,4 +1127,27 @@ class RocksDBServiceTest {
                 QueueWithinCrawlParams.newBuilder().setCrawlID("crawl_id").build();
         rocksDBService.getStats(qwcp, statsObserver);
     }
+
+    @Test
+    @Order(94)
+    void testDeleteUnknownURLItemIsANoOp() {
+        // a URL whose entries are already gone (never put, or wiped by a concurrent
+        // deleteCrawl range delete) must not blow up the delete path
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://unknown.invalid/nowhere")
+                        .setKey("queue_unknown")
+                        .setCrawlID("crawl_id")
+                        .build();
+        URLItem item =
+                URLItem.newBuilder()
+                        .setKnown(
+                                KnownURLItem.newBuilder()
+                                        .setInfo(info)
+                                        .setRefetchableFromDate(0)
+                                        .build())
+                        .build();
+
+        rocksDBService.deleteURLItem(item);
+    }
 }


### PR DESCRIPTION
Seven call sites wrap work in `synchronized (getQueues())`, which reads as "hold a lock over the queues map". `ConcurrentOrderedMap` never honoured that monitor: its mutators take Guava stripe locks, its readers take nothing, so the blocks only excluded each other. Two concrete consequences beyond the false sense of safety:

* the `getURLs` rotation (`pollFirstEntry` + `put`) removes the mapping and re-inserts it, so for a moment the queue is absent from the map — a concurrent RocksDB `putURLItem.computeIfAbsent` can slot in a fresh `QueueMetadata` with zeroed counters and have it clobbered;
* nothing stops `deleteQueue`/`deleteCrawl` from emptying the map mid-rotation, which is the NPE reported in #171.

## The contract, made real

**Rotation is now a map primitive.** `rotateFirstEntry()` moves the head to the tail *in place*: only the position in the order index changes, the mapping never leaves the value map, so no reader can ever observe the key as absent. Two mechanisms, covering two distinct races:

* a private `orderMutationLock` (shared with `pollFirstEntry`) serializes head extraction — without it, two rotations on a single-queue frontier can interleave so one returns `null` while the map is live;
* the insertion-order number doubles as a version stamp, checked under the key's stripe. The lock cannot exclude `remove`/`putIfAbsent` (they take only stripes), and without the stamp a remove-and-re-add between the order-index poll and the stripe acquisition leaves two order entries pointing at one key, which later surfaces as spurious `null`s. `pollFirstEntry` had this exact bug and gets the same guard; `clear()` no longer resets the counter so stamps are never reused.

**Admin scans get a completeness guarantee.** Ordered iteration walks the order index and can miss a key that rotates while the iterator is in flight. Crawl deletion, purge and the shutdown stats write need "every queue currently in the map", not insertion order, so they now iterate a new `unorderedEntries()` view backed by the value map — which rotation cannot perturb. It is a live view, not a copy: a materialised snapshot view was removed in b3e1a6d for causing OOM on getStats, and this deliberately does not bring it back. `listURLs`/`countURLs` keep ordered iteration, where pagination stability matters more than completeness.

**The memory backend locks what it actually mutates.** `putURLItem` uses `putIfAbsent` for the get-or-create race and fully forms new queues *before* publication (a known-completed URL can never be observed in its seeded intermediate state); mutations synchronize on the queue object, the same monitor `tryReserveQueue` already uses. `MemoryURLItemIterator` snapshots the active URLs under that monitor — one queue at a time — instead of wrapping the raw fail-fast `PriorityQueue` iterator, which `listURLs`/`countURLs` were already racing against writers. Purge delegates its per-queue scan+delete to a `purgeQueue` hook that the memory backend wraps in the queue monitor: `InternalURL` equality is by URL only, so without that atomicity a URL refreshed after the purge decision would be deleted by its stale predecessor's delete.

**One exclusion the old monitor did provide is preserved differently.** RocksDB `deleteURLItem` and `deleteLocalCrawl` really were mutually exclusive through the shared monitor. Rather than reintroduce a lock, `deleteURLItem` now treats missing entries (already wiped by a concurrent range delete) as "nothing left to delete" instead of throwing NPEs that escape its `RocksDBException` handler.

## Notes for review

* Behavioural delta in `getURLs`: the wrap-around sentinel is now checked *after* rotating, so on wrap the sentinel queue takes one extra trip to the tail. The sentinel is a per-request scan bound, already best-effort under concurrent requests.
* Lock ordering is one-directional: `orderMutationLock` → stripe inside the map; queue monitor → stripe at the call sites; nothing acquires a queue monitor while holding a stripe.
* `writeQueueInfos` runs only from `close()`; with the unordered view it sees every queue even under concurrent rotation, while counts racing an in-flight delete may be off by that delta — as they already were with puts.
* The commits are ordered for review: the two map primitives, then `getURLs`, then the memory backend (snapshot before locking, so no intermediate state exposes the purge scan), then the monitor removals, then the RocksDB delete guard.

Tests: deterministic regression for the #171 NPE (fails on master), a reproducible CME for the unlocked iterator (fails on master), rotation/ABA/completeness hammers on the map, characterization tests pinning what the old monitor guaranteed (concurrent queue creation, prepare-then-publish, purge-vs-refresh), and a deterministic guard for the RocksDB delete path.

The one queue-content reader still outside the contract is the memory `sendURLsForQueue` iteration — pre-existing, and it cannot simply take the queue monitor because `onNext` may block on flow control (#192). Filed separately as #194.

Closes #172
Closes #171
