### PR TITLE
Check the RocksDB iterator is valid before reading its key (#168)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/QueueWithinCrawl.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/QueueWithinCrawl.java
@@ -68,6 +68,9 @@ public class QueueWithinCrawl implements Comparable<QueueWithinCrawl> {
 
     public static final QueueWithinCrawl parseAndDeNormalise(final String currentKey) {
         final int pos = currentKey.indexOf('_');
+        if (pos == -1) {
+            throw new IllegalArgumentException("Not a normalised queue key: " + currentKey);
+        }
         final String crawlID = currentKey.substring(0, pos).replace("%5F", "_");
         int pos2 = currentKey.indexOf('_', pos + 1);
         // no separator? just normalise whatever is left

--- a/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/rocksdb/RocksDBService.java
@@ -1326,13 +1326,14 @@ public class RocksDBService extends AbstractFrontierService {
                 sent++;
                 rocksIterator.next();
 
-                currentKey = new String(rocksIterator.key(), StandardCharsets.UTF_8);
-                Qkey = QueueWithinCrawl.parseAndDeNormalise(currentKey);
-
-                if (!queueID.equals(Qkey.getCrawlid(), Qkey.getQueue())) {
+                // key() is only defined on a valid iterator: the record just returned
+                // may have been the last one of the column family
+                if (!rocksIterator.isValid()) {
                     hasNext = false;
                 } else {
-                    hasNext = rocksIterator.isValid();
+                    currentKey = new String(rocksIterator.key(), StandardCharsets.UTF_8);
+                    Qkey = QueueWithinCrawl.parseAndDeNormalise(currentKey);
+                    hasNext = queueID.equals(Qkey.getCrawlid(), Qkey.getQueue());
                 }
 
                 long createdEpoch = created == null ? 0L : ByteBuffer.wrap(created).getLong();

--- a/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/RocksDBServiceTest.java
@@ -5,6 +5,7 @@ package crawlercommons.urlfrontier.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -32,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -410,6 +412,38 @@ class RocksDBServiceTest {
 
         assertEquals(2, nbQueues);
         assertEquals(4, nbUrls);
+    }
+
+    /**
+     * The URLs of the last queue are also the last records of the column family: draining that
+     * queue leaves the underlying RocksIterator invalid, which the iterator must detect without
+     * reading its key.
+     */
+    @Test
+    @Order(8)
+    void testUrlIteratorLastQueueOfTheDatabase() throws IOException {
+
+        // the existence keys are sorted by their normalised form, so the last queue
+        // of the database is the one whose normalised key sorts last
+        Entry<QueueWithinCrawl, QueueInterface> last = null;
+        for (Entry<QueueWithinCrawl, QueueInterface> cur : rocksDBService.getQueues().entrySet()) {
+            if (last == null || cur.getKey().toString().compareTo(last.getKey().toString()) > 0) {
+                last = cur;
+            }
+        }
+
+        assertEquals("queue_mysite", last.getKey().getQueue());
+
+        int nbUrls = 0;
+        try (CloseableIterator<URLItem> iter = rocksDBService.urlIterator(last, 0, 100)) {
+            while (iter.hasNext()) {
+                assertTrue(iter.next().getCreationDate() > 0);
+                nbUrls++;
+            }
+            assertThrows(NoSuchElementException.class, iter::next);
+        }
+
+        assertEquals(3, nbUrls);
     }
 
     @Test


### PR DESCRIPTION
Fixes the first half of #168.

`RocksDBService.RocksDBURLItemIterator.next()` advanced the iterator and read `key()` straight after, consulting `isValid()` only once the key had already been parsed. When the record just returned was the last one of the default column family — i.e. for the last queue of the database, reachable from `listURLs`, `countURLs` and `purgeURLs` — the iterator is left invalid and `key()` is undefined.

In practice the release build of the native library returns the last saved key rather than asserting, so the queue check passes and `hasNext` ends up false by luck; the read is still undefined behaviour and one implementation change away from feeding a garbage key to `parseAndDeNormalise`. This checks `isValid()` first and only then reads and parses the key.

Also throws an explicit `IllegalArgumentException` from `QueueWithinCrawl.parseAndDeNormalise` when the key holds no separator, instead of a bare `StringIndexOutOfBoundsException` (the `pos2 == -1` case was already handled).

The second issue described in #168 — `ByteBuffer.wrap(null)` on a missing creation date — was fixed separately and is already covered by `testMissingCreationDate`.

## Testing

`mvn test` on the service module passes. Added `testUrlIteratorLastQueueOfTheDatabase`, which picks the queue whose normalised key sorts last (so its URLs really are the last records of the column family), drains the iterator and asserts the count plus `NoSuchElementException` on the extra `next()`.

Note that this test would not have failed before the fix — the pre-fix behaviour was benign-by-luck rather than throwing. It pins the contract and would catch a regression if the native layer ever returned something else, but it is not a reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)