### PR TITLE
Add a DumpURLs client command to export the Frontier data

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -31,4 +31,31 @@ Commands:
   DeleteCrawl  Delete an entire crawl from the Frontier
   SetLogLevel  Change the log level of a package in the Frontier service
   CountURLs    Counts the number of URLs in a Frontier
+  DumpURLs     Export all the URLs of a Frontier as JSON, one per line, in the
+                 format taken by PutURLs; used to migrate the data to a
+                 different backend or version.
 ```
+
+## Exporting and re-importing the data
+
+`DumpURLs` writes every URL of a Frontier, with its queue key, crawl ID, metadata and scheduling
+information, as one JSON object per line - the exact format `PutURLs` takes as input. This makes it
+possible to migrate the data to a different backend implementation or a different major version:
+
+```
+java -jar ./target/urlfrontier-client*.jar DumpURLs -o frontier.jsonl.gz
+java -jar ./target/urlfrontier-client*.jar -t newhost PutURLs -f frontier.jsonl.gz
+```
+
+By default the content is streamed one crawl at a time; with `-t` the client lists the queues
+first and several threads dump them in parallel, which spreads the work over the server's cores:
+
+```
+java -jar ./target/urlfrontier-client*.jar DumpURLs -t 8 -o frontier.jsonl.gz
+```
+
+The dump covers only the node the client connects to; in a cluster, dump every node and
+concatenate the files before re-importing. For a complete and consistent dump, deactivate the
+Frontier (`SetActive -s false`) and stop injecting URLs while it runs. Note that the creation date
+of the URLs is not preserved by a dump / re-import cycle: the target Frontier assigns it at import
+time, which affects `PurgeURLs`.

--- a/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/Client.java
@@ -27,7 +27,8 @@ import picocli.CommandLine.Option;
             SetCrawlLimit.class,
             GetURLStatus.class,
             CountURLs.class,
-            PurgeURLs.class
+            PurgeURLs.class,
+            DumpURLs.class
         },
         description = "Interacts with a URL Frontier from the command line")
 public class Client {

--- a/client/src/main/java/crawlercommons/urlfrontier/client/DumpURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/DumpURLs.java
@@ -115,6 +115,7 @@ public class DumpURLs implements Callable<Integer> {
             final Instant start = Instant.now();
             final boolean toFile = !output.isEmpty();
 
+            boolean success = false;
             try {
                 OutputStream os = toFile ? new FileOutputStream(output) : System.out;
                 if (toFile && output.endsWith(".gz")) {
@@ -122,22 +123,10 @@ public class DumpURLs implements Callable<Integer> {
                 }
                 out = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
 
-                final boolean success;
                 if (threads > 1) {
                     success = dumpParallel(blockingFrontier, crawlIDs);
                 } else {
                     success = dumpSequential(blockingFrontier, crawlIDs);
-                }
-
-                if (toFile) {
-                    out.close();
-                } else {
-                    out.flush();
-                }
-
-                if (!success) {
-                    System.err.println("The dump is incomplete");
-                    return 1;
                 }
             } catch (IOException e) {
                 System.err.println(
@@ -145,6 +134,29 @@ public class DumpURLs implements Callable<Integer> {
                                 + (toFile ? output : "to the standard output")
                                 + ": "
                                 + e.getMessage());
+            } finally {
+                // whatever happened, finish the output so that what was dumped so far
+                // stays usable: a gzip stream without its trailer would be invalid
+                if (out != null) {
+                    try {
+                        if (toFile) {
+                            out.close();
+                        } else {
+                            out.flush();
+                        }
+                    } catch (IOException e) {
+                        success = false;
+                        System.err.println(
+                                "Error while writing "
+                                        + (toFile ? output : "to the standard output")
+                                        + ": "
+                                        + e.getMessage());
+                    }
+                }
+            }
+
+            if (!success) {
+                System.err.println("The dump is incomplete");
                 return 1;
             }
 

--- a/client/src/main/java/crawlercommons/urlfrontier/client/DumpURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/DumpURLs.java
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.client;
+
+import com.google.protobuf.util.JsonFormat;
+import com.google.protobuf.util.JsonFormat.Printer;
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.Urlfrontier.ListUrlParams;
+import crawlercommons.urlfrontier.Urlfrontier.Local;
+import crawlercommons.urlfrontier.Urlfrontier.Pagination;
+import crawlercommons.urlfrontier.Urlfrontier.QueueList;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPOutputStream;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Command(
+        name = "DumpURLs",
+        description = {
+            "Export all the URLs of a Frontier as JSON, one per line, in the format taken by"
+                    + " PutURLs; used to migrate the data to a different backend or version.",
+            "The dump covers only the node the client connects to: in a cluster, dump every node"
+                    + " and concatenate the files.",
+            "Deactivate the Frontier and stop the URL injection first if the dump must be"
+                    + " complete."
+        })
+public class DumpURLs implements Callable<Integer> {
+
+    /** how many URLs between progress messages */
+    private static final long REPORT_EVERY = 100_000;
+
+    /** how many queue names are retrieved per ListQueues call */
+    private static final int QUEUE_PAGE = 10_000;
+
+    @ParentCommand private Client parent;
+
+    @Option(
+            names = {"-o", "--output"},
+            defaultValue = "",
+            paramLabel = "STRING",
+            description =
+                    "output file for the dump, compressed with gzip if its name ends in .gz;"
+                            + " defaults to the standard output")
+    private String output;
+
+    @Option(
+            names = {"-c", "--crawlID"},
+            required = false,
+            paramLabel = "STRING",
+            description = "restrict the dump to this crawl; by default every crawl is dumped")
+    private String crawl;
+
+    @Option(
+            names = {"-t", "--threads"},
+            defaultValue = "1",
+            paramLabel = "NUM",
+            description =
+                    "number of threads dumping the content queue by queue, each on its own"
+                            + " connection (default to 1, i.e. each crawl is streamed whole in a"
+                            + " single call)")
+    private int threads;
+
+    /** PutURLs reads the dump back one line at a time */
+    private final Printer printer = JsonFormat.printer().omittingInsignificantWhitespace();
+
+    private final AtomicLong total = new AtomicLong();
+
+    private Writer out;
+
+    @Override
+    public Integer call() {
+
+        final ManagedChannel channel =
+                ManagedChannelBuilder.forAddress(parent.hostname, parent.port)
+                        .usePlaintext()
+                        .build();
+
+        try {
+            final URLFrontierBlockingStub blockingFrontier =
+                    URLFrontierGrpc.newBlockingStub(channel);
+
+            // the URLs come from the node we are connected to, so take the crawl IDs
+            // from that same node
+            final List<String> crawlIDs;
+            if (crawl != null) {
+                crawlIDs = List.of(crawl);
+            } else {
+                crawlIDs =
+                        blockingFrontier
+                                .listCrawls(Local.newBuilder().setLocal(true).build())
+                                .getValuesList();
+            }
+
+            final Instant start = Instant.now();
+            final boolean toFile = !output.isEmpty();
+
+            try {
+                OutputStream os = toFile ? new FileOutputStream(output) : System.out;
+                if (toFile && output.endsWith(".gz")) {
+                    os = new GZIPOutputStream(os);
+                }
+                out = new BufferedWriter(new OutputStreamWriter(os, StandardCharsets.UTF_8));
+
+                final boolean success;
+                if (threads > 1) {
+                    success = dumpParallel(blockingFrontier, crawlIDs);
+                } else {
+                    success = dumpSequential(blockingFrontier, crawlIDs);
+                }
+
+                if (toFile) {
+                    out.close();
+                } else {
+                    out.flush();
+                }
+
+                if (!success) {
+                    System.err.println("The dump is incomplete");
+                    return 1;
+                }
+            } catch (IOException e) {
+                System.err.println(
+                        "Error while writing "
+                                + (toFile ? output : "to the standard output")
+                                + ": "
+                                + e.getMessage());
+                return 1;
+            }
+
+            long timetaken = Instant.now().toEpochMilli() - start.toEpochMilli();
+            System.err.println("Total: " + total.get() + " URLs dumped in " + timetaken + " msec");
+
+            return 0;
+        } catch (StatusRuntimeException e) {
+            System.err.println("Error while dumping the URLs: " + e.getMessage());
+            return 1;
+        } finally {
+            channel.shutdownNow();
+        }
+    }
+
+    /** Streams each crawl whole, in a single call */
+    private boolean dumpSequential(
+            final URLFrontierBlockingStub blockingFrontier, final List<String> crawlIDs)
+            throws IOException {
+        for (String crawlID : crawlIDs) {
+            long count = 0;
+            ListUrlParams params =
+                    ListUrlParams.newBuilder()
+                            .setCrawlID(crawlID)
+                            .setSize(Integer.MAX_VALUE)
+                            .build();
+            Iterator<URLItem> it = blockingFrontier.listURLs(params);
+            while (it.hasNext()) {
+                writeLine(printer.print(it.next()));
+                count++;
+            }
+            System.err.println(count + " URLs dumped for crawl " + crawlID);
+        }
+        return true;
+    }
+
+    /**
+     * Lists the queues of every crawl, then dumps them queue by queue with the threads sharing the
+     * list; returns false if any of them failed.
+     */
+    private boolean dumpParallel(
+            final URLFrontierBlockingStub blockingFrontier, final List<String> crawlIDs) {
+
+        // [crawlID, queue] pairs, taken by whichever thread is free
+        final ConcurrentLinkedQueue<String[]> work = new ConcurrentLinkedQueue<>();
+
+        for (String crawlID : crawlIDs) {
+            int startpos = 0;
+            int queues = 0;
+            while (true) {
+                QueueList page =
+                        blockingFrontier.listQueues(
+                                Pagination.newBuilder()
+                                        .setCrawlID(crawlID)
+                                        .setIncludeInactive(true)
+                                        .setLocal(true)
+                                        .setStart(startpos)
+                                        .setSize(QUEUE_PAGE)
+                                        .build());
+                for (String queue : page.getValuesList()) {
+                    work.add(new String[] {crawlID, queue});
+                }
+                queues += page.getValuesCount();
+                startpos += page.getValuesCount();
+                if (page.getValuesCount() < QUEUE_PAGE) {
+                    break;
+                }
+            }
+            System.err.println(queues + " queues to dump for crawl " + crawlID);
+        }
+
+        final AtomicBoolean failed = new AtomicBoolean(false);
+
+        final List<Thread> workers = new ArrayList<>(threads);
+        for (int i = 0; i < threads; i++) {
+            Thread worker =
+                    new Thread(
+                            () -> {
+                                final ManagedChannel channel =
+                                        ManagedChannelBuilder.forAddress(
+                                                        parent.hostname, parent.port)
+                                                .usePlaintext()
+                                                .build();
+                                try {
+                                    final URLFrontierBlockingStub stub =
+                                            URLFrontierGrpc.newBlockingStub(channel);
+                                    String[] item;
+                                    while (!failed.get() && (item = work.poll()) != null) {
+                                        ListUrlParams params =
+                                                ListUrlParams.newBuilder()
+                                                        .setCrawlID(item[0])
+                                                        .setKey(item[1])
+                                                        .setSize(Integer.MAX_VALUE)
+                                                        .build();
+                                        Iterator<URLItem> it = stub.listURLs(params);
+                                        while (it.hasNext()) {
+                                            writeLine(printer.print(it.next()));
+                                        }
+                                    }
+                                } catch (StatusRuntimeException | IOException e) {
+                                    failed.set(true);
+                                    System.err.println(
+                                            "Error while dumping the URLs: " + e.getMessage());
+                                } finally {
+                                    channel.shutdownNow();
+                                }
+                            },
+                            "DumpURLs-" + i);
+            workers.add(worker);
+            worker.start();
+        }
+
+        for (Thread worker : workers) {
+            try {
+                worker.join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        return !failed.get();
+    }
+
+    private void writeLine(final String line) throws IOException {
+        synchronized (out) {
+            out.write(line);
+            out.write('\n');
+        }
+        long soFar = total.incrementAndGet();
+        if (soFar % REPORT_EVERY == 0) {
+            System.err.println(soFar + " URLs dumped so far...");
+        }
+    }
+}

--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -21,6 +21,9 @@ import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.StreamObserver;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -35,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.ParentCommand;
@@ -51,7 +55,9 @@ public class PutURLs implements Callable<Integer> {
             names = {"-f", "--file"},
             required = true,
             paramLabel = "STRING",
-            description = "path to file containing the URLs to inject into the Frontier")
+            description =
+                    "path to file containing the URLs to inject into the Frontier, decompressed"
+                            + " with gzip if its name ends in .gz")
     private String file;
 
     @Option(
@@ -149,7 +155,7 @@ public class PutURLs implements Callable<Integer> {
 
         // the file is read once and the lines handed out in chunks, so that adding threads
         // multiplies the parsing and sending but not the reading
-        try (BufferedReader reader = Files.newBufferedReader(Paths.get(file))) {
+        try (BufferedReader reader = openInput(file)) {
 
             final LineSource lines = new LineSource(reader);
 
@@ -206,6 +212,14 @@ public class PutURLs implements Callable<Integer> {
         }
 
         return (streamError.get() || readError.get()) ? 1 : 0;
+    }
+
+    private static BufferedReader openInput(String file) throws IOException {
+        InputStream is = Files.newInputStream(Paths.get(file));
+        if (file.endsWith(".gz")) {
+            is = new GZIPInputStream(is);
+        }
+        return new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
     }
 
     /**

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -1201,19 +1201,27 @@ public abstract class AbstractFrontierService
         long pos = -1; // Current position in the list of (filtered) URLs
         long sentCount = 0;
 
-        Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                getQueues().entrySet().iterator();
+        // a specific queue is targeted: look it up directly instead of scanning the
+        // whole map, so that listing a large frontier queue by queue does not cost a
+        // full scan per queue
+        final Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator;
+        if (key != null && !key.isEmpty()) {
+            final QueueWithinCrawl qwc = QueueWithinCrawl.get(key, normalisedCrawlID);
+            final QueueInterface queue = getQueues().get(qwc);
+            if (queue == null) {
+                responseObserver.onCompleted();
+                return;
+            }
+            qiterator = List.of(Map.entry(qwc, queue)).iterator();
+        } else {
+            qiterator = getQueues().entrySet().iterator();
+        }
 
         while (qiterator.hasNext() && sentCount < maxURLs) {
             Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
 
             // check that it is within the right crawlID
             if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
-                continue;
-            }
-
-            // check that it is within the right key/queue
-            if (key != null && !key.isEmpty() && !e.getKey().getQueue().equals(key)) {
                 continue;
             }
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -64,6 +64,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.github.crawler-commons</groupId>
+			<artifactId>urlfrontier-client</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>

--- a/tests/src/test/java/crawlercommons/urlfrontier/service/DumpURLsTest.java
+++ b/tests/src/test/java/crawlercommons/urlfrontier/service/DumpURLsTest.java
@@ -1,0 +1,327 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import com.google.protobuf.util.JsonFormat;
+import crawlercommons.urlfrontier.CrawlID;
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierBlockingStub;
+import crawlercommons.urlfrontier.URLFrontierGrpc.URLFrontierStub;
+import crawlercommons.urlfrontier.Urlfrontier;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.StringList;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLStatusRequest;
+import crawlercommons.urlfrontier.client.Client;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Checks that a dump made with the client's DumpURLs command can be re-imported with PutURLs
+ * without losing anything: URLs, queue keys, crawl IDs, metadata and scheduling information.
+ */
+public class DumpURLsTest {
+
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(DumpURLsTest.class);
+
+    private String host;
+    private String port;
+
+    private ManagedChannel channel;
+
+    private URLFrontierStub frontier;
+
+    private URLFrontierBlockingStub blockingFrontier;
+
+    @Before
+    public void init() throws IOException {
+
+        host = System.getProperty("urlfrontier.host", "localhost");
+        port = System.getProperty("urlfrontier.port", "7071");
+
+        LOG.info("Initialisation of connection to URLFrontier service on {}:{}", host, port);
+
+        channel =
+                ManagedChannelBuilder.forAddress(host, Integer.parseInt(port))
+                        .usePlaintext()
+                        .build();
+        frontier = URLFrontierGrpc.newStub(channel);
+        blockingFrontier = URLFrontierGrpc.newBlockingStub(channel);
+
+        deleteAllCrawls();
+    }
+
+    @After
+    public void shutdown() {
+        deleteAllCrawls();
+        channel.shutdown();
+    }
+
+    private void deleteAllCrawls() {
+        StringList crawlids =
+                blockingFrontier.listCrawls(Urlfrontier.Local.newBuilder().setLocal(true).build());
+        for (String crawlid : crawlids.getValuesList()) {
+            blockingFrontier.deleteCrawl(
+                    Urlfrontier.DeleteCrawlMessage.newBuilder().setValue(crawlid).build());
+        }
+    }
+
+    @Test
+    public void roundTrip() throws IOException {
+
+        final long refetchDate = Instant.now().getEpochSecond() + 3600;
+
+        // a URL with custom metadata, one completed, one scheduled for refetch and one
+        // in a separate crawl
+        URLInfo withMetadata =
+                URLInfo.newBuilder()
+                        .setUrl("http://example.com/discovered")
+                        .setKey("example.com")
+                        .putMetadata("source", StringList.newBuilder().addValues("seed").build())
+                        .build();
+        URLInfo done =
+                URLInfo.newBuilder()
+                        .setUrl("http://example.com/done")
+                        .setKey("example.com")
+                        .build();
+        URLInfo later =
+                URLInfo.newBuilder()
+                        .setUrl("http://example.com/later")
+                        .setKey("example.com")
+                        .build();
+        URLInfo bespoke =
+                URLInfo.newBuilder()
+                        .setUrl("http://bespoke.com/")
+                        .setKey("bespoke.com")
+                        .setCrawlID("BESPOKE")
+                        .build();
+
+        int acked =
+                sendURLs(
+                        URLItem.newBuilder()
+                                .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(withMetadata))
+                                .build(),
+                        URLItem.newBuilder()
+                                .setKnown(KnownURLItem.newBuilder().setInfo(done))
+                                .build(),
+                        URLItem.newBuilder()
+                                .setKnown(
+                                        KnownURLItem.newBuilder()
+                                                .setInfo(later)
+                                                .setRefetchableFromDate(refetchDate))
+                                .build(),
+                        URLItem.newBuilder()
+                                .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(bespoke))
+                                .build());
+
+        Assert.assertEquals("incorrect number of URLs acked", 4, acked);
+
+        // dump the whole frontier with the client command
+        Path dump = Files.createTempFile("urlfrontier-dump", ".jsonl");
+        try {
+            int exitCode =
+                    new CommandLine(new Client())
+                            .execute("-t", host, "-p", port, "DumpURLs", "-o", dump.toString());
+            Assert.assertEquals("DumpURLs failed", 0, exitCode);
+
+            List<String> lines = Files.readAllLines(dump, StandardCharsets.UTF_8);
+            Assert.assertEquals("incorrect number of URLs dumped", 4, lines.size());
+
+            // every line must parse back as a URLItem, the format PutURLs takes
+            for (String line : lines) {
+                URLItem.Builder builder = URLItem.newBuilder();
+                JsonFormat.parser().merge(line, builder);
+                Assert.assertTrue("dumped item is not a known URL", builder.hasKnown());
+            }
+
+            // empty the frontier before re-importing
+            deleteAllCrawls();
+            StringList crawlids =
+                    blockingFrontier.listCrawls(
+                            Urlfrontier.Local.newBuilder().setLocal(true).build());
+            Assert.assertEquals("frontier not empty", 0, crawlids.getValuesCount());
+
+            exitCode =
+                    new CommandLine(new Client())
+                            .execute("-t", host, "-p", port, "PutURLs", "-f", dump.toString());
+            Assert.assertEquals("PutURLs failed", 0, exitCode);
+        } finally {
+            Files.deleteIfExists(dump);
+        }
+
+        // the completed URL must still be completed
+        URLItem status =
+                blockingFrontier.getURLStatus(
+                        URLStatusRequest.newBuilder()
+                                .setUrl("http://example.com/done")
+                                .setKey("example.com")
+                                .setCrawlID(CrawlID.DEFAULT)
+                                .build());
+        Assert.assertEquals(
+                "refetch date of completed URL not preserved",
+                0,
+                status.getKnown().getRefetchableFromDate());
+
+        // the scheduled URL must have kept its refetch date
+        status =
+                blockingFrontier.getURLStatus(
+                        URLStatusRequest.newBuilder()
+                                .setUrl("http://example.com/later")
+                                .setKey("example.com")
+                                .setCrawlID(CrawlID.DEFAULT)
+                                .build());
+        Assert.assertEquals(
+                "refetch date of scheduled URL not preserved",
+                refetchDate,
+                status.getKnown().getRefetchableFromDate());
+
+        // the metadata must have survived the round trip
+        status =
+                blockingFrontier.getURLStatus(
+                        URLStatusRequest.newBuilder()
+                                .setUrl("http://example.com/discovered")
+                                .setKey("example.com")
+                                .setCrawlID(CrawlID.DEFAULT)
+                                .build());
+        Assert.assertEquals(
+                "metadata not preserved",
+                "seed",
+                status.getKnown().getInfo().getMetadataOrThrow("source").getValues(0));
+
+        // the separate crawl must be back as well
+        Urlfrontier.Long count =
+                blockingFrontier.countURLs(
+                        Urlfrontier.CountUrlParams.newBuilder().setCrawlID("BESPOKE").build());
+        Assert.assertEquals("incorrect number of URLs in BESPOKE crawl", 1, count.getValue());
+    }
+
+    @Test
+    public void parallelDump() throws IOException {
+
+        // spread the URLs over several queues in two crawls
+        URLItem[] items = new URLItem[21];
+        for (int i = 0; i < 20; i++) {
+            URLInfo info =
+                    URLInfo.newBuilder().setUrl("http://site" + (i % 10) + ".com/page" + i).build();
+            items[i] =
+                    URLItem.newBuilder()
+                            .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info))
+                            .build();
+        }
+        items[20] =
+                URLItem.newBuilder()
+                        .setDiscovered(
+                                DiscoveredURLItem.newBuilder()
+                                        .setInfo(
+                                                URLInfo.newBuilder()
+                                                        .setUrl("http://bespoke.com/")
+                                                        .setCrawlID("BESPOKE")))
+                        .build();
+
+        int acked = sendURLs(items);
+        Assert.assertEquals("incorrect number of URLs acked", 21, acked);
+
+        Path dump = Files.createTempFile("urlfrontier-dump", ".jsonl");
+        try {
+            int exitCode =
+                    new CommandLine(new Client())
+                            .execute(
+                                    "-t",
+                                    host,
+                                    "-p",
+                                    port,
+                                    "DumpURLs",
+                                    "-o",
+                                    dump.toString(),
+                                    "-t",
+                                    "4");
+            Assert.assertEquals("DumpURLs failed", 0, exitCode);
+
+            List<String> lines = Files.readAllLines(dump, StandardCharsets.UTF_8);
+            Assert.assertEquals("incorrect number of URLs dumped", 21, lines.size());
+
+            deleteAllCrawls();
+
+            exitCode =
+                    new CommandLine(new Client())
+                            .execute("-t", host, "-p", port, "PutURLs", "-f", dump.toString());
+            Assert.assertEquals("PutURLs failed", 0, exitCode);
+        } finally {
+            Files.deleteIfExists(dump);
+        }
+
+        Urlfrontier.Long count =
+                blockingFrontier.countURLs(
+                        Urlfrontier.CountUrlParams.newBuilder()
+                                .setCrawlID(CrawlID.DEFAULT)
+                                .build());
+        Assert.assertEquals("incorrect number of URLs in default crawl", 20, count.getValue());
+
+        count =
+                blockingFrontier.countURLs(
+                        Urlfrontier.CountUrlParams.newBuilder().setCrawlID("BESPOKE").build());
+        Assert.assertEquals("incorrect number of URLs in BESPOKE crawl", 1, count.getValue());
+    }
+
+    private final int sendURLs(URLItem... items) {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicInteger acked = new AtomicInteger(0);
+
+        StreamObserver<Urlfrontier.AckMessage> responseObserver =
+                new StreamObserver<>() {
+
+                    @Override
+                    public void onNext(Urlfrontier.AckMessage value) {
+                        acked.addAndGet(1);
+                    }
+
+                    @Override
+                    public void onError(Throwable t) {
+                        completed.set(true);
+                        LOG.info("Error received", t);
+                    }
+
+                    @Override
+                    public void onCompleted() {
+                        completed.set(true);
+                    }
+                };
+
+        StreamObserver<URLItem> streamObserver = frontier.putURLs(responseObserver);
+
+        for (URLItem item : items) {
+            streamObserver.onNext(item);
+        }
+
+        streamObserver.onCompleted();
+
+        // wait for completion
+        while (completed.get() == false) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        return acked.get();
+    }
+}


### PR DESCRIPTION
Fixes #209 

Adds a way to dump the entire content of a Frontier in the backend-neutral format taken by `PutURLs`, so that the data can be moved to a different backend implementation or migrated between major versions.

## Client: new `DumpURLs` command

* Writes every URL with its queue key, crawl ID, metadata and scheduling information as one JSON object per line — exactly what `PutURLs` parses, so restoring is simply `PutURLs -f dump.jsonl`.
* Enumerates the crawls of the node it connects to, then streams each crawl whole in a single `ListURLs` call (no offset pagination, which would rescan the queues per page and skip/duplicate under concurrent writes).
* `-t N` parallelises the dump: the queues are listed first (including inactive ones, which hold the completed URLs) and N threads, each on its own connection, dump them queue by queue into the shared output file. Any failure marks the dump incomplete and exits non-zero.
* `-o file.gz` compresses the output; `PutURLs` gained transparent gzip reading so a compressed dump re-imports directly.
* Status messages go to stderr so a dump to stdout stays clean.

## Service

`listURLs` now looks a targeted queue up directly in the queue map instead of scanning the whole map and skipping non-matching entries. Without this, dumping queue by queue would cost a full scan per queue — quadratic in the number of queues. It also benefits any existing caller that passes a key.

## Notes

* The dump covers the node the client connects to (`listURLs` is node-local: `DistributedFrontierService` does not fan it out); in a cluster, dump every node and concatenate the files — they merge trivially and redistribute on re-import.
* For a complete, consistent dump, deactivate the Frontier and stop the injection first; documented in the client README.
* The creation date of the URLs is not preserved across a dump/re-import cycle: the target frontier assigns it at import time, which affects `PurgeURLs`. Documented; honouring `URLItem.creation_date` on import could be a follow-up.

## Testing

New `DumpURLsTest` in the live test suite drives the actual picocli commands: a dump / delete-all / re-import round trip checking that refetch dates (both completed and scheduled-ahead), custom metadata and per-crawl counts survive, plus a parallel run (`-t 4`) over 11 queues in two crawls. All existing service unit tests and the live suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)