### PR TITLE
Scope the memory backend creation dates to their queue (#166)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.PriorityQueue;
-import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -35,10 +34,6 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
     private static final org.slf4j.Logger LOG =
             LoggerFactory.getLogger(MemoryFrontierService.class);
-
-    // written by the putURLs worker threads, read without synchronization by
-    // getURLStatus and the URL iterators
-    private Map<String, Long> creationDates = new ConcurrentHashMap<>();
 
     public MemoryFrontierService(final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
@@ -139,7 +134,6 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
             URLQueue existing = (URLQueue) getQueues().putIfAbsent(qk, created);
             if (existing == null) {
-                creationDates.put(iu.url, Instant.now().getEpochSecond());
                 if (!discovered && iu.nextFetchDate == 0) {
                     putURLs_completed_count.inc();
                 }
@@ -161,7 +155,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
                 }
             }
 
-            creationDates.put(iu.url, Instant.now().getEpochSecond());
+            queue.setCreationDateIfAbsent(iu.url, Instant.now().getEpochSecond());
 
             // add the new item
             // unless it is an update and it's nextFetchDate is 0 == NEVER
@@ -214,7 +208,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
 
         if (queue.isCompleted(url)) {
             found = true;
-            long creatDt = creationDates.get(url);
+            long creatDt = queue.getCreationDate(url);
             responseObserver.onNext(buildURLItem(builder, knownBuilder, info, 0, creatDt));
         } else {
             Iterator<InternalURL> iter = queue.iterator();
@@ -235,7 +229,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
                     }
 
                     builder.setKnown(knownBuilder.build());
-                    builder.setCreationDate(creationDates.get(url));
+                    builder.setCreationDate(queue.getCreationDate(url));
                     found = true;
                     responseObserver.onNext(builder.build());
                     break;
@@ -260,6 +254,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
         private final org.slf4j.Logger LOG = LoggerFactory.getLogger(MemoryURLItemIterator.class);
 
         private final Entry<QueueWithinCrawl, QueueInterface> qentry;
+        private final URLQueue queue;
         private final long start;
         private final long maxURLs;
         private long pos = 0;
@@ -274,7 +269,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
             this.qentry = qentry;
             this.start = start;
             this.maxURLs = maxURLs;
-            URLQueue queue = (URLQueue) qentry.getValue();
+            this.queue = (URLQueue) qentry.getValue();
             InternalURL[] activeSnapshot;
             synchronized (queue) {
                 activeSnapshot = queue.toArray(new InternalURL[0]);
@@ -307,7 +302,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
                                     .build();
                     if (pos > start) {
                         sent++;
-                        long creatDt = creationDates.get(curcomplete);
+                        long creatDt = queue.getCreationDate(curcomplete);
                         return buildURLItem(builder, knownBuilder, info, 0, creatDt);
                     }
                 } else if (iter.hasNext()) {
@@ -317,7 +312,7 @@ public class MemoryFrontierService extends AbstractFrontierService {
                         URLInfo info = item.toURLInfo(qentry.getKey());
                         if (pos > start) {
                             sent++;
-                            long creatDt = creationDates.get(item.url);
+                            long creatDt = queue.getCreationDate(item.url);
                             return buildURLItem(
                                     builder, knownBuilder, info, item.nextFetchDate, creatDt);
                         }
@@ -359,10 +354,10 @@ public class MemoryFrontierService extends AbstractFrontierService {
         synchronized (queue) {
             if (queue.isCompleted(info.getUrl())) {
                 queue.getCompleted().remove(info.getUrl());
-                creationDates.remove(info.getUrl());
+                queue.removeCreationDate(info.getUrl());
             } else if (queue.contains(iu)) {
                 queue.remove(iu);
-                creationDates.remove(info.getUrl());
+                queue.removeCreationDate(info.getUrl());
             }
         }
     }

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
@@ -4,7 +4,9 @@
 package crawlercommons.urlfrontier.service.memory;
 
 import crawlercommons.urlfrontier.service.QueueInterface;
+import java.time.Instant;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.Set;
@@ -14,12 +16,20 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
 
     public URLQueue(InternalURL initial) {
         this.add(initial);
+        setCreationDateIfAbsent(initial.url, Instant.now().getEpochSecond());
     }
 
     // keep a hash of the completed URLs
     // these won't be refetched
     // written by the putURLs worker threads, read by the getURLs gate via isLimitReached
     private Set<String> completed = ConcurrentHashMap.newKeySet();
+
+    // creation date of every URL held by this queue, active or completed
+    // scoped to the queue so that the entries go away with it and so that the same URL in
+    // another queue or crawl keeps its own date
+    // written by the putURLs worker threads, read without synchronization by getURLStatus
+    // and the URL iterators
+    private final Map<String, Long> creationDates = new ConcurrentHashMap<>();
 
     private Optional<Integer> limit = Optional.empty();
 
@@ -54,6 +64,25 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
 
     public void addToCompleted(String url) {
         completed.add(url);
+    }
+
+    /**
+     * Records when a URL was first added to this queue. Later versions of the same URL keep the
+     * date of the first one, like the RocksDB backend does.
+     */
+    public void setCreationDateIfAbsent(String url, long epochSeconds) {
+        creationDates.putIfAbsent(url, epochSeconds);
+    }
+
+    /**
+     * @return the epoch seconds at which the URL was added to this queue, 0 if unknown
+     */
+    public long getCreationDate(String url) {
+        return creationDates.getOrDefault(url, 0L);
+    }
+
+    public void removeCreationDate(String url) {
+        creationDates.remove(url);
     }
 
     @Override

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryCreationDatesTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryCreationDatesTest.java
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Creation dates are scoped to the queue they belong to, see issue #166. */
+class MemoryCreationDatesTest {
+
+    private static final String URL = "https://www.mysite.com/shared";
+    private static final String KEY = "queue_mysite";
+
+    private MemoryFrontierService service;
+
+    @BeforeEach
+    void setup() {
+        service = new MemoryFrontierService("localhost", 7071);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        service.close();
+    }
+
+    @Test
+    void sameURLInTwoCrawlsKeepsItsOwnCreationDate() {
+        putDiscovered("crawlA", KEY, URL);
+        putDiscovered("crawlB", KEY, URL);
+
+        deleteKnown("crawlA", KEY, URL);
+
+        // the URL is gone from crawlA but crawlB still knows when it was created
+        assertTrue(creationDate("crawlB", KEY, URL) > 0, "creation date lost for the other crawl");
+    }
+
+    @Test
+    void sameURLInTwoQueuesKeepsItsOwnCreationDate() {
+        putDiscovered("crawlA", KEY, URL);
+        putDiscovered("crawlA", "another_queue", URL);
+
+        deleteKnown("crawlA", KEY, URL);
+
+        assertTrue(
+                creationDate("crawlA", "another_queue", URL) > 0,
+                "creation date lost for the other queue");
+    }
+
+    @Test
+    void updatingAURLKeepsItsOriginalCreationDate() throws InterruptedException {
+        putDiscovered("crawlA", KEY, URL);
+        long initial = creationDate("crawlA", KEY, URL);
+
+        // the dates have a resolution of a second: make sure a refreshed one would differ
+        Thread.sleep(1100);
+
+        putKnown("crawlA", KEY, URL, Instant.now().getEpochSecond() + 3600);
+
+        assertEquals(initial, creationDate("crawlA", KEY, URL), "creation date was refreshed");
+    }
+
+    @Test
+    void completingAURLKeepsItsOriginalCreationDate() throws InterruptedException {
+        putDiscovered("crawlA", KEY, URL);
+        long initial = creationDate("crawlA", KEY, URL);
+
+        Thread.sleep(1100);
+
+        // a nextFetchDate of 0 moves the URL to the completed set
+        putKnown("crawlA", KEY, URL, 0);
+
+        assertEquals(initial, creationDate("crawlA", KEY, URL), "creation date was refreshed");
+    }
+
+    private long creationDate(String crawlID, String key, String url) {
+        URLStatusRequest request =
+                URLStatusRequest.newBuilder().setCrawlID(crawlID).setKey(key).setUrl(url).build();
+
+        final AtomicLong date = new AtomicLong(-1);
+
+        service.getURLStatus(
+                request,
+                new StreamObserver<>() {
+                    @Override
+                    public void onNext(URLItem value) {
+                        date.set(value.getCreationDate());
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        fail("getURLStatus failed for " + url + " in " + crawlID, t);
+                    }
+
+                    @Override
+                    public void onCompleted() {}
+                });
+
+        assertTrue(date.get() >= 0, "no status returned for " + url + " in " + crawlID);
+        return date.get();
+    }
+
+    private void putDiscovered(String crawlID, String key, String url) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(crawlID).setKey(key).build();
+        put(
+                URLItem.newBuilder()
+                        .setID(crawlID + "_" + url)
+                        .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                        .build());
+    }
+
+    private void putKnown(String crawlID, String key, String url, long refetchableFromDate) {
+        put(knownItem(crawlID, key, url, refetchableFromDate));
+    }
+
+    private void deleteKnown(String crawlID, String key, String url) {
+        service.deleteURLItem(knownItem(crawlID, key, url, Instant.now().getEpochSecond()));
+    }
+
+    private URLItem knownItem(String crawlID, String key, String url, long refetchableFromDate) {
+        URLInfo info = URLInfo.newBuilder().setUrl(url).setCrawlID(crawlID).setKey(key).build();
+        return URLItem.newBuilder()
+                .setID(crawlID + "_" + url)
+                .setKnown(
+                        KnownURLItem.newBuilder()
+                                .setInfo(info)
+                                .setRefetchableFromDate(refetchableFromDate)
+                                .build())
+                .build();
+    }
+
+    private void put(URLItem item) {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicInteger acked = new AtomicInteger(0);
+
+        StreamObserver<URLItem> requestObserver =
+                service.putURLs(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                assertEquals(AckMessage.Status.OK, value.getStatus());
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                completed.set(true);
+                                fail("putURLs failed", t);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                completed.set(true);
+                            }
+                        });
+
+        requestObserver.onNext(item);
+        requestObserver.onCompleted();
+
+        ServiceTestUtil.awaitStreamClosed(completed);
+        assertEquals(1, acked.get());
+    }
+}


