### PR TITLE
Bound the forwarded blocking calls in DistributedFrontierService (#174)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -64,6 +64,11 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     public DistributedFrontierService(
             final Map<String, String> configuration, String host, int port) {
         super(configuration, host, port);
+        forwardDeadlineSeconds =
+                Integer.parseInt(
+                        configuration.getOrDefault(
+                                "forward.deadline.seconds",
+                                Integer.toString(FORWARD_DEADLINE_SECONDS)));
     }
 
     // no explicit config
@@ -76,8 +81,14 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     protected boolean clusterMode = false;
 
-    /** Maximum time granted to a forwarded control call before failing the caller. */
+    /** Default for {@link #forwardDeadlineSeconds}. */
     static final int FORWARD_DEADLINE_SECONDS = 30;
+
+    /**
+     * Maximum time granted to a forwarded control call before failing the caller. Configurable with
+     * 'forward.deadline.seconds'.
+     */
+    private final int forwardDeadlineSeconds;
 
     /** How often the items forwarded to other nodes are checked for expiry. */
     static final int INPROCESS_CLEANUP_SECONDS = 10;
@@ -101,8 +112,21 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     private LoadingCache<String, ManagedChannel> channelCache =
             CacheBuilder.newBuilder().removalListener(channelRemovalListener).build(channelLoader);
 
