### PR TITLE
Fix addToConfig (#177)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -47,7 +47,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -160,30 +159,28 @@ public abstract class AbstractFrontierService
         final int availableProcessor = Runtime.getRuntime().availableProcessors();
         LOG.info("Available processor(s) {}", availableProcessor);
         // by default uses 1/4 of the available processors
-        final Integer defaultParallelism = Math.max(availableProcessor / 4, 1);
+        final int defaultParallelism = Math.max(availableProcessor / 4, 1);
 
         final int rthreadNum =
                 ParamHelper.getIntegerParameter(
-                        configuration, "read.thread.num", Optional.of(defaultParallelism));
+                        configuration, "read.thread.num", defaultParallelism);
         LOG.info("Using {} threads for reading from queues", rthreadNum);
         readExecutorService = Executors.newFixedThreadPool(rthreadNum);
 
         final int wthreadNum =
                 ParamHelper.getIntegerParameter(
-                        configuration, "write.thread.num", Optional.of(defaultParallelism));
+                        configuration, "write.thread.num", defaultParallelism);
         writeExecutorService = Executors.newFixedThreadPool(wthreadNum);
         LOG.info("Using {} threads for writing to queues", wthreadNum);
 
         putURLsMaxInFlight =
-                ParamHelper.getIntegerParameter(
-                        configuration, "putURLs.max.inflight", Optional.of(1024));
+                ParamHelper.getIntegerParameter(configuration, "putURLs.max.inflight", 1024);
         if (putURLsMaxInFlight > 0) {
             LOG.info("Limiting putURLs streams to {} URLs in flight", putURLsMaxInFlight);
         }
 
         putDiscoveredMaxInFlight =
