### PR TITLE
Make the shared putURLs forwarding stream safe for concurrent clients

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -37,6 +37,7 @@ import crawlercommons.urlfrontier.service.AsyncCompletion;
 import crawlercommons.urlfrontier.service.QueueInterface;
 import crawlercommons.urlfrontier.service.QueueWithinCrawl;
 import crawlercommons.urlfrontier.service.SynchronizedStreamObserver;
+import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -418,14 +419,27 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                                         }
                                     };
 
-                    return stub.putURLs(observer);
+                    // this stream is shared by every client stream forwarding to that
+                    // node, so it must not inherit the Context of whichever server call
+                    // happened to trigger the load: that call ending would cancel the
+                    // stream for everyone and strand the items already in flight on it
+                    final Context previous = Context.ROOT.attach();
+                    try {
+                        // gRPC serializes the callbacks of a single stream but not across
+                        // streams, and concurrent onNext on one client call corrupts its
+                        // outbound buffers; -1 disables the token budget, the wrapper is
+                        // used here for its mutual exclusion only
+                        return SynchronizedStreamObserver.wrapping(stub.putURLs(observer), -1);
+                    } finally {
+                        Context.ROOT.detach(previous);
+                    }
                 }
             };
 
-    private final RemovalListener<String, StreamObserver<URLItem>> observerlistener =
+    private final RemovalListener<Integer, StreamObserver<URLItem>> observerlistener =
             new RemovalListener<>() {
                 @Override
-                public void onRemoval(RemovalNotification<String, StreamObserver<URLItem>> n) {
+                public void onRemoval(RemovalNotification<Integer, StreamObserver<URLItem>> n) {
                     LOG.info("Removed StreamObserver {} with key {}", n.getValue(), n.getKey());
                 }
             };
@@ -434,7 +448,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
             CacheBuilder.newBuilder()
                     .removalListener(observerlistener)
                     .expireAfterAccess(1, TimeUnit.MINUTES)
-                    .build((CacheLoader) observerloader);
+                    .build(observerloader);
 
     /**
      * An item forwarded to another node, waiting for that node to ack it back. Held in {@link

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierServiceTest.java
@@ -41,6 +41,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterAll;
@@ -510,6 +512,98 @@ class DistributedFrontierServiceTest {
                     AckMessage.Status.FAIL,
                     ack.getStatus(),
                     "no item must be left to expire in the in-process cache");
+        }
+    }
+
+    @Test
+    @Order(18)
+    void concurrentStreamsForwardingToTheSameOwnerAreAllAcked() throws Exception {
+        // issue #69: every client stream forwards through the same per-partition
+        // stream, which must therefore be written to under mutual exclusion (gRPC
+        // serializes the callbacks of one stream but not across streams) and must
+        // not be bound to the Context of whichever server call created it
+        final int streams = 8;
+        final int itemsPerStream = 250;
+        final String key = keyOwnedBy(1, "concurrent");
+
+        final List<AckMessage> acks = Collections.synchronizedList(new ArrayList<>());
+        final List<Throwable> errors = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(streams);
+        final ExecutorService pool = Executors.newFixedThreadPool(streams);
+        try {
+            for (int s = 0; s < streams; s++) {
+                final int stream = s;
+                pool.execute(
+                        () -> {
+                            StreamObserver<URLItem> input =
+                                    URLFrontierGrpc.newStub(channelA)
+                                            .putURLs(
+                                                    new StreamObserver<AckMessage>() {
+                                                        @Override
+                                                        public void onNext(AckMessage value) {
+                                                            acks.add(value);
+                                                        }
+
+                                                        @Override
+                                                        public void onError(Throwable t) {
+                                                            errors.add(t);
+                                                            done.countDown();
+                                                        }
+
+                                                        @Override
+                                                        public void onCompleted() {
+                                                            done.countDown();
+                                                        }
+                                                    });
+                            try {
+                                // all the streams push at once: the forwarding
+                                // observer must be hit from several threads
+                                start.await();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                return;
+                            }
+                            for (int i = 0; i < itemsPerStream; i++) {
+                                URLInfo info =
+                                        URLInfo.newBuilder()
+                                                .setUrl("https://" + key + "/s" + stream + "-" + i)
+                                                .setKey(key)
+                                                .setCrawlID("DEFAULT")
+                                                .build();
+                                input.onNext(
+                                        URLItem.newBuilder()
+                                                .setID(stream + "-" + i)
+                                                .setDiscovered(
+                                                        DiscoveredURLItem.newBuilder()
+                                                                .setInfo(info)
+                                                                .build())
+                                                .build());
+                            }
+                            input.onCompleted();
+                        });
+            }
+            start.countDown();
+            assertTrue(
+                    done.await(60, TimeUnit.SECONDS),
+                    "concurrent putURLs streams did not complete in time: acks="
+                            + acks.size()
+                            + " streamsLeft="
+                            + done.getCount()
+                            + " errors="
+                            + errors);
+        } finally {
+            pool.shutdownNow();
+        }
+
+        assertTrue(errors.isEmpty(), "no stream must fail: " + errors);
+        assertEquals(
+                streams * itemsPerStream, acks.size(), "every item must be acked exactly once");
+        for (AckMessage ack : acks) {
+            assertNotEquals(
+                    AckMessage.Status.FAIL,
+                    ack.getStatus(),
+                    "no forwarded item must be lost when streams run concurrently");
         }
     }
 


### PR DESCRIPTION
Fixes #69.

Items whose partition is not the local node are forwarded through a per-partition `StreamObserver` held in `observercache`. That observer is shared by every client stream hitting the same partition, and two separate defects followed from it.

### Concurrent writes to a shared client call

gRPC serializes the callbacks of a single server stream, but not across streams, so two clients forwarding to the same node call `onNext` concurrently on one `ClientCallStreamObserver`. That corrupts its outbound buffers and surfaces as the `IllegalReferenceCountException` / `UnpooledSlicedByteBuf(freed)` crash in the issue.

The observer is now wrapped in a `SynchronizedStreamObserver`, the same way the client-facing observer in `putURLs` already was. The `-1` disables the token budget: the wrapper is used here for its mutual exclusion only.

### Context inherited from an arbitrary server call

The forwarding stream is created lazily inside the cache loader, which runs on the server handler thread of whichever client stream happened to trigger the load. The outgoing call therefore inherited that server call's gRPC `Context`, and when that one client disconnected the shared stream was cancelled for *every* client:

```
CANCELLED: io.grpc.Context was cancelled without error
```

Items already in flight on it were then stranded until the one-minute `inprocesscache` expiry failed them. The call is now created under `Context.ROOT`.

This one was found by the regression test below rather than reported — the test still hung with only the synchronization fix in place.

### Also

The removal listener was declared with a `String` key on an `Integer`-keyed cache, which forced a raw `(CacheLoader)` cast on the builder. Both are fixed.

## Testing

`DistributedFrontierServiceTest#concurrentStreamsForwardingToTheSameOwnerAreAllAcked`: 8 concurrent client streams against node A, 250 items each, all keyed to a queue owned by node B, released together by a latch.

| Configuration | Result |
| --- | --- |
| Both fixes | 2000 acks, ~1.5s |
| `Context` fix only | hangs, fails 3/3 runs |
| Synchronization only | hangs at ~1700-1900 acks |
| Neither | hangs at ~536 acks |

Full service suite passes: 165 tests, 0 failures.

## Left for later

Both pre-existing and out of scope here:

- Evicting an entry from `observercache` neither completes nor cancels the underlying call, leaking a half-open stream on both nodes. Completing it on eviction would be wrong while items are still in flight, so it needs its own design.
- The forwarding call still ignores `isReady` / `onReadyHandler` (item 2 in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015At2iJaQQ6WHiQV586v7Py