-    private URLFrontierBlockingStub getFrontier(String target) {
-        return URLFrontierGrpc.newBlockingStub(channelCache.getUnchecked(target));
+    /**
+     * A deadline is mandatory on forwarded blocking calls: without one an unresponsive node holds
+     * the caller's gRPC handler thread for ever, and since each of these calls is a fan-out one bad
+     * node takes down the cluster-wide view for every client that asks. Callers pass a single
+     * deadline for the whole fan-out rather than one per hop, so that querying N nodes is bounded
+     * once instead of N times.
+     */
+    private URLFrontierBlockingStub getFrontier(String target, Deadline deadline) {
+        return URLFrontierGrpc.newBlockingStub(channelCache.getUnchecked(target))
+                .withDeadline(deadline);
+    }
+
+    /** Deadline shared by every hop of a fan-out, see {@link #getFrontier(String, Deadline)}. */
+    private Deadline forwardDeadline() {
+        return Deadline.after(forwardDeadlineSeconds, TimeUnit.SECONDS);
     }
 
     /**
@@ -126,7 +150,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     private URLFrontierStub getAsyncFrontier(String target) {
         return URLFrontierGrpc.newStub(channelCache.getUnchecked(target))
-                .withDeadlineAfter(FORWARD_DEADLINE_SECONDS, TimeUnit.SECONDS);
+                .withDeadlineAfter(forwardDeadlineSeconds, TimeUnit.SECONDS);
     }
 
     /**
@@ -293,7 +317,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     "Found conf 'nodes' but current node's address not in the list");
         }
         // one deadline for the whole aggregation, not per node
-        final Deadline deadline = Deadline.after(FORWARD_DEADLINE_SECONDS, TimeUnit.SECONDS);
+        final Deadline deadline = forwardDeadline();
         final Local localRequest = Local.newBuilder().setLocal(true).build();
         final boolean localState = isActive();
         boolean allActive = localState;
@@ -308,7 +332,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                 // queried, an unreachable one fails the call instead of being
                 // silently folded into a false
                 final boolean nodeActive =
-                        getFrontier(node).withDeadline(deadline).getActive(localRequest).getState();
+                        getFrontier(node, deadline).getActive(localRequest).getState();
                 allActive &= nodeActive;
                 sawActive |= nodeActive;
                 sawInactive |= !nodeActive;
@@ -509,7 +533,12 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     /** Correlation tokens for the items forwarded to other nodes; unique within this instance. */
     private final AtomicLong correlationSequence = new AtomicLong();
 
-    /** Delete the queue based on the key in parameter */
+    /**
+     * Delete the queue based on the key in parameter. In cluster mode the deletion is fanned out to
+     * every other node under a single deadline; an unreachable node fails the call instead of
+     * silently returning a partial count. The operation is not atomic: the nodes reached may have
+     * deleted their share when an error is returned, but repeating the deletion is idempotent.
+     */
     @Override
     public void deleteQueue(
             crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams request,
@@ -520,16 +549,21 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         int sizeQueue = 0;
 
         if (!request.getLocal() && clusterMode) {
-            for (String node : getNodes()) {
-                if (node.equals(address)) continue;
-                // call the delete endpoint in the target node
-                // force to local so that remote node don't go recursive
-                QueueWithinCrawlParams local =
-                        QueueWithinCrawlParams.newBuilder(request).setLocal(true).build();
-                URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-                crawlercommons.urlfrontier.Urlfrontier.Long total =
-                        blockingFrontier.deleteQueue(local);
-                sizeQueue += total.getValue();
+            // force to local so that remote node don't go recursive
+            QueueWithinCrawlParams local =
+                    QueueWithinCrawlParams.newBuilder(request).setLocal(true).build();
+            final Deadline deadline = forwardDeadline();
+            try {
+                for (String node : getNodes()) {
+                    if (node.equals(address)) continue;
+                    // call the delete endpoint in the target node
+                    crawlercommons.urlfrontier.Urlfrontier.Long total =
+                            getFrontier(node, deadline).deleteQueue(local);
+                    sizeQueue += total.getValue();
+                }
+            } catch (StatusRuntimeException e) {
+                responseObserver.onError(e);
+                return;
             }
         }
         // delete the queue held by this node
@@ -544,6 +578,10 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
     protected abstract int deleteLocalQueue(final QueueWithinCrawl qc);
 
+    /**
+     * Same fan-out contract as {@link #deleteQueue}: bounded by a single deadline, an unreachable
+     * node fails the call rather than under-reporting the number of URLs deleted.
+     */
     @Override
     public void deleteCrawl(
             crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage message,
@@ -566,13 +604,18 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                             .setLocal(true)
                             .setValue(message.getValue())
                             .build();
-            for (String node : getNodes()) {
-                if (node.equals(address)) continue;
-                // call the delete endpoint in the target node
-                URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-                crawlercommons.urlfrontier.Urlfrontier.Long localCount =
-                        blockingFrontier.deleteCrawl(local);
-                total += localCount.getValue();
+            final Deadline deadline = forwardDeadline();
+            try {
+                for (String node : getNodes()) {
+                    if (node.equals(address)) continue;
+                    // call the delete endpoint in the target node
+                    crawlercommons.urlfrontier.Urlfrontier.Long localCount =
+                            getFrontier(node, deadline).deleteCrawl(local);
+                    total += localCount.getValue();
+                }
+            } catch (StatusRuntimeException e) {
+                responseObserver.onError(e);
+                return;
             }
         }
 
@@ -606,20 +649,28 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         // force to local so that remote nodes don't go recursive
         QueueWithinCrawlParams local =
                 QueueWithinCrawlParams.newBuilder(request).setLocal(true).build();
-        for (String node : getNodes()) {
-            URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-            Stats localStats = blockingFrontier.getStats(local);
-            numQueues += localStats.getNumberOfQueues();
-            size += localStats.getSize();
-            inProc += localStats.getInProcess();
-            for (Entry<String, Long> entry : localStats.getCountsMap().entrySet()) {
-                counts.compute(
-                        entry.getKey(),
-                        (w, prev) ->
-                                prev != null
-                                        ? prev + entry.getValue().longValue()
-                                        : entry.getValue().longValue());
+        // one deadline for the whole aggregation, not per node
+        final Deadline deadline = forwardDeadline();
+        try {
+            for (String node : getNodes()) {
+                Stats localStats = getFrontier(node, deadline).getStats(local);
+                numQueues += localStats.getNumberOfQueues();
+                size += localStats.getSize();
+                inProc += localStats.getInProcess();
+                for (Entry<String, Long> entry : localStats.getCountsMap().entrySet()) {
+                    counts.compute(
+                            entry.getKey(),
+                            (w, prev) ->
+                                    prev != null
+                                            ? prev + entry.getValue().longValue()
+                                            : entry.getValue().longValue());
+                }
             }
+        } catch (StatusRuntimeException e) {
+            // an unreachable node surfaces an error rather than silently deflating the
+            // cluster-wide figures
+            responseObserver.onError(e);
+            return;
         }
 
         Stats stats =
@@ -639,11 +690,18 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         if (!request.getLocal() && clusterMode) {
             // force to local so that remote node don't go recursive
             LogLevelParams local = LogLevelParams.newBuilder(request).setLocal(true).build();
-            for (String node : getNodes()) {
-                // exclude the local node
-                if (node.equals(address)) continue;
-                URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-                blockingFrontier.setLogLevel(local);
+            final Deadline deadline = forwardDeadline();
+            try {
+                for (String node : getNodes()) {
+                    // exclude the local node
+                    if (node.equals(address)) continue;
+                    getFrontier(node, deadline).setLogLevel(local);
+                }
+            } catch (StatusRuntimeException e) {
+                // the level is not applied locally either: the call is idempotent, a retry
+                // once the node is back sets it everywhere
+                responseObserver.onError(e);
+                return;
             }
         }
         super.setLogLevel(request, responseObserver);
@@ -660,14 +718,21 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         if (!request.getLocal() && clusterMode) {
             // force to local so that remote node don't go recursive
             Local local = Local.newBuilder().setLocal(true).build();
-            for (String node : getNodes()) {
-                // exclude the local node
-                if (node.equals(address)) continue;
-                URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-                StringList results = blockingFrontier.listCrawls(local);
-                for (String s : results.getValuesList()) {
-                    crawlIDs.add(s);
+            // one deadline for the whole aggregation, not per node
+            final Deadline deadline = forwardDeadline();
+            try {
+                for (String node : getNodes()) {
+                    // exclude the local node
+                    if (node.equals(address)) continue;
+                    StringList results = getFrontier(node, deadline).listCrawls(local);
+                    for (String s : results.getValuesList()) {
+                        crawlIDs.add(s);
+                    }
                 }
+            } catch (StatusRuntimeException e) {
+                // an unreachable node surfaces an error rather than an incomplete list
+                responseObserver.onError(e);
+                return;
             }
         }
 
@@ -695,12 +760,19 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         Set<String> dedup = new HashSet<>();
 
         Pagination localPagination = Pagination.newBuilder(request).setLocal(true).build();
-        for (String node : getNodes()) {
-            URLFrontierBlockingStub blockingFrontier = getFrontier(node);
-            QueueList listqueues = blockingFrontier.listQueues(localPagination);
-            for (String s : listqueues.getValuesList()) {
-                dedup.add(s);
+        // one deadline for the whole aggregation, not per node
+        final Deadline deadline = forwardDeadline();
+        try {
+            for (String node : getNodes()) {
+                QueueList listqueues = getFrontier(node, deadline).listQueues(localPagination);
+                for (String s : listqueues.getValuesList()) {
+                    dedup.add(s);
+                }
             }
+        } catch (StatusRuntimeException e) {
+            // an unreachable node surfaces an error rather than an incomplete list
+            responseObserver.onError(e);
+            return;
         }
 
         crawlercommons.urlfrontier.Urlfrontier.QueueList.Builder list = QueueList.newBuilder();

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardDeadlineTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardDeadlineTest.java
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier.DeleteCrawlMessage;
+import crawlercommons.urlfrontier.Urlfrontier.Local;
+import crawlercommons.urlfrontier.Urlfrontier.LogLevelParams;
+import crawlercommons.urlfrontier.Urlfrontier.Pagination;
+import crawlercommons.urlfrontier.Urlfrontier.QueueWithinCrawlParams;
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+/**
+ * Issue #174: the blocking calls forwarded to every node must be bounded by a deadline. A node that
+ * is merely unreachable fails fast on connection refused; the case that used to hang the caller's
+ * handler thread for ever is a node that accepts the connection and then never answers, which the
+ * black hole below reproduces.
+ */
+class ForwardDeadlineTest {
+
+    private static final int PORT_A = 7311;
+    private static final int DEADLINE_SECONDS = 2;
+
+    /** Generous enough that a hanging fan-out cannot be mistaken for a slow one. */
+    private static final Duration MAX_WAIT = Duration.ofSeconds(DEADLINE_SECONDS + 15L);
+
+    private static final String PATH_A = "./target/rocksdb-deadline-a";
+
+    static ShardedRocksDBService serviceA;
+    static Server serverA;
+    static ManagedChannel channelA;
+    static URLFrontierBlockingStub stubA;
+    static BlackHole blackHole;
+
+    /** Accepts connections and never says anything: every RPC sent to it stays pending. */
+    private static final class BlackHole implements AutoCloseable {
+
+        private final ServerSocket socket;
+        private final List<Socket> accepted = new ArrayList<>();
+        private final Thread thread;
+
+        BlackHole() throws IOException {
+            socket = new ServerSocket(0);
+            thread =
+                    new Thread(
+                            () -> {
+                                while (!socket.isClosed()) {
+                                    try {
+                                        Socket s = socket.accept();
+                                        // keep a reference so the connection stays open
+                                        synchronized (accepted) {
+                                            accepted.add(s);
+                                        }
+                                    } catch (IOException e) {
+                                        return;
+                                    }
+                                }
+                            },
+                            "blackhole-accept");
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        String target() {
+            return "localhost:" + socket.getLocalPort();
+        }
+
+        @Override
+        public void close() throws IOException {
+            socket.close();
+            synchronized (accepted) {
+                for (Socket s : accepted) {
+                    try {
+                        s.close();
+                    } catch (IOException e) {
+                        // closing on teardown
+                    }
+                }
+            }
+        }
+    }
+
+    @BeforeAll
+    static void setup() throws IOException {
+        FileUtils.deleteQuietly(new File(PATH_A));
+        blackHole = new BlackHole();
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", PATH_A);
+        conf.put("nodes", "localhost:" + PORT_A + "," + blackHole.target());
+        conf.put("forward.deadline.seconds", Integer.toString(DEADLINE_SECONDS));
+        serviceA = new ShardedRocksDBService(conf, "localhost", PORT_A);
+        serverA = ServerBuilder.forPort(PORT_A).addService(serviceA).build().start();
+        channelA = ManagedChannelBuilder.forTarget("localhost:" + PORT_A).usePlaintext().build();
+        // a deadline well beyond the server-side one: the failure under test must come
+        // from the forwarded call, not from the client giving up
+        stubA = URLFrontierGrpc.newBlockingStub(channelA).withDeadlineAfter(60, TimeUnit.SECONDS);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (channelA != null) {
+            channelA.shutdownNow();
+            channelA.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        if (serverA != null) {
+            serverA.shutdownNow();
+            serverA.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        try {
+            if (serviceA != null) {
+                serviceA.close();
+            }
+        } finally {
+            try {
+                if (blackHole != null) {
+                    blackHole.close();
+                }
+            } finally {
+                FileUtils.deleteQuietly(new File(PATH_A));
+            }
+        }
+    }
+
+    /** Fails if the call hangs, and returns the status it failed with. */
+    private static Status.Code failsWithin(Executable call) {
+        StatusRuntimeException e =
+                assertTimeoutPreemptively(
+                        MAX_WAIT,
+                        () -> assertThrows(StatusRuntimeException.class, call),
+                        "the forwarded call was not bounded by a deadline");
+        return e.getStatus().getCode();
+    }
+
+    @Test
+    void getStatsIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(() -> stubA.getStats(QueueWithinCrawlParams.newBuilder().build())));
+    }
+
+    @Test
+    void listQueuesIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(() -> stubA.listQueues(Pagination.newBuilder().build())));
+    }
+
+    @Test
+    void listCrawlsIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(() -> stubA.listCrawls(Local.newBuilder().build())));
+    }
+
+    @Test
+    void setLogLevelIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(
+                        () ->
+                                stubA.setLogLevel(
+                                        LogLevelParams.newBuilder()
+                                                .setPackage("crawlercommons.urlfrontier")
+                                                .setLevel(LogLevelParams.Level.INFO)
+                                                .build())));
+    }
+
+    @Test
+    void deleteQueueIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(
+                        () ->
+                                stubA.deleteQueue(
+                                        QueueWithinCrawlParams.newBuilder()
+                                                .setKey("example.com")
+                                                .build())));
+    }
+
+    @Test
+    void deleteCrawlIsBounded() {
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(
+                        () ->
+                                stubA.deleteCrawl(
+                                        DeleteCrawlMessage.newBuilder()
+                                                .setValue("DEFAULT")
+                                                .build())));
+    }
+
+    @Test
+    void getActiveIsBounded() {
+        // already had a deadline: guards against it being lost again
+        assertEquals(
+                Status.Code.DEADLINE_EXCEEDED,
+                failsWithin(() -> stubA.getActive(Local.newBuilder().build())));
+    }
+}


### PR DESCRIPTION
Closes #174.

`deleteQueue`, `deleteCrawl`, `getStats`, `setLogLevel`, `listCrawls` and `listQueues` fanned out to every node with a blocking stub carrying no deadline. A node that accepts the connection but never answers held the caller's gRPC handler thread for ever, and since each of these is a fan-out, one such node took down the cluster-wide view for every client that asked.

### The fix

`getFrontier(String)` is gone. The only way to obtain a forwarding blocking stub is now `getFrontier(String target, Deadline deadline)`, which applies the deadline itself — a new call site cannot forget it.

Each of the six fan-outs creates **one** `Deadline` per request and shares it across every hop, so an N-node fan-out is bounded once rather than N times. This is the pattern `getActive` already used. Each loop catches `StatusRuntimeException` and passes it to `responseObserver.onError`, so an unreachable node surfaces an error instead of being folded into a partial count or a truncated list.

On failure the local half is not applied either. All six calls are idempotent, so a retry once the node is back sets the same state everywhere; this is documented on the methods that mutate state.

`FORWARD_DEADLINE_SECONDS` (still 30) becomes the default of a new `forward.deadline.seconds` setting, following the existing `putURLs.max.inflight` style. It now also drives `getAsyncFrontier` and `getActive`, which hardcoded the constant. This is what keeps the new test quick.

### The test

The existing dead-node tests in `DistributedFrontierServiceTest` could not have caught this: a shut-down server refuses the connection and fails fast. The hang needs a node that accepts the TCP connection and then never speaks gRPC.

`ForwardDeadlineTest` stands up a raw `ServerSocket` black hole next to one live sharded service with `forward.deadline.seconds=2`, and asserts that all six methods — plus `getActive`, as a guard against losing the deadline it already had — fail with `DEADLINE_EXCEEDED` inside an `assertTimeoutPreemptively`.

Verified the test is meaningful by temporarily dropping `.withDeadline(deadline)` from `getFrontier`: `getStatsIsBounded` then hangs and fails on the timeout, parked in `ClientCalls.blockingUnaryCall` — exactly the reported failure mode. With the fix, the 164 tests of the service module pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015At2iJaQQ6WHiQV586v7Py