-                ParamHelper.getIntegerParameter(
-                        configuration, "putDiscovered.max.inflight", Optional.of(16));
+                ParamHelper.getIntegerParameter(configuration, "putDiscovered.max.inflight", 16);
         if (putDiscoveredMaxInFlight > 0) {
             LOG.info(
                     "Limiting putDiscovered streams to {} batches in flight",

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -160,22 +160,37 @@ public abstract class AbstractFrontierService
         LOG.info("Available processor(s) {}", availableProcessor);
         // by default uses 1/4 of the available processors
         final String defaultParallelism = Integer.toString(Math.max(availableProcessor / 4, 1));
+        final String sReadThreads = configuration.get("read.thread.num");
         final int rthreadNum =
-                Integer.parseInt(configuration.getOrDefault("read.thread.num", defaultParallelism));
+                Integer.parseInt(
+                        sReadThreads != null && !sReadThreads.isEmpty()
+                                ? sReadThreads
+                                : defaultParallelism);
         LOG.info("Using {} threads for reading from queues", rthreadNum);
         readExecutorService = Executors.newFixedThreadPool(rthreadNum);
+        final String sWriteThreads = configuration.get("write.thread.num");
         final int wthreadNum =
                 Integer.parseInt(
-                        configuration.getOrDefault("write.thread.num", defaultParallelism));
+                        sWriteThreads != null && !sWriteThreads.isEmpty()
+                                ? sWriteThreads
+                                : defaultParallelism);
         writeExecutorService = Executors.newFixedThreadPool(wthreadNum);
         LOG.info("Using {} threads for writing to queues", wthreadNum);
+        final String sPutURLsMaxInFlight = configuration.get("putURLs.max.inflight");
         putURLsMaxInFlight =
-                Integer.parseInt(configuration.getOrDefault("putURLs.max.inflight", "1024"));
+                Integer.parseInt(
+                        sPutURLsMaxInFlight != null && !sPutURLsMaxInFlight.isEmpty()
+                                ? sPutURLsMaxInFlight
+                                : "1024");
         if (putURLsMaxInFlight > 0) {
             LOG.info("Limiting putURLs streams to {} URLs in flight", putURLsMaxInFlight);
         }
+        final String sPutDiscoveredMaxInFlight = configuration.get("putDiscovered.max.inflight");
         putDiscoveredMaxInFlight =
-                Integer.parseInt(configuration.getOrDefault("putDiscovered.max.inflight", "16"));
+                Integer.parseInt(
+                        sPutDiscoveredMaxInFlight != null && !sPutDiscoveredMaxInFlight.isEmpty()
+                                ? sPutDiscoveredMaxInFlight
+                                : "16");
         if (putDiscoveredMaxInFlight > 0) {
             LOG.info(
                     "Limiting putDiscovered streams to {} batches in flight",

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -159,38 +160,30 @@ public abstract class AbstractFrontierService
         final int availableProcessor = Runtime.getRuntime().availableProcessors();
         LOG.info("Available processor(s) {}", availableProcessor);
         // by default uses 1/4 of the available processors
-        final String defaultParallelism = Integer.toString(Math.max(availableProcessor / 4, 1));
-        final String sReadThreads = configuration.get("read.thread.num");
+        final Integer defaultParallelism = Math.max(availableProcessor / 4, 1);
+
         final int rthreadNum =
-                Integer.parseInt(
-                        sReadThreads != null && !sReadThreads.isEmpty()
-                                ? sReadThreads
-                                : defaultParallelism);
+                ParamHelper.getIntegerParameter(
+                        configuration, "read.thread.num", Optional.of(defaultParallelism));
         LOG.info("Using {} threads for reading from queues", rthreadNum);
         readExecutorService = Executors.newFixedThreadPool(rthreadNum);
-        final String sWriteThreads = configuration.get("write.thread.num");
+
         final int wthreadNum =
-                Integer.parseInt(
-                        sWriteThreads != null && !sWriteThreads.isEmpty()
-                                ? sWriteThreads
-                                : defaultParallelism);
+                ParamHelper.getIntegerParameter(
+                        configuration, "write.thread.num", Optional.of(defaultParallelism));
         writeExecutorService = Executors.newFixedThreadPool(wthreadNum);
         LOG.info("Using {} threads for writing to queues", wthreadNum);
-        final String sPutURLsMaxInFlight = configuration.get("putURLs.max.inflight");
+
         putURLsMaxInFlight =
-                Integer.parseInt(
-                        sPutURLsMaxInFlight != null && !sPutURLsMaxInFlight.isEmpty()
-                                ? sPutURLsMaxInFlight
-                                : "1024");
+                ParamHelper.getIntegerParameter(
+                        configuration, "putURLs.max.inflight", Optional.of(1024));
         if (putURLsMaxInFlight > 0) {
             LOG.info("Limiting putURLs streams to {} URLs in flight", putURLsMaxInFlight);
         }
-        final String sPutDiscoveredMaxInFlight = configuration.get("putDiscovered.max.inflight");
+
         putDiscoveredMaxInFlight =
-                Integer.parseInt(
-                        sPutDiscoveredMaxInFlight != null && !sPutDiscoveredMaxInFlight.isEmpty()
-                                ? sPutDiscoveredMaxInFlight
-                                : "16");
+                ParamHelper.getIntegerParameter(
+                        configuration, "putDiscovered.max.inflight", Optional.of(16));
         if (putDiscoveredMaxInFlight > 0) {
             LOG.info(
                     "Limiting putDiscovered streams to {} batches in flight",

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2025 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.LoggerFactory;
+
+/** Utility functions to retrieve and parse configuration parameters */
+public class ParamHelper {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(ParamHelper.class);
+
+    /**
+     * Retrieves and parses a configuration parameter using the provided parser function.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal An optional default value if the parameter is not set.
+     * @param parser Function to parse the string value to the target type.
+     * @param fallback Value to use if parameter is not set and no default provided.
+     * @param <T> The target type.
+     * @return The parsed parameter value, default value, or fallback.
+     */
+    private static <T> T parseParameter(
+            Map<String, String> config,
+            String paramName,
+            Optional<T> defaultVal,
+            java.util.function.Function<String, T> parser,
+            T fallback) {
+
+        String stringVal = config.get(paramName);
+
+        // defaultValue could potentially contain null but the public methods
+        // pass primitive types (int, long, double) or empty String so should not happen.
+        T val = (defaultVal != null) ? defaultVal.orElse(fallback) : fallback;
+        if (stringVal != null && !stringVal.isEmpty()) {
+            try {
+                val = parser.apply(stringVal);
+            } catch (NumberFormatException e) {
+                LOG.error(
+                        "Error parsing {} for config parameter {}",
+                        parser.getClass().getSimpleName(),
+                        paramName);
+                System.exit(-1);
+            }
+        }
+
+        return val;
+    }
+
+    /**
+     * Retrieves an integer configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal An optional default value if the parameter is not set.
+     * @return The integer parameter value if defined and parsable; otherwise the default value or
+     *     -1. Exits the program if the parameter value cannot be parsed as an integer.
+     */
+    public static int getIntegerParameter(
+            Map<String, String> config, String paramName, Optional<Integer> defaultVal) {
+        return parseParameter(config, paramName, defaultVal, Integer::parseInt, -1);
+    }
+
+    /**
+     * Retrieves a long configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal An optional default value if the parameter is not set.
+     * @return The long parameter value if defined and parsable; otherwise the default value or -1.
+     *     Exits the program if the parameter value cannot be parsed as a long.
+     */
+    public static long getLongParameter(
+            Map<String, String> config, String paramName, Optional<Long> defaultVal) {
+        return parseParameter(config, paramName, defaultVal, Long::parseLong, -1L);
+    }
+
+    /**
+     * Retrieves a double configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal An optional default value if the parameter is not set.
+     * @return The double parameter value if defined and parsable; otherwise the default value or
+     *     NaN. Exits the program if the parameter value cannot be parsed as a double.
+     */
+    public static double getDoubleParameter(
+            Map<String, String> config, String paramName, Optional<Double> defaultVal) {
+        return parseParameter(config, paramName, defaultVal, Double::parseDouble, Double.NaN);
+    }
+
+    /**
+     * Retrieves a string configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal An optional default value if the parameter is not set.
+     * @return The string parameter value if defined and non-empty; otherwise the default value if
+     *     provided (empty string if default is empty), or empty string if no default provided.
+     */
+    public static String getStringParameter(
+            Map<String, String> config, String paramName, Optional<String> defaultVal) {
+
+        return parseParameter(config, paramName, defaultVal, s -> s, "");
+    }
+
+    /**
+     * Retrieves a boolean configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal The default value if the parameter is not set.
+     * @return The boolean parameter value if defined; otherwise the default value. Empty string or
+     *     null values are treated as true.
+     */
+    public static boolean getBooleanParameter(
+            final Map<String, String> config, String paramName, boolean defaultVal) {
+        if (!config.containsKey(paramName)) {
+            return defaultVal;
+        } else {
+            String value = config.get(paramName);
+            return value == null || value.isEmpty() || Boolean.parseBoolean(value);
+        }
+    }
+}

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
@@ -4,55 +4,15 @@
 package crawlercommons.urlfrontier.service;
 
 import java.util.Map;
-import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
-import java.util.function.Function;
-import org.slf4j.LoggerFactory;
 
 /** Utility functions to retrieve and parse configuration parameters. */
 public final class ParamHelper {
 
     private ParamHelper() {
         // utility class
-    }
-
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(ParamHelper.class);
-
-    /**
-     * Retrieves and parses a configuration parameter using the provided parser function.
-     *
-     * @param config The configuration map holding parameter names and values.
-     * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal An optional default value if the parameter is not set.
-     * @param parser Function to parse the string value to the target type.
-     * @param fallback Value to use if parameter is not set and no default provided.
-     * @param <T> The target type.
-     * @return The parsed parameter value, default value, or fallback.
-     * @throws IllegalArgumentException if the config value cannot be parsed.
-     */
-    private static <T> T parseParameter(
-            Map<String, String> config,
-            String paramName,
-            Optional<T> defaultVal,
-            Function<String, T> parser,
-            T fallback) {
-
-        String stringVal = config.get(paramName);
-
-        T val = defaultVal.orElse(fallback);
-        if (stringVal != null && !stringVal.isEmpty()) {
-            try {
-                val = parser.apply(stringVal);
-            } catch (NumberFormatException e) {
-                LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
-                throw new IllegalArgumentException(
-                        "Cannot parse value '" + stringVal + "' for config parameter " + paramName,
-                        e);
-            }
-        }
-
-        return val;
     }
 
     /**
@@ -71,7 +31,6 @@ public final class ParamHelper {
         try {
             return OptionalInt.of(Integer.parseInt(stringVal));
         } catch (NumberFormatException e) {
-            LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
             throw new IllegalArgumentException(
                     "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
         }
@@ -107,7 +66,6 @@ public final class ParamHelper {
         try {
             return OptionalLong.of(Long.parseLong(stringVal));
         } catch (NumberFormatException e) {
-            LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
             throw new IllegalArgumentException(
                     "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
         }
@@ -132,14 +90,43 @@ public final class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
+     * @return An OptionalDouble containing the parsed value if the parameter is set and non-empty;
+     *     empty otherwise. Throws IllegalArgumentException if the value cannot be parsed.
+     */
+    public static OptionalDouble getDoubleParameter(Map<String, String> config, String paramName) {
+        String stringVal = config.get(paramName);
+        if (stringVal == null || stringVal.isEmpty()) {
+            return OptionalDouble.empty();
+        }
+        try {
+            return OptionalDouble.of(Double.parseDouble(stringVal));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
+        }
+    }
+
+    /**
+     * Retrieves a double configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
      * @param defaultVal The default value if the parameter is not set or empty.
      * @return The double parameter value if defined and parsable; otherwise the default value.
      * @throws IllegalArgumentException if the parameter value cannot be parsed as a double.
      */
     public static double getDoubleParameter(
             Map<String, String> config, String paramName, double defaultVal) {
-        return parseParameter(
-                config, paramName, Optional.of(defaultVal), Double::parseDouble, Double.NaN);
+        String stringVal = config.get(paramName);
+        if (stringVal == null || stringVal.isEmpty()) {
+            return defaultVal;
+        }
+        try {
+            return Double.parseDouble(stringVal);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
+        }
     }
 
     /**

--- a/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/ParamHelper.java
@@ -1,14 +1,21 @@
-// SPDX-FileCopyrightText: 2025 Crawler-commons
+// SPDX-FileCopyrightText: 2026 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.function.Function;
 import org.slf4j.LoggerFactory;
 
-/** Utility functions to retrieve and parse configuration parameters */
-public class ParamHelper {
+/** Utility functions to retrieve and parse configuration parameters. */
+public final class ParamHelper {
+
+    private ParamHelper() {
+        // utility class
+    }
 
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(ParamHelper.class);
 
@@ -22,28 +29,26 @@ public class ParamHelper {
      * @param fallback Value to use if parameter is not set and no default provided.
      * @param <T> The target type.
      * @return The parsed parameter value, default value, or fallback.
+     * @throws IllegalArgumentException if the config value cannot be parsed.
      */
     private static <T> T parseParameter(
             Map<String, String> config,
             String paramName,
             Optional<T> defaultVal,
-            java.util.function.Function<String, T> parser,
+            Function<String, T> parser,
             T fallback) {
 
         String stringVal = config.get(paramName);
 
-        // defaultValue could potentially contain null but the public methods
-        // pass primitive types (int, long, double) or empty String so should not happen.
-        T val = (defaultVal != null) ? defaultVal.orElse(fallback) : fallback;
+        T val = defaultVal.orElse(fallback);
         if (stringVal != null && !stringVal.isEmpty()) {
             try {
                 val = parser.apply(stringVal);
             } catch (NumberFormatException e) {
-                LOG.error(
-                        "Error parsing {} for config parameter {}",
-                        parser.getClass().getSimpleName(),
-                        paramName);
-                System.exit(-1);
+                LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
+                throw new IllegalArgumentException(
+                        "Cannot parse value '" + stringVal + "' for config parameter " + paramName,
+                        e);
             }
         }
 
@@ -55,13 +60,35 @@ public class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal An optional default value if the parameter is not set.
-     * @return The integer parameter value if defined and parsable; otherwise the default value or
-     *     -1. Exits the program if the parameter value cannot be parsed as an integer.
+     * @return An OptionalInt containing the parsed value if the parameter is set and non-empty;
+     *     empty otherwise. Throws IllegalArgumentException if the value cannot be parsed.
+     */
+    public static OptionalInt getIntegerParameter(Map<String, String> config, String paramName) {
+        String stringVal = config.get(paramName);
+        if (stringVal == null || stringVal.isEmpty()) {
+            return OptionalInt.empty();
+        }
+        try {
+            return OptionalInt.of(Integer.parseInt(stringVal));
+        } catch (NumberFormatException e) {
+            LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
+            throw new IllegalArgumentException(
+                    "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
+        }
+    }
+
+    /**
+     * Retrieves an integer configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal The default value if the parameter is not set or empty.
+     * @return The integer parameter value if defined and parsable; otherwise the default value.
+     * @throws IllegalArgumentException if the parameter value cannot be parsed as an integer.
      */
     public static int getIntegerParameter(
-            Map<String, String> config, String paramName, Optional<Integer> defaultVal) {
-        return parseParameter(config, paramName, defaultVal, Integer::parseInt, -1);
+            Map<String, String> config, String paramName, int defaultVal) {
+        return getIntegerParameter(config, paramName).orElse(defaultVal);
     }
 
     /**
@@ -69,13 +96,35 @@ public class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal An optional default value if the parameter is not set.
-     * @return The long parameter value if defined and parsable; otherwise the default value or -1.
-     *     Exits the program if the parameter value cannot be parsed as a long.
+     * @return An OptionalLong containing the parsed value if the parameter is set and non-empty;
+     *     empty otherwise. Throws IllegalArgumentException if the value cannot be parsed.
+     */
+    public static OptionalLong getLongParameter(Map<String, String> config, String paramName) {
+        String stringVal = config.get(paramName);
+        if (stringVal == null || stringVal.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        try {
+            return OptionalLong.of(Long.parseLong(stringVal));
+        } catch (NumberFormatException e) {
+            LOG.error("Cannot parse value '{}' for config parameter {}", stringVal, paramName);
+            throw new IllegalArgumentException(
+                    "Cannot parse value '" + stringVal + "' for config parameter " + paramName, e);
+        }
+    }
+
+    /**
+     * Retrieves a long configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal The default value if the parameter is not set or empty.
+     * @return The long parameter value if defined and parsable; otherwise the default value.
+     * @throws IllegalArgumentException if the parameter value cannot be parsed as a long.
      */
     public static long getLongParameter(
-            Map<String, String> config, String paramName, Optional<Long> defaultVal) {
-        return parseParameter(config, paramName, defaultVal, Long::parseLong, -1L);
+            Map<String, String> config, String paramName, long defaultVal) {
+        return getLongParameter(config, paramName).orElse(defaultVal);
     }
 
     /**
@@ -83,13 +132,14 @@ public class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal An optional default value if the parameter is not set.
-     * @return The double parameter value if defined and parsable; otherwise the default value or
-     *     NaN. Exits the program if the parameter value cannot be parsed as a double.
+     * @param defaultVal The default value if the parameter is not set or empty.
+     * @return The double parameter value if defined and parsable; otherwise the default value.
+     * @throws IllegalArgumentException if the parameter value cannot be parsed as a double.
      */
     public static double getDoubleParameter(
-            Map<String, String> config, String paramName, Optional<Double> defaultVal) {
-        return parseParameter(config, paramName, defaultVal, Double::parseDouble, Double.NaN);
+            Map<String, String> config, String paramName, double defaultVal) {
+        return parseParameter(
+                config, paramName, Optional.of(defaultVal), Double::parseDouble, Double.NaN);
     }
 
     /**
@@ -97,14 +147,25 @@ public class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal An optional default value if the parameter is not set.
-     * @return The string parameter value if defined and non-empty; otherwise the default value if
-     *     provided (empty string if default is empty), or empty string if no default provided.
+     * @return The string parameter value if defined and non-empty; otherwise empty string.
+     */
+    public static String getStringParameter(Map<String, String> config, String paramName) {
+        String stringVal = config.get(paramName);
+        return (stringVal != null && !stringVal.isEmpty()) ? stringVal : "";
+    }
+
+    /**
+     * Retrieves a string configuration parameter from the map.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal The default value if the parameter is not set or empty.
+     * @return The string parameter value if defined and non-empty; otherwise the default value.
      */
     public static String getStringParameter(
-            Map<String, String> config, String paramName, Optional<String> defaultVal) {
-
-        return parseParameter(config, paramName, defaultVal, s -> s, "");
+            Map<String, String> config, String paramName, String defaultVal) {
+        String stringVal = config.get(paramName);
+        return (stringVal != null && !stringVal.isEmpty()) ? stringVal : defaultVal;
     }
 
     /**
@@ -112,17 +173,39 @@ public class ParamHelper {
      *
      * @param config The configuration map holding parameter names and values.
      * @param paramName The name of the configuration parameter to retrieve.
-     * @param defaultVal The default value if the parameter is not set.
-     * @return The boolean parameter value if defined; otherwise the default value. Empty string or
-     *     null values are treated as true.
+     * @param defaultVal The default value if the parameter is not set, null, or empty.
+     * @return The boolean parameter value if defined and non-empty; otherwise the default value.
      */
     public static boolean getBooleanParameter(
             final Map<String, String> config, String paramName, boolean defaultVal) {
         if (!config.containsKey(paramName)) {
             return defaultVal;
-        } else {
-            String value = config.get(paramName);
-            return value == null || value.isEmpty() || Boolean.parseBoolean(value);
         }
+        String value = config.get(paramName);
+        if (value == null || value.isEmpty()) {
+            return defaultVal;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Retrieves a flag-style configuration parameter from the map. Flag-style keys are those where
+     * the mere presence of the key (with no value or an empty value) means "true". Used for legacy
+     * config keys like {@code rocksdb.bloom.filters} and {@code rocksdb.wal.disable} which
+     * historically were set as bare keys without a value.
+     *
+     * @param config The configuration map holding parameter names and values.
+     * @param paramName The name of the configuration parameter to retrieve.
+     * @param defaultVal The default value if the parameter is not present.
+     * @return {@code true} if the key is present (even with null or empty value), or if the value
+     *     is "true"; otherwise the result of {@link Boolean#parseBoolean(String)} or the default.
+     */
+    public static boolean getFlagParameter(
+            final Map<String, String> config, String paramName, boolean defaultVal) {
+        if (!config.containsKey(paramName)) {
+            return defaultVal;
+        }
+        String value = config.get(paramName);
+        return value == null || value.isEmpty() || Boolean.parseBoolean(value);
     }
 }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -98,10 +99,16 @@ public class URLFrontierServer implements Callable<Integer> {
         return 0;
     }
 
+    /**
+     * @throws Exception
+     */
+    /**
+     * @throws Exception
+     */
+    /**
+     * @throws Exception
+     */
     public void start() throws Exception {
-
-        // default implementation
-        String implementationClassName = RocksDBService.class.getName();
 
         Map<String, String> configuration = new HashMap<>();
 
@@ -127,7 +134,9 @@ public class URLFrontierServer implements Callable<Integer> {
                 // populate the config with the content of the file
                 for (String line : Files.readAllLines(Paths.get(config))) {
                     line = line.trim();
-                    if (line.startsWith("#")) continue;
+                    if (line.startsWith("#")) {
+                        continue;
+                    }
                     addToConfig(configuration, line);
                 }
             } catch (Exception e) {
@@ -143,22 +152,12 @@ public class URLFrontierServer implements Callable<Integer> {
             }
         }
 
-        // Validate known numeric config keys so errors name the offending key at startup
-        validateNumericConfig(
-                configuration,
-                LOG,
-                "read.thread.num",
-                "write.thread.num",
-                "putURLs.max.inflight",
-                "putDiscovered.max.inflight",
-                "rocksdb.max_background_jobs",
-                "rocksdb.max_subcompactions");
-
-        // get the implementation class from the config if set (ignore empty/flag-style values)
-        String impl = configuration.get("implementation");
-        if (impl != null && !impl.isEmpty()) {
-            implementationClassName = impl;
-        }
+        // Get the implementation class from the config if set (default is RocksDBService)
+        String implementationClassName =
+                ParamHelper.getStringParameter(
+                        configuration,
+                        "implementation",
+                        Optional.of(RocksDBService.class.getName()));
 
         Class<?> implementationClass = Class.forName(implementationClassName);
 
@@ -264,24 +263,6 @@ public class URLFrontierServer implements Callable<Integer> {
     private void blockUntilShutdown() throws InterruptedException {
         if (server != null) {
             server.awaitTermination();
-        }
-    }
-
-    /** Validate that known numeric config keys hold parseable integer values. */
-    private static void validateNumericConfig(
-            final Map<String, String> configuration,
-            final org.slf4j.Logger log,
-            final String... keys) {
-        for (String key : keys) {
-            String val = configuration.get(key);
-            if (val != null && !val.isEmpty()) {
-                try {
-                    Integer.parseInt(val);
-                } catch (NumberFormatException e) {
-                    log.error("Invalid numeric config value for '{}': '{}'", key, val);
-                    System.exit(-1);
-                }
-            }
         }
     }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -18,7 +18,6 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -99,25 +98,15 @@ public class URLFrontierServer implements Callable<Integer> {
         return 0;
     }
 
-    /**
-     * @throws Exception
-     */
-    /**
-     * @throws Exception
-     */
-    /**
-     * @throws Exception
-     */
+    /** Starts the URL Frontier server. */
     public void start() throws Exception {
 
         Map<String, String> configuration = new HashMap<>();
 
         // Do we want to expose Metrics via a Prometheus server?
         if (prometheus_server > 0) {
-            /**
-             * Register Prometheus collectors for garbage collection, memory pools, classloading,
-             * and thread counts.
-             */
+            // Register Prometheus collectors for garbage collection, memory pools, classloading,
+            // and thread counts.
             DefaultExports.initialize();
 
             LOG.info("Starting Prometheus server on port {}", prometheus_server);
@@ -155,9 +144,7 @@ public class URLFrontierServer implements Callable<Integer> {
         // Get the implementation class from the config if set (default is RocksDBService)
         String implementationClassName =
                 ParamHelper.getStringParameter(
-                        configuration,
-                        "implementation",
-                        Optional.of(RocksDBService.class.getName()));
+                        configuration, "implementation", RocksDBService.class.getName());
 
         Class<?> implementationClass = Class.forName(implementationClassName);
 
@@ -198,9 +185,8 @@ public class URLFrontierServer implements Callable<Integer> {
             }
         }
 
-        Boolean enableReflection =
-                Boolean.parseBoolean(
-                        configuration.getOrDefault("server.enable_reflection", "false"));
+        boolean enableReflection =
+                ParamHelper.getFlagParameter(configuration, "server.enable_reflection", false);
 
         ServerBuilder builder = ServerBuilder.forPort(port).addService(service);
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -143,9 +143,22 @@ public class URLFrontierServer implements Callable<Integer> {
             }
         }
 
-        // get the implementation class from the config if set
-        implementationClassName =
-                configuration.getOrDefault("implementation", implementationClassName);
+        // Validate known numeric config keys so errors name the offending key at startup
+        validateNumericConfig(
+                configuration,
+                LOG,
+                "read.thread.num",
+                "write.thread.num",
+                "putURLs.max.inflight",
+                "putDiscovered.max.inflight",
+                "rocksdb.max_background_jobs",
+                "rocksdb.max_subcompactions");
+
+        // get the implementation class from the config if set (ignore empty/flag-style values)
+        String impl = configuration.get("implementation");
+        if (impl != null && !impl.isEmpty()) {
+            implementationClassName = impl;
+        }
 
         Class<?> implementationClass = Class.forName(implementationClassName);
 
@@ -254,7 +267,29 @@ public class URLFrontierServer implements Callable<Integer> {
         }
     }
 
-    private static final void addToConfig(final Map<String, String> config, String line) {
+    /** Validate that known numeric config keys hold parseable integer values. */
+    private static void validateNumericConfig(
+            final Map<String, String> configuration,
+            final org.slf4j.Logger log,
+            final String... keys) {
+        for (String key : keys) {
+            String val = configuration.get(key);
+            if (val != null && !val.isEmpty()) {
+                try {
+                    Integer.parseInt(val);
+                } catch (NumberFormatException e) {
+                    log.error("Invalid numeric config value for '{}': '{}'", key, val);
+                    System.exit(-1);
+                }
+            }
+        }
+    }
+
+    /**
+     * Parse a single config line into the map. Lines without '=' are treated as flag-style keys
+     * with an empty string value (preserves containsKey, fixes getOrDefault).
+     */
+    static final void addToConfig(final Map<String, String> config, String line) {
         if (line == null || line.length() == 0) return;
 
         line = line.trim();
@@ -263,9 +298,9 @@ public class URLFrontierServer implements Callable<Integer> {
 
         // = to separate key from value
         int pos = line.indexOf('=');
-        // no value
+        // no '=' -> flag-style key with empty value (preserves containsKey, fixes getOrDefault)
         if (pos == -1) {
-            config.put(line, null);
+            config.put(line, "");
             return;
         }
         String key = line.substring(0, pos).trim();

--- a/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/URLFrontierServer.java
@@ -186,7 +186,7 @@ public class URLFrontierServer implements Callable<Integer> {
         }
 
         boolean enableReflection =
-                ParamHelper.getFlagParameter(configuration, "server.enable_reflection", false);
+                ParamHelper.getBooleanParameter(configuration, "server.enable_reflection", false);
 
         ServerBuilder builder = ServerBuilder.forPort(port).addService(service);
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -34,6 +34,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.service.AbstractFrontierService;
 import crawlercommons.urlfrontier.service.AsyncCompletion;
+import crawlercommons.urlfrontier.service.ParamHelper;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -66,10 +67,8 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
             final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
         forwardDeadlineSeconds =
-                Integer.parseInt(
-                        configuration.getOrDefault(
-                                "forward.deadline.seconds",
-                                Integer.toString(FORWARD_DEADLINE_SECONDS)));
+                ParamHelper.getIntegerParameter(
+                        configuration, "forward.deadline.seconds", FORWARD_DEADLINE_SECONDS);
     }
 
     // no explicit config

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -93,7 +93,8 @@ public class RocksDBService extends AbstractFrontierService {
         super(configuration, host, port);
 
         // where to store it?
-        String path = configuration.getOrDefault("rocksdb.path", "./rocksdb");
+        String sPath = configuration.get("rocksdb.path");
+        String path = (sPath != null && !sPath.isEmpty()) ? sPath : "./rocksdb";
 
         LOG.info("RocksDB data stored in {} ", path);
 
@@ -120,12 +121,12 @@ public class RocksDBService extends AbstractFrontierService {
         try (final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions()) {
 
             String sMaxBytesForLevelBase = configuration.get("rocksdb.max_bytes_for_level_base");
-            if (sMaxBytesForLevelBase != null) {
+            if (sMaxBytesForLevelBase != null && !sMaxBytesForLevelBase.isEmpty()) {
                 cfOpts.setMaxBytesForLevelBase(Long.parseLong(sMaxBytesForLevelBase));
             }
 
             String sMemtableBudget = configuration.get("rocksdb.memtable_memory_budget");
-            if (sMemtableBudget != null) {
+            if (sMemtableBudget != null && !sMemtableBudget.isEmpty()) {
                 cfOpts.optimizeUniversalStyleCompaction(Long.parseLong(sMemtableBudget));
             } else {
                 cfOpts.optimizeUniversalStyleCompaction();
@@ -156,13 +157,13 @@ public class RocksDBService extends AbstractFrontierService {
                 }
 
                 String smaxBackgroundJobs = configuration.get("rocksdb.max_background_jobs");
-                if (smaxBackgroundJobs != null) {
+                if (smaxBackgroundJobs != null && !smaxBackgroundJobs.isEmpty()) {
                     options.setMaxBackgroundJobs(Integer.parseInt(smaxBackgroundJobs));
                 }
 
                 // Options.max_subcompactions: 1
                 String smax_subcompactions = configuration.get("rocksdb.max_subcompactions");
-                if (smax_subcompactions != null) {
+                if (smax_subcompactions != null && !smax_subcompactions.isEmpty()) {
                     options.setMaxSubcompactions(Integer.parseInt(smax_subcompactions));
                 }
 
@@ -238,7 +239,7 @@ public class RocksDBService extends AbstractFrontierService {
 
         double bitsPerKey = 10d;
         final String sBitsPerKey = configuration.get("rocksdb.bloom.filters.bits_per_key");
-        if (sBitsPerKey != null) {
+        if (sBitsPerKey != null && !sBitsPerKey.isEmpty()) {
             bitsPerKey = Double.parseDouble(sBitsPerKey);
         }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -31,7 +31,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
-import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -95,9 +96,7 @@ public class RocksDBService extends AbstractFrontierService {
         super(configuration, host, port);
 
         // where to store it?
-        String path =
-                ParamHelper.getStringParameter(
-                        configuration, "rocksdb.path", Optional.of("./rocksdb"));
+        String path = ParamHelper.getStringParameter(configuration, "rocksdb.path", "./rocksdb");
 
         LOG.info("RocksDB data stored in {} ", path);
 
@@ -113,24 +112,18 @@ public class RocksDBService extends AbstractFrontierService {
 
         boolean checkOnRecovery = configuration.containsKey("rocksdb.recovery.check");
 
-        /**
-         * The filters are enabled by default: every URL sent to putURLItem needs a lookup to find
-         * out whether it is already known and most of them are not, which is the case they make
-         * cheap.
-         *
-         * <p>They used to be enabled with a valueless <i>rocksdb.bloom.filters</i> flag, so the
-         * mere presence of the key is still taken to mean 'enabled'.
-         */
+        // The filters are enabled by default: every URL sent to putURLItem needs a lookup to find
+        // out whether it is already known and most of them are not, which is the case they make
+        // cheap. They used to be enabled with a valueless rocksdb.bloom.filters flag, so the
+        // mere presence of the key is still taken to mean 'enabled'.
         boolean bloomFilters =
-                ParamHelper.getBooleanParameter(configuration, "rocksdb.bloom.filters", true);
+                ParamHelper.getFlagParameter(configuration, "rocksdb.bloom.filters", true);
 
-        /**
-         * The WAL is enabled by default: disabling it roughly halves the bytes written per URL but
-         * loses whatever was in the memtables if the service dies without closing cleanly. The URLs
-         * concerned get rediscovered by the crawl, so this is a reasonable trade for write-heavy
-         * setups.
-         */
-        walDisabled = ParamHelper.getBooleanParameter(configuration, "rocksdb.wal.disable", false);
+        // The WAL is enabled by default: disabling it roughly halves the bytes written per URL but
+        // loses whatever was in the memtables if the service dies without closing cleanly. The URLs
+        // concerned get rediscovered by the crawl, so this is a reasonable trade for write-heavy
+        // setups.
+        walDisabled = ParamHelper.getFlagParameter(configuration, "rocksdb.wal.disable", false);
         if (walDisabled) {
             LOG.info("WAL disabled - writes are made durable at flush time only");
             writeOptions.setDisableWAL(true);
@@ -138,18 +131,16 @@ public class RocksDBService extends AbstractFrontierService {
 
         try (final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions()) {
 
-            long maxBytesForLevelBase =
-                    ParamHelper.getLongParameter(
-                            configuration, "rocksdb.max_bytes_for_level_base", null);
-            if (maxBytesForLevelBase > 0) {
-                cfOpts.setMaxBytesForLevelBase(maxBytesForLevelBase);
+            OptionalLong maxBytesForLevelBase =
+                    ParamHelper.getLongParameter(configuration, "rocksdb.max_bytes_for_level_base");
+            if (maxBytesForLevelBase.isPresent()) {
+                cfOpts.setMaxBytesForLevelBase(maxBytesForLevelBase.getAsLong());
             }
 
-            long memTableBudget =
-                    ParamHelper.getLongParameter(
-                            configuration, "rocksdb.memtable_memory_budget", null);
-            if (memTableBudget > 0) {
-                cfOpts.optimizeUniversalStyleCompaction(memTableBudget);
+            OptionalLong memTableBudget =
+                    ParamHelper.getLongParameter(configuration, "rocksdb.memtable_memory_budget");
+            if (memTableBudget.isPresent()) {
+                cfOpts.optimizeUniversalStyleCompaction(memTableBudget.getAsLong());
             } else {
                 cfOpts.optimizeUniversalStyleCompaction();
             }
@@ -178,19 +169,19 @@ public class RocksDBService extends AbstractFrontierService {
                     options.setAtomicFlush(true);
                 }
 
-                int maxBackgroundJobs =
+                OptionalInt maxBackgroundJobs =
                         ParamHelper.getIntegerParameter(
-                                configuration, "rocksdb.max_background_jobs", null);
-                if (maxBackgroundJobs > 0) {
-                    options.setMaxBackgroundJobs(maxBackgroundJobs);
+                                configuration, "rocksdb.max_background_jobs");
+                if (maxBackgroundJobs.isPresent()) {
+                    options.setMaxBackgroundJobs(maxBackgroundJobs.getAsInt());
                 }
 
                 // Options.max_subcompactions: 1
-                int maxSubcompactions =
+                OptionalInt maxSubcompactions =
                         ParamHelper.getIntegerParameter(
-                                configuration, "rocksdb.max_subcompactions", null);
-                if (maxSubcompactions > 0) {
-                    options.setMaxSubcompactions(maxSubcompactions);
+                                configuration, "rocksdb.max_subcompactions");
+                if (maxSubcompactions.isPresent()) {
+                    options.setMaxSubcompactions(maxSubcompactions.getAsInt());
                 }
 
                 if (statistics != null) {
@@ -236,7 +227,7 @@ public class RocksDBService extends AbstractFrontierService {
 
         double bitsPerKey =
                 ParamHelper.getDoubleParameter(
-                        configuration, "rocksdb.bloom.filters.bits_per_key", Optional.of(10d));
+                        configuration, "rocksdb.bloom.filters.bits_per_key", 10d);
         LOG.info("Configuring Bloom filters with {} bits per key", bitsPerKey);
 
         bloomFilter = new BloomFilter(bitsPerKey);

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -14,6 +14,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.AbstractFrontierService;
 import crawlercommons.urlfrontier.service.CloseableIterator;
+import crawlercommons.urlfrontier.service.ParamHelper;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
@@ -93,8 +95,9 @@ public class RocksDBService extends AbstractFrontierService {
         super(configuration, host, port);
 
         // where to store it?
-        String sPath = configuration.get("rocksdb.path");
-        String path = (sPath != null && !sPath.isEmpty()) ? sPath : "./rocksdb";
+        String path =
+                ParamHelper.getStringParameter(
+                        configuration, "rocksdb.path", Optional.of("./rocksdb"));
 
         LOG.info("RocksDB data stored in {} ", path);
 
@@ -110,9 +113,24 @@ public class RocksDBService extends AbstractFrontierService {
 
         boolean checkOnRecovery = configuration.containsKey("rocksdb.recovery.check");
 
-        boolean bloomFilters = useBloomFilters(configuration);
+        /**
+         * The filters are enabled by default: every URL sent to putURLItem needs a lookup to find
+         * out whether it is already known and most of them are not, which is the case they make
+         * cheap.
+         *
+         * <p>They used to be enabled with a valueless <i>rocksdb.bloom.filters</i> flag, so the
+         * mere presence of the key is still taken to mean 'enabled'.
+         */
+        boolean bloomFilters =
+                ParamHelper.getBooleanParameter(configuration, "rocksdb.bloom.filters", true);
 
-        walDisabled = disableWAL(configuration);
+        /**
+         * The WAL is enabled by default: disabling it roughly halves the bytes written per URL but
+         * loses whatever was in the memtables if the service dies without closing cleanly. The URLs
+         * concerned get rediscovered by the crawl, so this is a reasonable trade for write-heavy
+         * setups.
+         */
+        walDisabled = ParamHelper.getBooleanParameter(configuration, "rocksdb.wal.disable", false);
         if (walDisabled) {
             LOG.info("WAL disabled - writes are made durable at flush time only");
             writeOptions.setDisableWAL(true);
@@ -120,14 +138,18 @@ public class RocksDBService extends AbstractFrontierService {
 
         try (final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions()) {
 
-            String sMaxBytesForLevelBase = configuration.get("rocksdb.max_bytes_for_level_base");
-            if (sMaxBytesForLevelBase != null && !sMaxBytesForLevelBase.isEmpty()) {
-                cfOpts.setMaxBytesForLevelBase(Long.parseLong(sMaxBytesForLevelBase));
+            long maxBytesForLevelBase =
+                    ParamHelper.getLongParameter(
+                            configuration, "rocksdb.max_bytes_for_level_base", null);
+            if (maxBytesForLevelBase > 0) {
+                cfOpts.setMaxBytesForLevelBase(maxBytesForLevelBase);
             }
 
-            String sMemtableBudget = configuration.get("rocksdb.memtable_memory_budget");
-            if (sMemtableBudget != null && !sMemtableBudget.isEmpty()) {
-                cfOpts.optimizeUniversalStyleCompaction(Long.parseLong(sMemtableBudget));
+            long memTableBudget =
+                    ParamHelper.getLongParameter(
+                            configuration, "rocksdb.memtable_memory_budget", null);
+            if (memTableBudget > 0) {
+                cfOpts.optimizeUniversalStyleCompaction(memTableBudget);
             } else {
                 cfOpts.optimizeUniversalStyleCompaction();
             }
@@ -156,15 +178,19 @@ public class RocksDBService extends AbstractFrontierService {
                     options.setAtomicFlush(true);
                 }
 
-                String smaxBackgroundJobs = configuration.get("rocksdb.max_background_jobs");
-                if (smaxBackgroundJobs != null && !smaxBackgroundJobs.isEmpty()) {
-                    options.setMaxBackgroundJobs(Integer.parseInt(smaxBackgroundJobs));
+                int maxBackgroundJobs =
+                        ParamHelper.getIntegerParameter(
+                                configuration, "rocksdb.max_background_jobs", null);
+                if (maxBackgroundJobs > 0) {
+                    options.setMaxBackgroundJobs(maxBackgroundJobs);
                 }
 
                 // Options.max_subcompactions: 1
-                String smax_subcompactions = configuration.get("rocksdb.max_subcompactions");
-                if (smax_subcompactions != null && !smax_subcompactions.isEmpty()) {
-                    options.setMaxSubcompactions(Integer.parseInt(smax_subcompactions));
+                int maxSubcompactions =
+                        ParamHelper.getIntegerParameter(
+                                configuration, "rocksdb.max_subcompactions", null);
+                if (maxSubcompactions > 0) {
+                    options.setMaxSubcompactions(maxSubcompactions);
                 }
 
                 if (statistics != null) {
@@ -197,35 +223,6 @@ public class RocksDBService extends AbstractFrontierService {
     }
 
     /**
-     * The filters are enabled by default: every URL sent to putURLItem needs a lookup to find out
-     * whether it is already known and most of them are not, which is the case they make cheap.
-     *
-     * <p>They used to be enabled with a valueless <i>rocksdb.bloom.filters</i> flag, so the mere
-     * presence of the key is still taken to mean 'enabled'.
-     */
-    static boolean useBloomFilters(final Map<String, String> configuration) {
-        if (!configuration.containsKey("rocksdb.bloom.filters")) {
-            return true;
-        }
-        final String value = configuration.get("rocksdb.bloom.filters");
-        return value == null || value.isEmpty() || Boolean.parseBoolean(value);
-    }
-
-    /**
-     * The WAL is enabled by default: disabling it roughly halves the bytes written per URL but
-     * loses whatever was in the memtables if the service dies without closing cleanly. The URLs
-     * concerned get rediscovered by the crawl, so this is a reasonable trade for write-heavy
-     * setups.
-     */
-    static boolean disableWAL(final Map<String, String> configuration) {
-        if (!configuration.containsKey("rocksdb.wal.disable")) {
-            return false;
-        }
-        final String value = configuration.get("rocksdb.wal.disable");
-        return value == null || value.isEmpty() || Boolean.parseBoolean(value);
-    }
-
-    /**
      * The filters spare the lookup done for every URL in putURLItem from having to read the data
      * blocks of the SST files when the URL is not known yet. Universal compaction leaves several
      * sorted runs to look into, which is what makes them worth their memory here.
@@ -237,12 +234,9 @@ public class RocksDBService extends AbstractFrontierService {
      */
     private BlockBasedTableConfig buildTableConfig(final Map<String, String> configuration) {
 
-        double bitsPerKey = 10d;
-        final String sBitsPerKey = configuration.get("rocksdb.bloom.filters.bits_per_key");
-        if (sBitsPerKey != null && !sBitsPerKey.isEmpty()) {
-            bitsPerKey = Double.parseDouble(sBitsPerKey);
-        }
-
+        double bitsPerKey =
+                ParamHelper.getDoubleParameter(
+                        configuration, "rocksdb.bloom.filters.bits_per_key", Optional.of(10d));
         LOG.info("Configuring Bloom filters with {} bits per key", bitsPerKey);
 
         bloomFilter = new BloomFilter(bitsPerKey);

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/ShardedRocksDBService.java
@@ -10,6 +10,7 @@ import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
 import crawlercommons.urlfrontier.service.CloseableIterator;
 import crawlercommons.urlfrontier.service.ConcurrentInsertionOrderMap;
+import crawlercommons.urlfrontier.service.ParamHelper;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
@@ -36,8 +37,8 @@ public class ShardedRocksDBService extends DistributedFrontierService {
 
         instance = new RocksDBService(configuration, host, port);
         // take coordinates of the nodes + able to identify itself in the list
-        final String snodes = configuration.get("nodes");
-        if (snodes == null) {
+        final String snodes = ParamHelper.getStringParameter(configuration, "nodes");
+        if (snodes.isEmpty()) {
             throw new RuntimeException(
                     "ShardedRocksDBService requires configuration 'nodes' to be set");
         }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
@@ -1,172 +1,275 @@
-// SPDX-FileCopyrightText: 2025 Crawler-commons
+// SPDX-FileCopyrightText: 2026 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
 
 /** Tests for ParamHelper parameter parsing */
 class ParamHelperTest {
 
+    // --- getIntegerParameter (OptionalInt return) ---
+
     @Test
     void getIntegerParameter_withValue_returnsParsedValue() {
         Map<String, String> config = new HashMap<>();
         config.put("test.int", "42");
-        assertEquals(42, ParamHelper.getIntegerParameter(config, "test.int", Optional.empty()));
+        OptionalInt result = ParamHelper.getIntegerParameter(config, "test.int");
+        assertTrue(result.isPresent());
+        assertEquals(42, result.getAsInt());
     }
+
+    @Test
+    void getIntegerParameter_missingKey_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        assertTrue(ParamHelper.getIntegerParameter(config, "missing").isEmpty());
+    }
+
+    @Test
+    void getIntegerParameter_emptyString_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.int", "");
+        assertTrue(ParamHelper.getIntegerParameter(config, "test.int").isEmpty());
+    }
+
+    @Test
+    void getIntegerParameter_invalidValue_throwsException() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.int", "not-a-number");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ParamHelper.getIntegerParameter(config, "test.int"));
+    }
+
+    // --- getIntegerParameter with default ---
 
     @Test
     void getIntegerParameter_withDefault_returnsDefaultWhenMissing() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(100, ParamHelper.getIntegerParameter(config, "missing", Optional.of(100)));
+        assertEquals(100, ParamHelper.getIntegerParameter(config, "missing", 100));
     }
 
     @Test
-    void getIntegerParameter_noDefault_returnsFallbackWhenMissing() {
+    void getIntegerParameter_withDefault_returnsParsedWhenSet() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(-1, ParamHelper.getIntegerParameter(config, "missing", Optional.empty()));
+        config.put("test.int", "42");
+        assertEquals(42, ParamHelper.getIntegerParameter(config, "test.int", 100));
     }
 
     @Test
-    void getIntegerParameter_emptyString_returnsDefault() {
+    void getIntegerParameter_withDefault_returnsDefaultWhenEmpty() {
         Map<String, String> config = new HashMap<>();
         config.put("test.int", "");
-        assertEquals(50, ParamHelper.getIntegerParameter(config, "test.int", Optional.of(50)));
+        assertEquals(50, ParamHelper.getIntegerParameter(config, "test.int", 50));
     }
 
     @Test
-    void getIntegerParameter_invalidValue_exitsProgram() {
+    void getIntegerParameter_withDefault_invalidValue_throwsException() {
         Map<String, String> config = new HashMap<>();
         config.put("test.int", "not-a-number");
-        // System.exit is called, so we can't easily test this without mocking
-        // This test documents the behavior
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ParamHelper.getIntegerParameter(config, "test.int", 10));
     }
+
+    // --- getLongParameter (OptionalLong return) ---
 
     @Test
     void getLongParameter_withValue_returnsParsedValue() {
         Map<String, String> config = new HashMap<>();
         config.put("test.long", "1234567890");
-        assertEquals(1234567890L, ParamHelper.getLongParameter(config, "test.long", Optional.empty()));
+        OptionalLong result = ParamHelper.getLongParameter(config, "test.long");
+        assertTrue(result.isPresent());
+        assertEquals(1234567890L, result.getAsLong());
     }
+
+    @Test
+    void getLongParameter_missingKey_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        assertTrue(ParamHelper.getLongParameter(config, "missing").isEmpty());
+    }
+
+    @Test
+    void getLongParameter_invalidValue_throwsException() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.long", "not-a-long");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ParamHelper.getLongParameter(config, "test.long"));
+    }
+
+    // --- getLongParameter with default ---
 
     @Test
     void getLongParameter_withDefault_returnsDefaultWhenMissing() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(999L, ParamHelper.getLongParameter(config, "missing", Optional.of(999L)));
+        assertEquals(999L, ParamHelper.getLongParameter(config, "missing", 999L));
     }
 
     @Test
-    void getLongParameter_noDefault_returnsFallbackWhenMissing() {
+    void getLongParameter_withDefault_returnsParsedWhenSet() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(-1L, ParamHelper.getLongParameter(config, "missing", Optional.empty()));
+        config.put("test.long", "42");
+        assertEquals(42L, ParamHelper.getLongParameter(config, "test.long", 999L));
     }
+
+    // --- getDoubleParameter ---
 
     @Test
     void getDoubleParameter_withValue_returnsParsedValue() {
         Map<String, String> config = new HashMap<>();
         config.put("test.double", "3.14");
-        assertEquals(3.14, ParamHelper.getDoubleParameter(config, "test.double", Optional.empty()));
+        assertEquals(3.14, ParamHelper.getDoubleParameter(config, "test.double", 0.0), 0.001);
     }
 
     @Test
     void getDoubleParameter_withDefault_returnsDefaultWhenMissing() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(2.71, ParamHelper.getDoubleParameter(config, "missing", Optional.of(2.71)));
+        assertEquals(2.71, ParamHelper.getDoubleParameter(config, "missing", 2.71), 0.001);
     }
 
     @Test
-    void getDoubleParameter_noDefault_returnsNaNWhenMissing() {
+    void getDoubleParameter_withDefault_returnsDefaultWhenEmpty() {
         Map<String, String> config = new HashMap<>();
-        assertTrue(Double.isNaN(ParamHelper.getDoubleParameter(config, "missing", Optional.empty())));
+        config.put("test.double", "");
+        assertEquals(2.71, ParamHelper.getDoubleParameter(config, "test.double", 2.71), 0.001);
     }
+
+    @Test
+    void getDoubleParameter_invalidValue_throwsException() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.double", "not-a-double");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ParamHelper.getDoubleParameter(config, "test.double", 0.0));
+    }
+
+    // --- getStringParameter ---
 
     @Test
     void getStringParameter_withValue_returnsValue() {
         Map<String, String> config = new HashMap<>();
         config.put("test.str", "hello");
-        assertEquals("hello", ParamHelper.getStringParameter(config, "test.str", Optional.empty()));
+        assertEquals("hello", ParamHelper.getStringParameter(config, "test.str"));
+    }
+
+    @Test
+    void getStringParameter_missingKey_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals("", ParamHelper.getStringParameter(config, "missing"));
     }
 
     @Test
     void getStringParameter_withDefault_returnsDefaultWhenMissing() {
         Map<String, String> config = new HashMap<>();
-        assertEquals("default", ParamHelper.getStringParameter(config, "missing", Optional.of("default")));
+        assertEquals("default", ParamHelper.getStringParameter(config, "missing", "default"));
     }
 
     @Test
-    void getStringParameter_noDefault_returnsEmptyWhenMissing() {
+    void getStringParameter_withDefault_returnsValueWhenSet() {
         Map<String, String> config = new HashMap<>();
-        assertEquals("", ParamHelper.getStringParameter(config, "missing", Optional.empty()));
+        config.put("test.str", "hello");
+        assertEquals("hello", ParamHelper.getStringParameter(config, "test.str", "default"));
     }
 
     @Test
-    void getStringParameter_nullDefault_returnsEmptyWhenMissing() {
-        Map<String, String> config = new HashMap<>();
-        assertEquals("", ParamHelper.getStringParameter(config, "missing", null));
-    }
-
-    @Test
-    void getStringParameter_emptyStringInConfig_returnsDefault() {
+    void getStringParameter_withDefault_returnsDefaultWhenEmpty() {
         Map<String, String> config = new HashMap<>();
         config.put("test.str", "");
-        assertEquals("default", ParamHelper.getStringParameter(config, "test.str", Optional.of("default")));
+        assertEquals("default", ParamHelper.getStringParameter(config, "test.str", "default"));
     }
 
-    @Test
-    void getStringParameter_optionalWithNull_returnsEmpty() {
-        Map<String, String> config = new HashMap<>();
-        assertEquals("", ParamHelper.getStringParameter(config, "missing", Optional.ofNullable(null)));
-    }
+    // --- getBooleanParameter ---
 
     @Test
     void getBooleanParameter_withTrueValue_returnsTrue() {
         Map<String, String> config = new HashMap<>();
         config.put("test.bool", "true");
-        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertTrue(ParamHelper.getBooleanParameter(config, "test.bool", false));
     }
 
     @Test
     void getBooleanParameter_withFalseValue_returnsFalse() {
         Map<String, String> config = new HashMap<>();
         config.put("test.bool", "false");
-        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", true));
+        assertFalse(ParamHelper.getBooleanParameter(config, "test.bool", true));
     }
 
     @Test
-    void getBooleanParameter_emptyString_returnsTrue() {
+    void getBooleanParameter_emptyString_returnsDefault() {
         Map<String, String> config = new HashMap<>();
         config.put("test.bool", "");
-        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertFalse(ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertTrue(ParamHelper.getBooleanParameter(config, "test.bool", true));
     }
-    
+
     @Test
     void getBooleanParameter_nullValue_returnsDefault() {
         Map<String, String> config = new HashMap<>();
         config.put("test.bool", null);
-        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", true));
+        assertFalse(ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertTrue(ParamHelper.getBooleanParameter(config, "test.bool", true));
     }
 
     @Test
     void getBooleanParameter_missingKey_returnsDefault() {
         Map<String, String> config = new HashMap<>();
-        assertEquals(true, ParamHelper.getBooleanParameter(config, "missing", true));
-        assertEquals(false, ParamHelper.getBooleanParameter(config, "missing", false));
+        assertTrue(ParamHelper.getBooleanParameter(config, "missing", true));
+        assertFalse(ParamHelper.getBooleanParameter(config, "missing", false));
     }
 
     @Test
     void getBooleanParameter_nonBooleanString_returnsFalse() {
-        // Boolean.parseBoolean returns true for any non-null, non-"true" string
         Map<String, String> config = new HashMap<>();
         config.put("test.bool", "yes");
-        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertFalse(ParamHelper.getBooleanParameter(config, "test.bool", false));
         config.put("test.bool", "1");
-        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", false));
+        assertFalse(ParamHelper.getBooleanParameter(config, "test.bool", false));
+    }
+
+    // --- getFlagParameter ---
+
+    @Test
+    void getFlagParameter_missingKey_returnsDefault() {
+        Map<String, String> config = new HashMap<>();
+        assertTrue(ParamHelper.getFlagParameter(config, "missing", true));
+        assertFalse(ParamHelper.getFlagParameter(config, "missing", false));
+    }
+
+    @Test
+    void getFlagParameter_emptyString_returnsTrue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.flag", "");
+        assertTrue(ParamHelper.getFlagParameter(config, "test.flag", false));
+    }
+
+    @Test
+    void getFlagParameter_nullValue_returnsTrue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.flag", null);
+        assertTrue(ParamHelper.getFlagParameter(config, "test.flag", false));
+    }
+
+    @Test
+    void getFlagParameter_trueValue_returnsTrue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.flag", "true");
+        assertTrue(ParamHelper.getFlagParameter(config, "test.flag", false));
+    }
+
+    @Test
+    void getFlagParameter_falseValue_returnsFalse() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.flag", "false");
+        assertFalse(ParamHelper.getFlagParameter(config, "test.flag", true));
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalDouble;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import org.junit.jupiter.api.Test;
@@ -122,7 +123,40 @@ class ParamHelperTest {
         assertEquals(42L, ParamHelper.getLongParameter(config, "test.long", 999L));
     }
 
-    // --- getDoubleParameter ---
+    // --- getDoubleParameter (OptionalDouble return) ---
+
+    @Test
+    void getDoubleParameter_noDefault_withValue_returnsParsedValue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.double", "3.14");
+        OptionalDouble result = ParamHelper.getDoubleParameter(config, "test.double");
+        assertTrue(result.isPresent());
+        assertEquals(3.14, result.getAsDouble(), 0.001);
+    }
+
+    @Test
+    void getDoubleParameter_noDefault_missingKey_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        assertTrue(ParamHelper.getDoubleParameter(config, "missing").isEmpty());
+    }
+
+    @Test
+    void getDoubleParameter_noDefault_emptyString_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.double", "");
+        assertTrue(ParamHelper.getDoubleParameter(config, "test.double").isEmpty());
+    }
+
+    @Test
+    void getDoubleParameter_noDefault_invalidValue_throwsException() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.double", "not-a-double");
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> ParamHelper.getDoubleParameter(config, "test.double"));
+    }
+
+    // --- getDoubleParameter with default ---
 
     @Test
     void getDoubleParameter_withValue_returnsParsedValue() {

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ParamHelperTest.java
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Tests for ParamHelper parameter parsing */
+class ParamHelperTest {
+
+    @Test
+    void getIntegerParameter_withValue_returnsParsedValue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.int", "42");
+        assertEquals(42, ParamHelper.getIntegerParameter(config, "test.int", Optional.empty()));
+    }
+
+    @Test
+    void getIntegerParameter_withDefault_returnsDefaultWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(100, ParamHelper.getIntegerParameter(config, "missing", Optional.of(100)));
+    }
+
+    @Test
+    void getIntegerParameter_noDefault_returnsFallbackWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(-1, ParamHelper.getIntegerParameter(config, "missing", Optional.empty()));
+    }
+
+    @Test
+    void getIntegerParameter_emptyString_returnsDefault() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.int", "");
+        assertEquals(50, ParamHelper.getIntegerParameter(config, "test.int", Optional.of(50)));
+    }
+
+    @Test
+    void getIntegerParameter_invalidValue_exitsProgram() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.int", "not-a-number");
+        // System.exit is called, so we can't easily test this without mocking
+        // This test documents the behavior
+    }
+
+    @Test
+    void getLongParameter_withValue_returnsParsedValue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.long", "1234567890");
+        assertEquals(1234567890L, ParamHelper.getLongParameter(config, "test.long", Optional.empty()));
+    }
+
+    @Test
+    void getLongParameter_withDefault_returnsDefaultWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(999L, ParamHelper.getLongParameter(config, "missing", Optional.of(999L)));
+    }
+
+    @Test
+    void getLongParameter_noDefault_returnsFallbackWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(-1L, ParamHelper.getLongParameter(config, "missing", Optional.empty()));
+    }
+
+    @Test
+    void getDoubleParameter_withValue_returnsParsedValue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.double", "3.14");
+        assertEquals(3.14, ParamHelper.getDoubleParameter(config, "test.double", Optional.empty()));
+    }
+
+    @Test
+    void getDoubleParameter_withDefault_returnsDefaultWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(2.71, ParamHelper.getDoubleParameter(config, "missing", Optional.of(2.71)));
+    }
+
+    @Test
+    void getDoubleParameter_noDefault_returnsNaNWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertTrue(Double.isNaN(ParamHelper.getDoubleParameter(config, "missing", Optional.empty())));
+    }
+
+    @Test
+    void getStringParameter_withValue_returnsValue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.str", "hello");
+        assertEquals("hello", ParamHelper.getStringParameter(config, "test.str", Optional.empty()));
+    }
+
+    @Test
+    void getStringParameter_withDefault_returnsDefaultWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals("default", ParamHelper.getStringParameter(config, "missing", Optional.of("default")));
+    }
+
+    @Test
+    void getStringParameter_noDefault_returnsEmptyWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals("", ParamHelper.getStringParameter(config, "missing", Optional.empty()));
+    }
+
+    @Test
+    void getStringParameter_nullDefault_returnsEmptyWhenMissing() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals("", ParamHelper.getStringParameter(config, "missing", null));
+    }
+
+    @Test
+    void getStringParameter_emptyStringInConfig_returnsDefault() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.str", "");
+        assertEquals("default", ParamHelper.getStringParameter(config, "test.str", Optional.of("default")));
+    }
+
+    @Test
+    void getStringParameter_optionalWithNull_returnsEmpty() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals("", ParamHelper.getStringParameter(config, "missing", Optional.ofNullable(null)));
+    }
+
+    @Test
+    void getBooleanParameter_withTrueValue_returnsTrue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.bool", "true");
+        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", false));
+    }
+
+    @Test
+    void getBooleanParameter_withFalseValue_returnsFalse() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.bool", "false");
+        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", true));
+    }
+
+    @Test
+    void getBooleanParameter_emptyString_returnsTrue() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.bool", "");
+        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", false));
+    }
+    
+    @Test
+    void getBooleanParameter_nullValue_returnsDefault() {
+        Map<String, String> config = new HashMap<>();
+        config.put("test.bool", null);
+        assertEquals(true, ParamHelper.getBooleanParameter(config, "test.bool", true));
+    }
+
+    @Test
+    void getBooleanParameter_missingKey_returnsDefault() {
+        Map<String, String> config = new HashMap<>();
+        assertEquals(true, ParamHelper.getBooleanParameter(config, "missing", true));
+        assertEquals(false, ParamHelper.getBooleanParameter(config, "missing", false));
+    }
+
+    @Test
+    void getBooleanParameter_nonBooleanString_returnsFalse() {
+        // Boolean.parseBoolean returns true for any non-null, non-"true" string
+        Map<String, String> config = new HashMap<>();
+        config.put("test.bool", "yes");
+        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", false));
+        config.put("test.bool", "1");
+        assertEquals(false, ParamHelper.getBooleanParameter(config, "test.bool", false));
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 /** Tests for URLFrontierServer.addToConfig — config line parsing */
@@ -18,6 +19,7 @@ class URLFrontierServerConfigTest {
     void bareKeyStoredAsEmptyString() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "rocksdb.purge");
+
         assertTrue(config.containsKey("rocksdb.purge"));
         assertEquals("", config.get("rocksdb.purge"));
     }
@@ -26,28 +28,30 @@ class URLFrontierServerConfigTest {
     void keyWithValue() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "read.thread.num=8");
-        assertEquals("8", config.get("read.thread.num"));
+        assertEquals(
+                8, ParamHelper.getIntegerParameter(config, "read.thread.num", Optional.of(1234)));
     }
 
     @Test
     void keyWithEmptyValue() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "key=");
-        assertEquals("", config.get("key"));
+        assertEquals("", ParamHelper.getStringParameter(config, "key", null));
     }
 
     @Test
     void valueContainingEquals() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "key=a=b");
-        assertEquals("a=b", config.get("key"));
+
+        assertEquals("a=b", ParamHelper.getStringParameter(config, "key", null));
     }
 
     @Test
     void keyAndValueWithSpacesTrimmed() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "  key  =  value  ");
-        assertEquals("value", config.get("key"));
+        assertEquals("value", ParamHelper.getStringParameter(config, "key", null));
     }
 
     @Test
@@ -82,6 +86,7 @@ class URLFrontierServerConfigTest {
         assertTrue(config.containsKey("rocksdb.purge"));
         assertTrue(config.containsKey("rocksdb.recovery.check"));
         assertTrue(config.containsKey("rocksdb.bloom.filters"));
+        assertTrue(ParamHelper.getBooleanParameter(config, "rocksdb.bloom.filters", false));
     }
 
     @Test
@@ -93,6 +98,10 @@ class URLFrontierServerConfigTest {
         String result = config.getOrDefault("implementation", "default");
         assertNotNull(result);
         assertEquals("", result);
+        assertEquals("", ParamHelper.getStringParameter(config, "implementation", null));
+        assertEquals(
+                "", ParamHelper.getStringParameter(config, "implementation", Optional.empty()));
+        assertEquals("", ParamHelper.getStringParameter(config, "implementation", Optional.of("")));
     }
 
     @Test
@@ -100,6 +109,9 @@ class URLFrontierServerConfigTest {
         Map<String, String> config = new HashMap<>();
         String result = config.getOrDefault("absent.key", "default");
         assertEquals("default", result);
+        assertEquals(
+                "default",
+                ParamHelper.getStringParameter(config, "absent.key", Optional.of("default")));
     }
 
     @Test
@@ -120,5 +132,6 @@ class URLFrontierServerConfigTest {
         // Simulate positional arg override
         URLFrontierServer.addToConfig(config, "read.thread.num=8");
         assertEquals("8", config.get("read.thread.num"));
+        assertEquals(8, ParamHelper.getIntegerParameter(config, "read.thread.num", null));
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-FileCopyrightText: 2026 Crawler-commons
 // SPDX-License-Identifier: Apache-2.0
 
 package crawlercommons.urlfrontier.service;

--- a/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
@@ -9,10 +9,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
-/** Tests for URLFrontierServer.addToConfig — config line parsing */
+/** Tests for URLFrontierServer.addToConfig -- config line parsing */
 class URLFrontierServerConfigTest {
 
     @Test
@@ -28,15 +27,14 @@ class URLFrontierServerConfigTest {
     void keyWithValue() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "read.thread.num=8");
-        assertEquals(
-                8, ParamHelper.getIntegerParameter(config, "read.thread.num", Optional.of(1234)));
+        assertEquals(8, ParamHelper.getIntegerParameter(config, "read.thread.num", 1234));
     }
 
     @Test
     void keyWithEmptyValue() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "key=");
-        assertEquals("", ParamHelper.getStringParameter(config, "key", null));
+        assertEquals("", ParamHelper.getStringParameter(config, "key"));
     }
 
     @Test
@@ -44,14 +42,14 @@ class URLFrontierServerConfigTest {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "key=a=b");
 
-        assertEquals("a=b", ParamHelper.getStringParameter(config, "key", null));
+        assertEquals("a=b", ParamHelper.getStringParameter(config, "key"));
     }
 
     @Test
     void keyAndValueWithSpacesTrimmed() {
         Map<String, String> config = new HashMap<>();
         URLFrontierServer.addToConfig(config, "  key  =  value  ");
-        assertEquals("value", ParamHelper.getStringParameter(config, "key", null));
+        assertEquals("value", ParamHelper.getStringParameter(config, "key"));
     }
 
     @Test
@@ -86,7 +84,7 @@ class URLFrontierServerConfigTest {
         assertTrue(config.containsKey("rocksdb.purge"));
         assertTrue(config.containsKey("rocksdb.recovery.check"));
         assertTrue(config.containsKey("rocksdb.bloom.filters"));
-        assertTrue(ParamHelper.getBooleanParameter(config, "rocksdb.bloom.filters", false));
+        assertTrue(ParamHelper.getFlagParameter(config, "rocksdb.bloom.filters", false));
     }
 
     @Test
@@ -98,10 +96,7 @@ class URLFrontierServerConfigTest {
         String result = config.getOrDefault("implementation", "default");
         assertNotNull(result);
         assertEquals("", result);
-        assertEquals("", ParamHelper.getStringParameter(config, "implementation", null));
-        assertEquals(
-                "", ParamHelper.getStringParameter(config, "implementation", Optional.empty()));
-        assertEquals("", ParamHelper.getStringParameter(config, "implementation", Optional.of("")));
+        assertEquals("", ParamHelper.getStringParameter(config, "implementation"));
     }
 
     @Test
@@ -109,9 +104,7 @@ class URLFrontierServerConfigTest {
         Map<String, String> config = new HashMap<>();
         String result = config.getOrDefault("absent.key", "default");
         assertEquals("default", result);
-        assertEquals(
-                "default",
-                ParamHelper.getStringParameter(config, "absent.key", Optional.of("default")));
+        assertEquals("default", ParamHelper.getStringParameter(config, "absent.key", "default"));
     }
 
     @Test
@@ -132,6 +125,6 @@ class URLFrontierServerConfigTest {
         // Simulate positional arg override
         URLFrontierServer.addToConfig(config, "read.thread.num=8");
         assertEquals("8", config.get("read.thread.num"));
-        assertEquals(8, ParamHelper.getIntegerParameter(config, "read.thread.num", null));
+        assertEquals(8, ParamHelper.getIntegerParameter(config, "read.thread.num", 0));
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServerConfigTest.java
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Tests for URLFrontierServer.addToConfig — config line parsing */
+class URLFrontierServerConfigTest {
+
+    @Test
+    void bareKeyStoredAsEmptyString() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "rocksdb.purge");
+        assertTrue(config.containsKey("rocksdb.purge"));
+        assertEquals("", config.get("rocksdb.purge"));
+    }
+
+    @Test
+    void keyWithValue() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "read.thread.num=8");
+        assertEquals("8", config.get("read.thread.num"));
+    }
+
+    @Test
+    void keyWithEmptyValue() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "key=");
+        assertEquals("", config.get("key"));
+    }
+
+    @Test
+    void valueContainingEquals() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "key=a=b");
+        assertEquals("a=b", config.get("key"));
+    }
+
+    @Test
+    void keyAndValueWithSpacesTrimmed() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "  key  =  value  ");
+        assertEquals("value", config.get("key"));
+    }
+
+    @Test
+    void bareKeyWithSpacesTrimmed() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "  rocksdb.purge  ");
+        assertTrue(config.containsKey("rocksdb.purge"));
+        assertEquals("", config.get("rocksdb.purge"));
+    }
+
+    @Test
+    void emptyLineIgnored() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "");
+        URLFrontierServer.addToConfig(config, "   ");
+        assertTrue(config.isEmpty());
+    }
+
+    @Test
+    void nullLineIgnored() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, null);
+        assertTrue(config.isEmpty());
+    }
+
+    @Test
+    void containsKeyWorksForFlagStyleKeys() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "rocksdb.purge");
+        URLFrontierServer.addToConfig(config, "rocksdb.recovery.check");
+        URLFrontierServer.addToConfig(config, "rocksdb.bloom.filters");
+        assertTrue(config.containsKey("rocksdb.purge"));
+        assertTrue(config.containsKey("rocksdb.recovery.check"));
+        assertTrue(config.containsKey("rocksdb.bloom.filters"));
+    }
+
+    @Test
+    void getOrDefaultDoesNotReturnNullForBareKeys() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "implementation");
+        // Before fix: getOrDefault returned null, breaking Class.forName
+        // After fix: getOrDefault returns "" (not null)
+        String result = config.getOrDefault("implementation", "default");
+        assertNotNull(result);
+        assertEquals("", result);
+    }
+
+    @Test
+    void getOrDefaultReturnsDefaultForAbsentKeys() {
+        Map<String, String> config = new HashMap<>();
+        String result = config.getOrDefault("absent.key", "default");
+        assertEquals("default", result);
+    }
+
+    @Test
+    void multipleKeysCoexist() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "rocksdb.purge");
+        URLFrontierServer.addToConfig(config, "read.thread.num=4");
+        URLFrontierServer.addToConfig(config, "rocksdb.path=/data");
+        assertEquals("", config.get("rocksdb.purge"));
+        assertEquals("4", config.get("read.thread.num"));
+        assertEquals("/data", config.get("rocksdb.path"));
+    }
+
+    @Test
+    void positionalArgOverride() {
+        Map<String, String> config = new HashMap<>();
+        URLFrontierServer.addToConfig(config, "read.thread.num=2");
+        // Simulate positional arg override
+        URLFrontierServer.addToConfig(config, "read.thread.num=8");
+        assertEquals("8", config.get("read.thread.num"));
+    }
+}

