### PR TITLE
Do not rely on PriorityQueue.iterator() being in sort order

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.PriorityQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +57,17 @@ public class MemoryFrontierService extends AbstractFrontierService {
             int secsUntilRequestable,
             long now,
             SynchronizedStreamObserver<URLInfo> responseObserver) {
-        Iterator<InternalURL> iter = ((PriorityQueue<InternalURL>) queue).iterator();
+        final URLQueue pq = (URLQueue) queue;
+
+        // PriorityQueue.iterator() walks the backing heap array and is not in sort order: only
+        // the head is guaranteed to be the minimum. Use it as a cheap way to rule out the common
+        // case where nothing is due, and sort explicitly when there is something to send.
+        final InternalURL head = pq.peek();
+        if (head == null || head.nextFetchDate > now) {
+            return 0;
+        }
+
+        Iterator<InternalURL> iter = pq.stream().sorted().iterator();
         int alreadySent = 0;
 
         while (iter.hasNext() && alreadySent < maxURLsPerQueue) {
@@ -66,7 +75,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
             // check that is is due
             if (item.nextFetchDate > now) {
-                // they are sorted by date no need to go further
+                // sorted by date, no need to go further
                 return alreadySent;
             }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
@@ -4,7 +4,6 @@
 package crawlercommons.urlfrontier.service.memory;
 
 import crawlercommons.urlfrontier.service.QueueInterface;
-import java.util.Iterator;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
@@ -31,14 +30,13 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
 
     @Override
     public int getInProcess(long now) {
-        // a URL in process has a heldUntil and is at the beginning of a queue
-        Iterator<InternalURL> iter = this.iterator();
+        // heldUntil is not part of the sort order and the iterator follows the backing heap
+        // array anyway, so every element has to be checked
         int inproc = 0;
-        while (iter.hasNext()) {
-            InternalURL iu = iter.next();
-            if (iu.heldUntil > now) inproc++;
-            // can stop if no heldUntil at all
-            else if (iu.heldUntil == -1) return inproc;
+        for (InternalURL iu : this) {
+            if (iu.heldUntil > now) {
+                inproc++;
+            }
         }
         return inproc;
     }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/memory/MemoryQueueOrderingTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/memory/MemoryQueueOrderingTest.java
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.memory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces issue #162: {@link java.util.PriorityQueue#iterator()} walks the backing heap array
+ * and is not in sort order, so neither sendURLsForQueue nor getInProcess can stop at the first
+ * element that does not match.
+ */
+class MemoryQueueOrderingTest {
+
+    static final String CRAWL_ID = "crawl_id";
+    static final String KEY = "queue_mysite";
+    static final QueueWithinCrawl QWC = QueueWithinCrawl.get(KEY, CRAWL_ID);
+
+    static final long NOW = 1_000_000L;
+
+    static class CollectingObserver implements StreamObserver<URLInfo> {
+        final List<String> received = new ArrayList<>();
+
+        @Override
+        public void onNext(URLInfo value) {
+            received.add(value.getUrl());
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {}
+    }
+
+    private static InternalURL known(String url, long refetchableFromDate) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(CRAWL_ID).setKey(KEY).build();
+        URLItem item =
+                URLItem.newBuilder()
+                        .setID(CRAWL_ID + "_" + url)
+                        .setKnown(
+                                KnownURLItem.newBuilder()
+                                        .setInfo(info)
+                                        .setRefetchableFromDate(refetchableFromDate)
+                                        .build())
+                        .build();
+        return (InternalURL) InternalURL.from(item)[2];
+    }
+
+    /**
+     * Five URLs whose insertion order leaves the heap array as [-100, +100, -50, +400, +300]
+     * relative to {@link #NOW}: the second element is not due yet but the third one is, so anything
+     * stopping at the first non-matching element misses it.
+     */
+    private static URLQueue interleavedQueue() {
+        URLQueue queue = new URLQueue(known("https://www.mysite.com/a", NOW - 100));
+        queue.add(known("https://www.mysite.com/b", NOW + 300));
+        queue.add(known("https://www.mysite.com/c", NOW - 50));
+        queue.add(known("https://www.mysite.com/d", NOW + 400));
+        queue.add(known("https://www.mysite.com/e", NOW + 100));
+        return queue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static SynchronizedStreamObserver<URLInfo> wrap(StreamObserver<URLInfo> observer) {
+        // -1 token means the queue gate is deactivated
+        return (SynchronizedStreamObserver<URLInfo>)
+                SynchronizedStreamObserver.wrapping(observer, -1);
+    }
+
+    @Test
+    void dueURLsBehindANotDueOneAreSent() {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        URLQueue queue = interleavedQueue();
+
+        CollectingObserver observer = new CollectingObserver();
+        int sent = service.sendURLsForQueue(queue, QWC, 10, 30, NOW, wrap(observer));
+
+        assertEquals(2, sent, "a due URL was skipped because of the heap iteration order");
+        assertEquals(
+                List.of("https://www.mysite.com/a", "https://www.mysite.com/c"),
+                observer.received,
+                "due URLs must be sent oldest first");
+    }
+
+    @Test
+    void notDueURLsAreNotSent() {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        URLQueue queue = interleavedQueue();
+
+        CollectingObserver observer = new CollectingObserver();
+        // 200 secs before the earliest nextFetchDate
+        int sent = service.sendURLsForQueue(queue, QWC, 10, 30, NOW - 200, wrap(observer));
+
+        assertEquals(0, sent);
+        assertEquals(List.of(), observer.received);
+    }
+
+    @Test
+    void maxURLsPerQueueTakesTheOldestFirst() {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        URLQueue queue = interleavedQueue();
+
+        CollectingObserver observer = new CollectingObserver();
+        // everything is due, but only 2 can be sent
+        int sent = service.sendURLsForQueue(queue, QWC, 2, 30, NOW + 1000, wrap(observer));
+
+        assertEquals(2, sent);
+        assertEquals(
+                List.of("https://www.mysite.com/a", "https://www.mysite.com/c"), observer.received);
+    }
+
+    @Test
+    void sendingMarksURLsAsInProcess() {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        URLQueue queue = interleavedQueue();
+
+        assertEquals(0, queue.getInProcess(NOW));
+
+        service.sendURLsForQueue(queue, QWC, 10, 30, NOW, wrap(new CollectingObserver()));
+
+        assertEquals(2, queue.getInProcess(NOW));
+        // the hold has expired
+        assertEquals(0, queue.getInProcess(NOW + 30));
+
+        // and they are not sent again while held
+        CollectingObserver second = new CollectingObserver();
+        assertEquals(0, service.sendURLsForQueue(queue, QWC, 10, 30, NOW, wrap(second)));
+    }
+
+    @Test
+    void inProcessCountsHeldURLsAnywhereInTheHeap() {
+        URLQueue queue = interleavedQueue();
+
+        // hold the two entries sitting behind a non-held one in the heap array
+        for (InternalURL iu : queue) {
+            if (iu.url.endsWith("/c") || iu.url.endsWith("/d")) {
+                iu.setHeldUntil(NOW + 60);
+            }
+        }
+
+        assertEquals(
+                2,
+                queue.getInProcess(NOW),
+                "in-process URLs were missed because of the heap iteration order");
+        assertEquals(0, queue.getInProcess(NOW + 60), "expired holds must not count");
+    }
+}


### PR DESCRIPTION
Fixes #162.

`PriorityQueue.iterator()` walks the backing heap array: only the head is guaranteed to be the minimum. Both `MemoryFrontierService.sendURLsForQueue` and `URLQueue.getInProcess` stopped at the first element that did not match, so entries sitting further along in the array were missed.

## Effect

- `sendURLsForQueue` silently under-delivered due URLs, which only became visible on a later `getURLs` once the heap had reshuffled.
- `getInProcess` understated the number of held URLs. That count gates `maxURLsPerQueue` in `tryReserveQueue`, so a queue could be handed out more in-process URLs than its cap allows, and the `inProcess` figure in `getStats` was wrong.
- Under `maxURLsPerQueue` truncation, URLs were also served out of date order.

## Fix

- `sendURLsForQueue` peeks at the head to rule out the common case where nothing is due — the head *is* guaranteed minimal — and sorts explicitly when there is something to send. The nothing-due fast path stays O(1); the sort only happens on calls that will emit URLs.
- `getInProcess` scans every element.

Switching `URLQueue` to a `TreeSet` was considered and rejected: `TreeSet` decides membership with `compareTo`, which includes `nextFetchDate`, while `InternalURL.equals` is url-only. `putURLItem` relies on `contains` to skip already-discovered URLs, and a re-discovered URL gets `nextFetchDate = now`, so `contains` would nearly always miss and the queue would fill with duplicates.

A poll/re-add implementation would be cheaper, but `sendURLsForQueue` runs outside any lock on the queue, so elements temporarily removed from it would be invisible to a concurrent `contains` check. The snapshot approach does not remove anything.

## Tests

`MemoryQueueOrderingTest` sits in the `memory` package so it can build `InternalURL`/`URLQueue` directly and call `sendURLsForQueue` with a fixed `now` — no timing dependence. Five URLs inserted in an order that leaves the heap array as `[-100, +100, -50, +400, +300]` relative to `now`, i.e. the reproduction from the issue.

Reverting the two main-source files makes 4 of the 5 tests fail with exactly the expected symptoms:

```
dueURLsBehindANotDueOneAreSent ........... expected: <2> but was: <1>
inProcessCountsHeldURLsAnywhereInTheHeap . expected: <2> but was: <0>
maxURLsPerQueueTakesTheOldestFirst ....... expected: <[.../a, .../c]> but was: <[.../a, .../e]>
sendingMarksURLsAsInProcess .............. expected: <2> but was: <1>
```

All 127 tests in the service module pass with the fix.

## Follow-ups, not in this PR

- `getInProcess` is now unconditionally O(n) per queue, and is called for every queue in both `tryReserveQueue` and `getStats`. If it shows up in profiling, the fix is a `heldUntil`-ordered structure inside `URLQueue` with lazy expiry, which needs `remove()` overridden to stay in sync.
- `getURLStatus` and `MemoryURLItemIterator` iterate the queue unsynchronised while putURLs workers mutate it. Pre-existing and unrelated to #162, but it is the reason poll/re-add was avoided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aJEypVdR3ueXk4azpzECH