### PR TITLE
Fix NPEs on the delete paths for deleteQueue and deleteCrawl (#165)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -279,7 +279,9 @@ public abstract class AbstractFrontierService
 
             for (QueueWithinCrawl quid : toDelete) {
                 QueueInterface q = getQueues().remove(quid);
-                total += q.countActive();
+                if (q != null) {
+                    total += q.countActive();
+                }
             }
         }
         responseObserver.onNext(
@@ -447,7 +449,9 @@ public abstract class AbstractFrontierService
         if (!isClosing()) {
             QueueWithinCrawl qwc = QueueWithinCrawl.get(request.getKey(), request.getCrawlID());
             QueueInterface q = getQueues().remove(qwc);
-            countActive = q.countActive();
+            if (q != null) {
+                countActive = q.countActive();
+            }
         }
         responseObserver.onNext(
                 crawlercommons.urlfrontier.Urlfrontier.Long.newBuilder()


### PR DESCRIPTION
Fixes NPEs on the delete paths for deleteQueue and deleteCrawl 
The two other issues mentionned in #165 were already fixed:

Point 3: RocksDBService.deleteURLItem has already been fixed in commit https://github.com/crawler-commons/url-frontier/commit/53d3a1554779418e091c6f1015d5f06b876adada
Point 4: NPE inside the error handlers of deleteLocalQueue / deleteLocalCrawl fixed by commit https://github.com/crawler-commons/url-frontier/commit/3541d64e452eca8649bd1bc7447437fb53c278b2