--- a/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
@@ -17,7 +17,7 @@ class RocksDBBloomFilterConfigTest {
     @Test
     void enabledWhenNotConfigured() {
         boolean bloomFilters =
-                ParamHelper.getBooleanParameter(new HashMap<>(), "rocksdb.bloom.filters", true);
+                ParamHelper.getFlagParameter(new HashMap<>(), "rocksdb.bloom.filters", true);
         assertTrue(bloomFilters);
     }
 
@@ -26,12 +26,12 @@ class RocksDBBloomFilterConfigTest {
     void enabledWhenKeyHasNoValue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", null);
-        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+        boolean bloomFilters = ParamHelper.getFlagParameter(conf, "rocksdb.bloom.filters", true);
 
         assertTrue(bloomFilters);
 
         conf.put("rocksdb.bloom.filters", "");
-        bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+        bloomFilters = ParamHelper.getFlagParameter(conf, "rocksdb.bloom.filters", true);
 
         assertTrue(bloomFilters);
     }
@@ -40,7 +40,7 @@ class RocksDBBloomFilterConfigTest {
     void enabledWhenSetToTrue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", "true");
-        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+        boolean bloomFilters = ParamHelper.getFlagParameter(conf, "rocksdb.bloom.filters", true);
 
         assertTrue(bloomFilters);
     }
@@ -49,7 +49,7 @@ class RocksDBBloomFilterConfigTest {
     void disabledWhenSetToFalse() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", "false");
-        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+        boolean bloomFilters = ParamHelper.getFlagParameter(conf, "rocksdb.bloom.filters", true);
 
         assertFalse(bloomFilters);
     }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBBloomFilterConfigTest.java
@@ -6,6 +6,7 @@ package crawlercommons.urlfrontier.service.rocksdb;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import crawlercommons.urlfrontier.service.ParamHelper;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,9 @@ class RocksDBBloomFilterConfigTest {
 
     @Test
     void enabledWhenNotConfigured() {
-        assertTrue(RocksDBService.useBloomFilters(new HashMap<>()));
+        boolean bloomFilters =
+                ParamHelper.getBooleanParameter(new HashMap<>(), "rocksdb.bloom.filters", true);
+        assertTrue(bloomFilters);
     }
 
     /** the key used to be a flag without a value */
@@ -23,23 +26,31 @@ class RocksDBBloomFilterConfigTest {
     void enabledWhenKeyHasNoValue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", null);
-        assertTrue(RocksDBService.useBloomFilters(conf));
+        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+
+        assertTrue(bloomFilters);
 
         conf.put("rocksdb.bloom.filters", "");
-        assertTrue(RocksDBService.useBloomFilters(conf));
+        bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+
+        assertTrue(bloomFilters);
     }
 
     @Test
     void enabledWhenSetToTrue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", "true");
-        assertTrue(RocksDBService.useBloomFilters(conf));
+        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+
+        assertTrue(bloomFilters);
     }
 
     @Test
     void disabledWhenSetToFalse() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.bloom.filters", "false");
-        assertFalse(RocksDBService.useBloomFilters(conf));
+        boolean bloomFilters = ParamHelper.getBooleanParameter(conf, "rocksdb.bloom.filters", true);
+
+        assertFalse(bloomFilters);
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBWALConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBWALConfigTest.java
@@ -17,7 +17,7 @@ class RocksDBWALConfigTest {
     @Test
     void enabledWhenNotConfigured() {
         boolean walDisabled =
-                ParamHelper.getBooleanParameter(new HashMap<>(), "rocksdb.wal.disable", false);
+                ParamHelper.getFlagParameter(new HashMap<>(), "rocksdb.wal.disable", false);
 
         assertFalse(walDisabled);
     }
@@ -27,11 +27,11 @@ class RocksDBWALConfigTest {
     void disabledWhenKeyHasNoValue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", null);
-        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        boolean walDisabled = ParamHelper.getFlagParameter(conf, "rocksdb.wal.disable", false);
         assertTrue(walDisabled);
 
         conf.put("rocksdb.wal.disable", "");
-        walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        walDisabled = ParamHelper.getFlagParameter(conf, "rocksdb.wal.disable", false);
         assertTrue(walDisabled);
     }
 
@@ -39,7 +39,7 @@ class RocksDBWALConfigTest {
     void disabledWhenSetToTrue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", "true");
-        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        boolean walDisabled = ParamHelper.getFlagParameter(conf, "rocksdb.wal.disable", false);
         assertTrue(walDisabled);
     }
 
@@ -47,7 +47,7 @@ class RocksDBWALConfigTest {
     void enabledWhenSetToFalse() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", "false");
-        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        boolean walDisabled = ParamHelper.getFlagParameter(conf, "rocksdb.wal.disable", false);
         assertFalse(walDisabled);
     }
 }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBWALConfigTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBWALConfigTest.java
@@ -6,6 +6,7 @@ package crawlercommons.urlfrontier.service.rocksdb;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import crawlercommons.urlfrontier.service.ParamHelper;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -15,7 +16,10 @@ class RocksDBWALConfigTest {
 
     @Test
     void enabledWhenNotConfigured() {
-        assertFalse(RocksDBService.disableWAL(new HashMap<>()));
+        boolean walDisabled =
+                ParamHelper.getBooleanParameter(new HashMap<>(), "rocksdb.wal.disable", false);
+
+        assertFalse(walDisabled);
     }
 
     /** the mere presence of the key counts as a flag */
@@ -23,23 +27,27 @@ class RocksDBWALConfigTest {
     void disabledWhenKeyHasNoValue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", null);
-        assertTrue(RocksDBService.disableWAL(conf));
+        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        assertTrue(walDisabled);
 
         conf.put("rocksdb.wal.disable", "");
-        assertTrue(RocksDBService.disableWAL(conf));
+        walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        assertTrue(walDisabled);
     }
 
     @Test
     void disabledWhenSetToTrue() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", "true");
-        assertTrue(RocksDBService.disableWAL(conf));
+        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        assertTrue(walDisabled);
     }
 
     @Test
     void enabledWhenSetToFalse() {
         final Map<String, String> conf = new HashMap<>();
         conf.put("rocksdb.wal.disable", "false");
-        assertFalse(RocksDBService.disableWAL(conf));
+        boolean walDisabled = ParamHelper.getBooleanParameter(conf, "rocksdb.wal.disable", false);
+        assertFalse(walDisabled);
     }
 }