### PR DESCRIPTION
Fixes #166.

`MemoryFrontierService` kept the creation dates in a map keyed on the bare URL, while the rest of the service scopes URLs by queue and crawl. The same URL present in two crawls therefore shared a single entry:

- deleting it from one crawl stripped the date still needed by the other, and every subsequent read unboxed a `null Long` — `getURLStatus` and `MemoryURLItemIterator.next()`, the latter reached from `listURLs`, `countURLs` and `purgeURLs`;
- the entries belonging to a queue removed by `deleteQueue` / `deleteCrawl` were never reclaimed.

## What changed

The dates now live on the `URLQueue` that holds the URL, covering both the active URLs and the completed ones. They are scoped by queue and crawl by construction, and are dropped along with the queue, so `deleteQueue` and `deleteCrawl` need no change. Reads default to `0` when no date is known, as the RocksDB backend already does.

Writes use `putIfAbsent` rather than `put`, so a URL keeps the date of its first insertion instead of having it refreshed by every update. This matches the `brandNew` check in `RocksDBService` and stops an updated URL from being permanently kept out of reach of `purgeURLs`.

The creation date of the seed URL is recorded by the `URLQueue` constructor, before the queue is published by `putIfAbsent`, so a reader cannot see a queue whose URL has no date yet.

## Tests

New `MemoryCreationDatesTest`: same URL in two crawls, same URL in two queues, an update keeps its date, a completion keeps its date. Against the unfixed code the first two fail with the NPE described in the issue and the last two with a refreshed date. The memory backend suites pass (53 tests).

Not covered by a test: the leak from `deleteQueue` / `deleteCrawl`. With the map held inside the queue object there is nothing observable left to assert beyond the queue being removed, which the existing delete tests already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019aJEypVdR3ueXk4azpzECH