### PR TITLE
Lock the remaining queue-content readers in the memory backend (#194)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/MemoryFrontierService.java
@@ -228,29 +228,34 @@ public class MemoryFrontierService extends AbstractFrontierService {
             long creatDt = queue.getCreationDate(url);
             responseObserver.onNext(buildURLItem(builder, knownBuilder, info, 0, creatDt));
         } else {
-            Iterator<InternalURL> iter = queue.iterator();
-
-            while (iter.hasNext()) {
-                InternalURL item = iter.next();
-
-                if (url.equals(item.url)) {
-
-                    try {
-                        knownBuilder.setInfo(item.toURLInfo(qwc));
-                        knownBuilder.setRefetchableFromDate(item.nextFetchDate);
-                    } catch (InvalidProtocolBufferException e) {
-                        LOG.error(e.getMessage(), e);
-                        responseObserver.onError(
-                                io.grpc.Status.fromThrowable(e).asRuntimeException());
-                        return;
+            // PriorityQueue's iterator is fail-fast and the putURLs workers mutate the queue
+            // structurally, so the scan has to happen under the queue monitor. Only the match
+            // is kept: InternalURL is immutable apart from heldUntil, which this path does not
+            // read, so the response can be built outside the lock.
+            InternalURL match = null;
+            synchronized (queue) {
+                for (InternalURL item : queue) {
+                    if (url.equals(item.url)) {
+                        match = item;
+                        break;
                     }
-
-                    builder.setKnown(knownBuilder.build());
-                    builder.setCreationDate(queue.getCreationDate(url));
-                    found = true;
-                    responseObserver.onNext(builder.build());
-                    break;
                 }
+            }
+
+            if (match != null) {
+                try {
+                    knownBuilder.setInfo(match.toURLInfo(qwc));
+                    knownBuilder.setRefetchableFromDate(match.nextFetchDate);
+                } catch (InvalidProtocolBufferException e) {
+                    LOG.error(e.getMessage(), e);
+                    responseObserver.onError(io.grpc.Status.fromThrowable(e).asRuntimeException());
+                    return;
+                }
+
+                builder.setKnown(knownBuilder.build());
+                builder.setCreationDate(queue.getCreationDate(url));
+                found = true;
+                responseObserver.onNext(builder.build());
             }
         }
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/memory/URLQueue.java
@@ -41,14 +41,19 @@ public class URLQueue extends PriorityQueue<InternalURL> implements QueueInterfa
     @Override
     public int getInProcess(long now) {
         // heldUntil is not part of the sort order and the iterator follows the backing heap
-        // array anyway, so every element has to be checked
-        int inproc = 0;
-        for (InternalURL iu : this) {
-            if (iu.heldUntil > now) {
-                inproc++;
+        // array anyway, so every element has to be checked.
+        // PriorityQueue's iterator is fail-fast: getStats calls this without holding the queue
+        // monitor, so take it here. It is the same monitor as tryReserveQueue's, which calls
+        // this method too, and monitors are reentrant.
+        synchronized (this) {
+            int inproc = 0;
+            for (InternalURL iu : this) {
+                if (iu.heldUntil > now) {
+                    inproc++;
+                }
             }
+            return inproc;
         }
-        return inproc;
     }
 
     @Override

--- a/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/MemoryFrontierServiceConcurrencyTest.java
@@ -12,6 +12,8 @@ import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.GetParams;
 import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
 import crawlercommons.urlfrontier.Urlfrontier.PurgeUrlParams;
+import crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams;
+import crawlercommons.urlfrontier.Urlfrontier.Stats;
 import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
 import crawlercommons.urlfrontier.Urlfrontier.URLItem;
 import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
@@ -154,6 +156,99 @@ class MemoryFrontierServiceConcurrencyTest {
         writer.join();
         if (failure.get() != null) {
             fail(failure.get());
+        }
+    }
+
+    @Test
+    void queueContentReadersSurviveConcurrentQueueMutation() throws Exception {
+        MemoryFrontierService service = new MemoryFrontierService("localhost", 0);
+        for (int i = 0; i < 100; i++) {
+            putOne(service, discovered("https://example.com/seed-" + i));
+        }
+
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicBoolean running = new AtomicBoolean(true);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread writer =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                for (int i = 0; i < 500; i++) {
+                                    putOne(service, discovered("https://example.com/live-" + i));
+                                }
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            } finally {
+                                running.set(false);
+                            }
+                        });
+
+        // getStats walks every URL of the queue through getInProcess
+        Thread statsReader =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                while (running.get()) {
+                                    readStats(service);
+                                }
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            }
+                        });
+
+        // getURLStatus scans the queue for a URL that is never there
+        Thread statusReader =
+                new Thread(
+                        () -> {
+                            try {
+                                start.await();
+                                while (running.get()) {
+                                    urlIsKnown(service, "https://example.com/absent");
+                                }
+                            } catch (Throwable t) {
+                                failure.compareAndSet(null, t);
+                            }
+                        });
+
+        writer.start();
+        statsReader.start();
+        statusReader.start();
+        start.countDown();
+        writer.join();
+        statsReader.join();
+        statusReader.join();
+
+        if (failure.get() != null) {
+            fail(failure.get());
+        }
+    }
+
+    private static void readStats(MemoryFrontierService service) throws Exception {
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        service.getStats(
+                QueueWithinCrawlParams.newBuilder().setCrawlID(CRAWL_ID).build(),
+                new StreamObserver<>() {
+                    @Override
+                    public void onNext(Stats value) {}
+
+                    @Override
+                    public void onError(Throwable t) {
+                        error.set(t);
+                        done.countDown();
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        done.countDown();
+                    }
+                });
+        assertTrue(done.await(5, TimeUnit.SECONDS));
+        if (error.get() != null) {
+            throw new IllegalStateException("getStats failed", error.get());
         }
     }
 