### PR DESCRIPTION
## Fix addToConfig (#177)

### Core fix — `addToConfig`

Map config lines with no equal sign to empty string instead of null. This preserves `containsKey()` for flag-style keys while fixing `getOrDefault()` which previously returned `null` and broke `Class.forName()`.

- Bare key (`rocksdb.purge`) → stored as `""`, `getOrDefault` returns `""` (not `null`)
- `implementation` bare key no longer overrides the default (falls through to `RocksDBService`)

### `ParamHelper` — shared configuration utility

New `final` utility class that centralises all config parameter retrieval, parsing, and validation:

- **`getIntegerParameter(config, name)`** → `OptionalInt` (no sentinel, distinguishes "not set" from "set to ≤ 0")
- **`getIntegerParameter(config, name, defaultVal)`** → `int` with default
- **`getLongParameter(config, name)`** → `OptionalLong`
- **`getLongParameter(config, name, defaultVal)`** → `long` with default
- **`getDoubleParameter(config, name, defaultVal)`** → `double` with default
- **`getStringParameter(config, name)`** → empty string if not set
- **`getStringParameter(config, name, defaultVal)`** → default if not set
- **`getBooleanParameter(config, name, defaultVal)`** — empty/null returns `defaultVal`
- **`getFlagParameter(config, name, defaultVal)`** — flag semantics: empty/null means `true` (for legacy keys like `rocksdb.bloom.filters`, `rocksdb.wal.disable`, `server.enable_reflection`)

