### PR TITLE
Close the putURLs forwarding streams instead of dropping them (#207)

### DIFF
--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -59,6 +59,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.LoggerFactory;
 
 public abstract class DistributedFrontierService extends AbstractFrontierService {
@@ -359,6 +360,11 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     final URLFrontierStub stub =
                             URLFrontierGrpc.newStub(channelCache.getUnchecked(nodeAddress));
 
+                    // the stream removes itself from the cache when it ends; it is held
+                    // here so that only this stream is ever removed and never a
+                    // replacement created for the same partition in the meantime
+                    final AtomicReference<StreamObserver<URLItem>> self = new AtomicReference<>();
+
                     // pass an observer for the results coming back from that node
                     final StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage>
                             observer =
@@ -395,7 +401,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
                                         @Override
                                         public void onError(Throwable t) {
-                                            observercache.invalidate(index);
+                                            discardForwardingStream(index, self.get());
                                             if (t instanceof StatusRuntimeException) {
                                                 // ignore messages about the client having cancelled
                                                 if (((StatusRuntimeException) t)
@@ -413,8 +419,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
                                         @Override
                                         public void onCompleted() {
-                                            // finished?
-                                            observercache.invalidate(index);
+                                            // the remote side will not ack anything else on
+                                            // this stream: it must not be handed out again
+                                            discardForwardingStream(index, self.get());
                                         }
                                     };
 
@@ -422,32 +429,82 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     // node, so it must not inherit the Context of whichever server call
                     // happened to trigger the load: that call ending would cancel the
                     // stream for everyone and strand the items already in flight on it
+                    final StreamObserver<URLItem> forwarder;
                     final Context previous = Context.ROOT.attach();
                     try {
                         // gRPC serializes the callbacks of a single stream but not across
                         // streams, and concurrent onNext on one client call corrupts its
                         // outbound buffers; -1 disables the token budget, the wrapper is
                         // used here for its mutual exclusion only
-                        return SynchronizedStreamObserver.wrapping(stub.putURLs(observer), -1);
+                        forwarder = SynchronizedStreamObserver.wrapping(stub.putURLs(observer), -1);
                     } finally {
                         Context.ROOT.detach(previous);
                     }
+                    self.set(forwarder);
+                    return forwarder;
                 }
             };
 
+    /**
+     * Removing a stream from the cache closes it: the call is half-closed, so the node keeps the
+     * items already forwarded on it and acks them back on the response side, which stays open until
+     * it has answered them all. Dropping the entry without this leaves the call half-open on both
+     * nodes until the channel is shut down (issue #207).
+     */
     private final RemovalListener<Integer, StreamObserver<URLItem>> observerlistener =
             new RemovalListener<>() {
                 @Override
                 public void onRemoval(RemovalNotification<Integer, StreamObserver<URLItem>> n) {
                     LOG.info("Removed StreamObserver {} with key {}", n.getValue(), n.getKey());
+                    final StreamObserver<URLItem> observer = n.getValue();
+                    if (observer == null) {
+                        return;
+                    }
+                    try {
+                        observer.onCompleted();
+                    } catch (RuntimeException e) {
+                        // a stream is usually discarded *because* it has already failed
+                        LOG.debug(
+                                "Error while closing the stream forwarding to partition {}: {}",
+                                n.getKey(),
+                                e.getLocalizedMessage());
+                    }
                 }
             };
 
-    private LoadingCache<Integer, StreamObserver<URLItem>> observercache =
-            CacheBuilder.newBuilder()
-                    .removalListener(observerlistener)
-                    .expireAfterAccess(1, TimeUnit.MINUTES)
-                    .build(observerloader);
+    /**
+     * One forwarding stream per partition, held for the lifetime of the service. There is no expiry
+     * on purpose: the node list is fixed at startup so there is nothing to reclaim by dropping
+     * streams, and a stream cannot be closed on a timer without stranding the items it still has in
+     * flight or racing with a concurrent onNext (issue #207). An entry is removed only once its
+     * stream has ended - the remote side completing or erroring, or a failed onNext - and by {@link
+     * #close()}, so a broken stream is never handed out for long.
+     */
+    private final LoadingCache<Integer, StreamObserver<URLItem>> observercache =
+            CacheBuilder.newBuilder().removalListener(observerlistener).build(observerloader);
+
+    /**
+     * Discards a forwarding stream, closing it, but only if it is still the one held for that
+     * partition: a stream that has ended must not take away the replacement another thread may have
+     * created for the same partition in the meantime. A null observer means the stream ended before
+     * the load which created it returned, in which case there is nothing cached to remove yet - the
+     * first item forwarded on it fails and discards it then.
+     */
+    private void discardForwardingStream(int partition, StreamObserver<URLItem> observer) {
+        if (observer == null) {
+            return;
+        }
+        observercache.asMap().remove(partition, observer);
+    }
+
+    /**
+     * Discards the forwarding stream held for a partition, if any. Visible for testing: in
+     * production the streams are discarded by {@link #discardForwardingStream(int, StreamObserver)}
+     * when they end, or by {@link #close()}.
+     */
+    void discardForwardingStream(int partition) {
+        observercache.invalidate(partition);
+    }
 
     /**
      * An item forwarded to another node, waiting for that node to ack it back. Held in {@link
@@ -798,6 +855,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
     public void close() throws IOException {
         super.close();
         inprocessCacheCleaner.shutdownNow();
+        // half-close the forwarding streams before the channels go, so that the items
+        // still in flight on them have a chance of being acked back
+        observercache.invalidateAll();
         // close all the connections
         channelCache.invalidateAll();
     }
@@ -924,12 +984,12 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     // before the item goes out as the ack can come back at any point
                     inprocesscache.put(token, pending);
 
+                    StreamObserver<URLItem> forwarder = null;
                     try {
                         // get the stream observer for the node in charge of the partition
                         // and give it the value to process
-                        observercache
-                                .getUnchecked(partition)
-                                .onNext(URLItem.newBuilder(value).setID(token).build());
+                        forwarder = observercache.getUnchecked(partition);
+                        forwarder.onNext(URLItem.newBuilder(value).setID(token).build());
                     } catch (Exception e) {
                         LOG.error(
                                 "Error while sending {} to partition {}: {}",
@@ -938,7 +998,7 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                                 e.getLocalizedMessage());
                         // no ack will ever come back for it: fail it now instead of
                         // waiting for the entry to expire
-                        observercache.invalidate(partition);
+                        discardForwardingStream(partition, forwarder);
                         inprocesscache.invalidate(token);
                         pending.ack(Status.FAIL);
                     }

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardingStreamLifecycleTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardingStreamLifecycleTest.java
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import io.grpc.ForwardingServerCall;
+import io.grpc.ForwardingServerCallListener;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerInterceptors;
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lifecycle of the per-partition putURLs streams node A opens onto node B (issue #207): one stream
+ * is shared by every client and kept open, and dropping it from the cache closes the call instead
+ * of leaving it half-open on both nodes.
+ */
+class ForwardingStreamLifecycleTest {
+
+    private static final int PORT_A = 7311;
+    private static final int PORT_B = 7312;
+    private static final List<String> NODES = List.of("localhost:" + PORT_A, "localhost:" + PORT_B);
+    private static final String PATH_A = "./target/rocksdb-forwarding-a";
+    private static final String PATH_B = "./target/rocksdb-forwarding-b";
+
+    /** Counts the putURLs calls node B serves, and how they end. */
+    private static final AtomicInteger putURLsStarted = new AtomicInteger();
+
+    private static final AtomicInteger putURLsClosed = new AtomicInteger();
+    private static final List<Status.Code> closeCodes =
+            Collections.synchronizedList(new ArrayList<>());
+    private static final AtomicInteger halfClosed = new AtomicInteger();
+
+    // typed as the base class: discardForwardingStream is package-private to this package
+    static DistributedFrontierService serviceA;
+
+    static ShardedRocksDBService serviceB;
+    static Server serverA;
+    static Server serverB;
+    static ManagedChannel channelA;
+
+    private static final ServerInterceptor counter =
+            new ServerInterceptor() {
+                @Override
+                public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                        ServerCall<ReqT, RespT> call,
+                        Metadata headers,
+                        ServerCallHandler<ReqT, RespT> next) {
+                    if (!call.getMethodDescriptor()
+                            .getFullMethodName()
+                            .endsWith("URLFrontier/PutURLs")) {
+                        return next.startCall(call, headers);
+                    }
+                    putURLsStarted.incrementAndGet();
+                    ServerCall<ReqT, RespT> counted =
+                            new ForwardingServerCall.SimpleForwardingServerCall<>(call) {
+                                @Override
+                                public void close(Status status, Metadata trailers) {
+                                    closeCodes.add(status.getCode());
+                                    putURLsClosed.incrementAndGet();
+                                    super.close(status, trailers);
+                                }
+                            };
+                    return new ForwardingServerCallListener.SimpleForwardingServerCallListener<>(
+                            next.startCall(counted, headers)) {
+                        @Override
+                        public void onHalfClose() {
+                            halfClosed.incrementAndGet();
+                            super.onHalfClose();
+                        }
+
+                        @Override
+                        public void onCancel() {
+                            putURLsClosed.incrementAndGet();
+                            closeCodes.add(Status.Code.CANCELLED);
+                            super.onCancel();
+                        }
+                    };
+                }
+            };
+
+    @BeforeAll
+    static void setup() throws IOException {
+        FileUtils.deleteQuietly(new File(PATH_A));
+        FileUtils.deleteQuietly(new File(PATH_B));
+        serviceA = newService(PATH_A, PORT_A);
+        serviceB = newService(PATH_B, PORT_B);
+        serverA = ServerBuilder.forPort(PORT_A).addService(serviceA).build().start();
+        serverB =
+                ServerBuilder.forPort(PORT_B)
+                        .addService(ServerInterceptors.intercept(serviceB, counter))
+                        .build()
+                        .start();
+        channelA = ManagedChannelBuilder.forTarget("localhost:" + PORT_A).usePlaintext().build();
+    }
+
+    private static ShardedRocksDBService newService(String path, int port) {
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", path);
+        conf.put("nodes", String.join(",", NODES));
+        return new ShardedRocksDBService(conf, "localhost", port);
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (channelA != null) {
+            channelA.shutdownNow();
+            channelA.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        for (Server server : new Server[] {serverA, serverB}) {
+            if (server == null || server.isTerminated()) {
+                continue;
+            }
+            server.shutdownNow();
+            server.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        try {
+            if (serviceA != null) {
+                serviceA.close();
+            }
+        } finally {
+            try {
+                if (serviceB != null) {
+                    serviceB.close();
+                }
+            } finally {
+                FileUtils.deleteQuietly(new File(PATH_A));
+                FileUtils.deleteQuietly(new File(PATH_B));
+            }
+        }
+    }
+
+    /** Finds a key owned by the wanted partition, distinct per label. */
+    private static String keyOwnedBy(int partition, String label) {
+        for (int i = 0; i < 10_000; i++) {
+            String key = label + "-" + i + ".test";
+            if (DistributedFrontierService.partitionFor(QueueWithinCrawl.get(key, "DEFAULT"), NODES)
+                    == partition) {
+                return key;
+            }
+        }
+        throw new IllegalStateException("no key found for partition " + partition);
+    }
+
+    /** Sends items owned by node B through node A and waits for every ack. */
+    private static void forwardThroughA(String key, int items) throws InterruptedException {
+        final List<AckMessage> acks = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch done = new CountDownLatch(1);
+        StreamObserver<URLItem> input =
+                URLFrontierGrpc.newStub(channelA)
+                        .putURLs(
+                                new StreamObserver<AckMessage>() {
+                                    @Override
+                                    public void onNext(AckMessage value) {
+                                        acks.add(value);
+                                    }
+
+                                    @Override
+                                    public void onError(Throwable t) {
+                                        done.countDown();
+                                    }
+
+                                    @Override
+                                    public void onCompleted() {
+                                        done.countDown();
+                                    }
+                                });
+        for (int i = 0; i < items; i++) {
+            URLInfo info =
+                    URLInfo.newBuilder()
+                            .setUrl("https://" + key + "/" + i)
+                            .setKey(key)
+                            .setCrawlID("DEFAULT")
+                            .build();
+            input.onNext(
+                    URLItem.newBuilder()
+                            .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                            .build());
+        }
+        input.onCompleted();
+        assertTrue(done.await(20, TimeUnit.SECONDS), "putURLs did not complete in time");
+        assertEquals(items, acks.size(), "every item must be acked");
+        for (AckMessage ack : acks) {
+            assertNotEquals(AckMessage.Status.FAIL, ack.getStatus(), "forwarded item failed");
+        }
+    }
+
+    private static void awaitClosed(int expected) throws InterruptedException {
+        for (int i = 0; i < 100 && putURLsClosed.get() < expected; i++) {
+            Thread.sleep(50);
+        }
+        assertEquals(expected, putURLsClosed.get(), "closed putURLs calls on the owner");
+    }
+
+    @Test
+    void oneForwardingStreamIsSharedAndDiscardingItClosesTheCall() throws Exception {
+        final String key = keyOwnedBy(1, "lifecycle");
+
+        // several client streams, one after the other: they all forward through the
+        // same stream, which stays open in between
+        forwardThroughA(key, 5);
+        forwardThroughA(key, 5);
+        forwardThroughA(key, 5);
+
+        assertEquals(1, putURLsStarted.get(), "the forwarding stream must be shared and reused");
+        assertEquals(0, putURLsClosed.get(), "the forwarding stream must be kept open");
+
+        // dropping the entry must terminate the call rather than leave it half-open
+        serviceA.discardForwardingStream(1);
+        awaitClosed(1);
+        assertEquals(1, halfClosed.get(), "the forwarding call must be half-closed, not cancelled");
+        assertEquals(List.of(Status.Code.OK), closeCodes, "the forwarding call must end cleanly");
+
+        // and the next item opens a fresh one
+        forwardThroughA(key, 5);
+        assertEquals(2, putURLsStarted.get(), "a new stream must be created after a discard");
+        assertEquals(1, putURLsClosed.get(), "the replacement must stay open");
+    }
+}


### PR DESCRIPTION
Fixes #207.

`observercache` expired the per-partition forwarding streams after a minute without access, and the removal listener only logged. Nothing called `onCompleted()` or `cancel()` on the evicted stream, so the client call on this node and the corresponding server-side `putURLs` on the target node were both left half-open — one pair per idle gap longer than a minute, per partition, until the process shut its channels down.

### The change

Option 1 from the issue: these streams are cluster infrastructure, not per-request state.

- **No expiry.** One stream per partition, held for the lifetime of the service. The node list is fixed at startup (`ShardedRocksDBService` reads `nodes` from the config and never changes it), so there is nothing to reclaim, and no timer can close a stream out from under the items it still has in flight.
- **Removal now closes the stream.** The removal listener half-closes the call (`onCompleted()`, guarded — a stream is usually removed *because* it has already failed). Half-closing rather than cancelling means the target node keeps the items already forwarded and acks them all back on the response side, which stays open until it has answered them.
- **Removal is identity-conditional** (`asMap().remove(partition, observer)`). This matters once the streams are long-lived: `invalidate(partition)` from a failing thread — or from the ack observer's `onError`/`onCompleted` — could otherwise evict the replacement another thread had just created. The loader keeps its own observer in an `AtomicReference` so its callbacks only ever remove themselves.
- **`close()` invalidates `observercache` before `channelCache`**, so the streams are half-closed before the channels go.

The recreate-on-error path is unchanged: a broken stream is discarded by its own `onError`/`onCompleted`, or by the first `onNext` that fails, and the next item loads a fresh one. That is also what stops a dead stream from being cached indefinitely now that there is no expiry.

### Test

`ForwardingStreamLifecycleTest` puts a counting `ServerInterceptor` on the target node and asserts that three successive client streams produce exactly one `putURLs` call there which stays open; that discarding it makes the target see a half-close with status OK — not a cancel, not a dangling call; and that the next item opens exactly one replacement.

Verified it fails without the fix (`closed putURLs calls on the owner ==> expected: <1> but was: <0>`).

Full service suite passes: 217 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)