### PR DESCRIPTION
Closes #194.

## What was left

The site the issue was filed on — `MemoryFrontierService.sendURLsForQueue` — was already fixed by 39affda, which snapshots the queue under its monitor while making the iteration order safe for #162. But the issue's framing ("the one queue-content reader left outside the per-queue locking contract") turned out to be off by two: the same fail-fast `PriorityQueue` iterator is walked with no lock in two other places.

- **`URLQueue.getInProcess`** — safe when called from `tryReserveQueue`, which holds the queue monitor, but `getStats` (`AbstractFrontierService:509`) calls it with no lock at all. The comment there only claims safety for the *queues map* iterator, not the per-queue heap walk.
- **`MemoryFrontierService.getURLStatus`** — `queue.iterator()` with no lock, the literal pattern #194 describes.

Either can throw `ConcurrentModificationException` out of a gRPC worker, or traverse a heap mid-sift, when a `putURLs` worker mutates the queue concurrently.

## The fix

`getInProcess` takes the queue monitor itself, which covers the `getStats` path without touching `tryReserveQueue` — that already holds the same monitor and re-enters it harmlessly.

`getURLStatus` finds the matching `InternalURL` under the monitor and builds the response outside it, so `onNext` stays lock-free. `InternalURL` is immutable apart from `heldUntil`, which this path does not read, so keeping the reference past the monitor is safe.

## Test

`queueContentReadersSurviveConcurrentQueueMutation`: a writer doing 500 `putURLs` against one queue while a `getStats` loop and a `getURLStatus` loop hammer it. Reverting just the two main-code changes fails it with `ConcurrentModificationException` in ~3s. Full service suite green.

## Not in scope

`sendURLsForQueue` copies *and sorts the whole queue* on every call where the head is due, rather than the bounded `maxURLsPerQueue` selection the issue sketched. That is a cost question rather than the correctness one #194 raised, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015At2iJaQQ6WHiQV586v7Py