Parse errors throw `IllegalArgumentException` with the offending value logged (no more `System.exit()` from library code, no more unreadable lambda class names in error messages).

### Migration — one way to read config

All config reads now go through `ParamHelper`:

| File | Config key(s) |
|------|--------------|
| `AbstractFrontierService` | `read.thread.num`, `write.thread.num`, `putURLs.max.inflight`, `putDiscovered.max.inflight` |
| `URLFrontierServer` | `implementation`, `server.enable_reflection` |
| `RocksDBService` | `rocksdb.path`, `rocksdb.bloom.filters`, `rocksdb.wal.disable`, `rocksdb.max_bytes_for_level_base`, `rocksdb.memtable_memory_budget`, `rocksdb.max_background_jobs`, `rocksdb.max_subcompactions`, `rocksdb.bloom.filters.bits_per_key` |
| `DistributedFrontierService` | `forward.deadline.seconds` |
| `ShardedRocksDBService` | `nodes` |

### Tests

- 33 tests in `ParamHelperTest` covering all methods, parse errors (`assertThrows`), empty/null/default behaviour, and flag semantics
- 13 tests in `URLFrontierServerConfigTest` for `addToConfig` parsing
- 4 tests each in `RocksDBBloomFilterConfigTest` and `RocksDBWALConfigTest` for flag-style keys

