### PR TITLE
Pace the putURLs forwarding streams on the transport's readiness (#208)

### DIFF
--- a/service/config.ini
+++ b/service/config.ini
@@ -22,6 +22,14 @@ implementation = crawlercommons.urlfrontier.service.rocksdb.RocksDBService
 # URLs. Set to 0 to disable.
 # putDiscovered.max.inflight = 16
 
+# cluster mode only: maximum time an item waits for the stream forwarding it to
+# the node owning its queue to become writable before being failed back to the
+# client. Caps what a node which has stopped keeping up can have buffered on the
+# nodes forwarding to it, rather than letting it accumulate there. Defaults to
+# forward.deadline.seconds, and must stay well under a minute, after which a
+# forwarded item is given up on anyway.
+# forward.ready.timeout.ms = 30000
+
 rocksdb.path = /data/crawl/rocksdb
 # rocksdb.purge = true
 

--- a/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/cluster/DistributedFrontierService.java
@@ -43,8 +43,11 @@ import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.StatusRuntimeException;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
 import io.grpc.stub.ServerCallStreamObserver;
 import io.grpc.stub.StreamObserver;
+import io.prometheus.client.Counter;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -59,7 +62,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.LoggerFactory;
 
 public abstract class DistributedFrontierService extends AbstractFrontierService {
@@ -70,6 +72,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         forwardDeadlineSeconds =
                 ParamHelper.getIntegerParameter(
                         configuration, "forward.deadline.seconds", FORWARD_DEADLINE_SECONDS);
+        forwardReadyTimeoutMillis =
+                ParamHelper.getIntegerParameter(
+                        configuration, "forward.ready.timeout.ms", forwardDeadlineSeconds * 1000);
     }
 
     // no explicit config
@@ -91,8 +96,29 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
      */
     private final int forwardDeadlineSeconds;
 
+    /**
+     * Maximum time an item waits for the stream forwarding to its owner to become writable before
+     * being failed back to the client. Configurable with 'forward.ready.timeout.ms', defaults to
+     * 'forward.deadline.seconds'; it must stay well under the expiry of {@link #inprocesscache} so
+     * that an item which did make it out has a chance of being acked back.
+     */
+    private final int forwardReadyTimeoutMillis;
+
+    /**
+     * Longest a caller sleeps before looking at the readiness of the stream again. Readiness is
+     * signalled, this only bounds the cost of a signal landing just before the caller waits for it.
+     */
+    static final long READY_POLL_MILLIS = 100;
+
     /** How often the items forwarded to other nodes are checked for expiry. */
     static final int INPROCESS_CLEANUP_SECONDS = 10;
+
+    protected static final Counter putURLs_forward_notready_count =
+            Counter.build()
+                    .name("frontier_putURLs_forward_notready_total")
+                    .help(
+                            "Number of URLs failed back to the client because the stream to the node owning them did not become writable in time")
+                    .register();
 
     private final CacheLoader<String, ManagedChannel> channelLoader =
             new CacheLoader<String, ManagedChannel>() {
@@ -349,26 +375,179 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
         responseObserver.onCompleted();
     }
 
+    /**
+     * The putURLs stream forwarding to one owner node, shared by every client stream with items for
+     * that node. Writes are paced on the readiness of the transport: while the owner is not
+     * draining, the callers wait rather than pile serialised items onto the netty write queue of
+     * this node, where they are invisible, unbounded across concurrent client streams, and can
+     * expire from {@link #inprocesscache} before they even leave (issue #208).
+     *
+     * <p>Making the caller wait is the point of it: it is a putURLs handler thread, so it stops
+     * consuming from its own client, whose in-flight budget then stops being replenished and the
+     * backpressure reaches the crawler. It is never a transport thread - the server is built
+     * without a directExecutor - so blocking it holds up that one client stream and nothing else. A
+     * node which is not merely slow but wedged is not worth waiting for repeatedly: the wait is
+     * bounded, and once it has timed out the items are failed back without waiting again until the
+     * owner shows a sign of life.
+     */
+    private final class PacedForwarder implements StreamObserver<URLItem> {
+
+        private final int partition;
+
+        /** signalled when the stream becomes writable again, or when it has ended */
+        private final Object readyMonitor = new Object();
+
+        /**
+         * gRPC serializes the callbacks of a single stream but not across streams, and concurrent
+         * onNext on one client call corrupts its outbound buffers
+         */
+        private final Object sendLock = new Object();
+
+        /** set by {@link #bind} before the call starts, and therefore before any onNext */
+        private volatile ClientCallStreamObserver<URLItem> out;
+
+        /** a stream which has ended will never be ready again: waiting on it is pointless */
+        private volatile boolean ended;
+
+        /** found unwritable and no readiness signalled since, see {@link #awaitReady()} */
+        private volatile boolean stalled;
+
+        PacedForwarder(int partition) {
+            this.partition = partition;
+        }
+
+        /**
+         * Takes hold of the request stream of the call. Must be called from {@link
+         * ClientResponseObserver#beforeStart}: the handler can no longer be set once the call has
+         * started, which is before the stub returns the stream to us.
+         */
+        void bind(ClientCallStreamObserver<URLItem> stream) {
+            this.out = stream;
+            stream.setOnReadyHandler(this::wakeUp);
+        }
+
+        /** Releases whoever waits on this stream: the remote side has ended it. */
+        void streamEnded() {
+            ended = true;
+            wakeUp();
+        }
+
+        private void wakeUp() {
+            stalled = false;
+            synchronized (readyMonitor) {
+                readyMonitor.notifyAll();
+            }
+        }
+
+        /**
+         * Waits for the stream to be able to take another item. Returns false when it did not
+         * become writable in time, or when it has ended or the service is closing, in which case
+         * the caller must fail the item instead of sending it. Once a wait has timed out the
+         * following calls return false straight away, until the transport signals readiness again.
+         */
+        boolean awaitReady() {
+            if (out.isReady()) {
+                return true;
+            }
+            if (ended || isClosing()) {
+                return false;
+            }
+            // the stream was found unwritable already and has signalled nothing since: the
+            // timeout is paid once per stall and not once per item, otherwise one wedged
+            // owner would also hold up whatever the same client stream has for the others
+            if (stalled) {
+                return false;
+            }
+            final long deadline =
+                    System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(forwardReadyTimeoutMillis);
+            // readiness is deliberately read outside the monitor: gRPC may signal it from
+            // a transport thread holding locks of its own, and taking one of ours while it
+            // does would put the two in opposite orders. The window that opens between the
+            // read and the wait is what the poll interval below is for
+            while (!out.isReady()) {
+                if (ended || isClosing()) {
+                    return false;
+                }
+                final long remaining = TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime());
+                if (remaining <= 0) {
+                    LOG.warn(
+                            "Stream forwarding to partition {} not writable after {} ms",
+                            partition,
+                            forwardReadyTimeoutMillis);
+                    stalled = true;
+                    return false;
+                }
+                synchronized (readyMonitor) {
+                    try {
+                        readyMonitor.wait(Math.min(remaining, READY_POLL_MILLIS));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        @Override
+        public void onNext(URLItem value) {
+            synchronized (sendLock) {
+                out.onNext(value);
+            }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+            // nothing more will go out on it: release the callers before closing, they
+            // would otherwise wait for a readiness which can no longer come
+            streamEnded();
+            synchronized (sendLock) {
+                out.onError(t);
+            }
+        }
+
+        @Override
+        public void onCompleted() {
+            streamEnded();
+            synchronized (sendLock) {
+                out.onCompleted();
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "PacedForwarder to partition " + partition;
+        }
+    }
+
     /** Create or return an existing stream to an external Frontier * */
-    private final CacheLoader<Integer, StreamObserver<URLItem>> observerloader =
+    private final CacheLoader<Integer, PacedForwarder> observerloader =
             new CacheLoader<>() {
                 @Override
-                public StreamObserver<URLItem> load(Integer index) {
+                public PacedForwarder load(Integer index) {
 
                     final String nodeAddress = getNodes().get(index);
 
                     final URLFrontierStub stub =
                             URLFrontierGrpc.newStub(channelCache.getUnchecked(nodeAddress));
 
-                    // the stream removes itself from the cache when it ends; it is held
-                    // here so that only this stream is ever removed and never a
-                    // replacement created for the same partition in the meantime
-                    final AtomicReference<StreamObserver<URLItem>> self = new AtomicReference<>();
+                    // created before the call: it is what beforeStart binds the request
+                    // stream to, and the stream removes itself from the cache when it ends,
+                    // so that only this stream is ever removed and never a replacement
+                    // created for the same partition in the meantime
+                    final PacedForwarder forwarder = new PacedForwarder(index);
 
                     // pass an observer for the results coming back from that node
-                    final StreamObserver<crawlercommons.urlfrontier.Urlfrontier.AckMessage>
+                    final ClientResponseObserver<
+                                    URLItem, crawlercommons.urlfrontier.Urlfrontier.AckMessage>
                             observer =
-                                    new StreamObserver<>() {
+                                    new ClientResponseObserver<>() {
+
+                                        @Override
+                                        public void beforeStart(
+                                                ClientCallStreamObserver<URLItem> requestStream) {
+                                            forwarder.bind(requestStream);
+                                        }
 
                                         @Override
                                         public void onNext(
@@ -401,7 +580,8 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
 
                                         @Override
                                         public void onError(Throwable t) {
-                                            discardForwardingStream(index, self.get());
+                                            forwarder.streamEnded();
+                                            discardForwardingStream(index, forwarder);
                                             if (t instanceof StatusRuntimeException) {
                                                 // ignore messages about the client having cancelled
                                                 if (((StatusRuntimeException) t)
@@ -421,7 +601,8 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                                         public void onCompleted() {
                                             // the remote side will not ack anything else on
                                             // this stream: it must not be handed out again
-                                            discardForwardingStream(index, self.get());
+                                            forwarder.streamEnded();
+                                            discardForwardingStream(index, forwarder);
                                         }
                                     };
 
@@ -429,18 +610,15 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     // node, so it must not inherit the Context of whichever server call
                     // happened to trigger the load: that call ending would cancel the
                     // stream for everyone and strand the items already in flight on it
-                    final StreamObserver<URLItem> forwarder;
                     final Context previous = Context.ROOT.attach();
                     try {
-                        // gRPC serializes the callbacks of a single stream but not across
-                        // streams, and concurrent onNext on one client call corrupts its
-                        // outbound buffers; -1 disables the token budget, the wrapper is
-                        // used here for its mutual exclusion only
-                        forwarder = SynchronizedStreamObserver.wrapping(stub.putURLs(observer), -1);
+                        // the request stream it returns is the one already bound to the
+                        // forwarder by beforeStart, which is where the readiness handler
+                        // has to be set: the call is started by then
+                        stub.putURLs(observer);
                     } finally {
                         Context.ROOT.detach(previous);
                     }
-                    self.set(forwarder);
                     return forwarder;
                 }
             };
@@ -451,12 +629,12 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
      * it has answered them all. Dropping the entry without this leaves the call half-open on both
      * nodes until the channel is shut down (issue #207).
      */
-    private final RemovalListener<Integer, StreamObserver<URLItem>> observerlistener =
+    private final RemovalListener<Integer, PacedForwarder> observerlistener =
             new RemovalListener<>() {
                 @Override
-                public void onRemoval(RemovalNotification<Integer, StreamObserver<URLItem>> n) {
+                public void onRemoval(RemovalNotification<Integer, PacedForwarder> n) {
                     LOG.info("Removed StreamObserver {} with key {}", n.getValue(), n.getKey());
-                    final StreamObserver<URLItem> observer = n.getValue();
+                    final PacedForwarder observer = n.getValue();
                     if (observer == null) {
                         return;
                     }
@@ -480,26 +658,21 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
      * stream has ended - the remote side completing or erroring, or a failed onNext - and by {@link
      * #close()}, so a broken stream is never handed out for long.
      */
-    private final LoadingCache<Integer, StreamObserver<URLItem>> observercache =
+    private final LoadingCache<Integer, PacedForwarder> observercache =
             CacheBuilder.newBuilder().removalListener(observerlistener).build(observerloader);
 
     /**
      * Discards a forwarding stream, closing it, but only if it is still the one held for that
      * partition: a stream that has ended must not take away the replacement another thread may have
-     * created for the same partition in the meantime. A null observer means the stream ended before
-     * the load which created it returned, in which case there is nothing cached to remove yet - the
-     * first item forwarded on it fails and discards it then.
+     * created for the same partition in the meantime.
      */
-    private void discardForwardingStream(int partition, StreamObserver<URLItem> observer) {
-        if (observer == null) {
-            return;
-        }
+    private void discardForwardingStream(int partition, PacedForwarder observer) {
         observercache.asMap().remove(partition, observer);
     }
 
     /**
      * Discards the forwarding stream held for a partition, if any. Visible for testing: in
-     * production the streams are discarded by {@link #discardForwardingStream(int, StreamObserver)}
+     * production the streams are discarded by {@link #discardForwardingStream(int, PacedForwarder)}
      * when they end, or by {@link #close()}.
      */
     void discardForwardingStream(int partition) {
@@ -972,6 +1145,33 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                             partition,
                             getNodes().get(partition));
 
+                    final PacedForwarder forwarder;
+                    try {
+                        forwarder = observercache.getUnchecked(partition);
+                    } catch (Exception e) {
+                        LOG.error(
+                                "Error while getting the stream to partition {} for {}: {}",
+                                partition,
+                                url,
+                                e.getLocalizedMessage());
+                        sso.onNext(ack.setStatus(Status.FAIL).build());
+                        return;
+                    }
+
+                    // pace on the readiness of the stream to the owner before taking the
+                    // item on: a slow node must push back on the client rather than have
+                    // its items accumulate in the outbound buffers of this one. Done
+                    // before the item is registered below so that one given up on has
+                    // never occupied a correlation slot, and without discarding the
+                    // stream: it is slow, not broken, and it is shared by every client
+                    if (!forwarder.awaitReady()) {
+                        LOG.error(
+                                "Stream to partition {} not writable, failing {}", partition, url);
+                        putURLs_forward_notready_count.inc();
+                        sso.onNext(ack.setStatus(Status.FAIL).build());
+                        return;
+                    }
+
                     // the item goes out under a correlation token of ours rather than the
                     // client's ID: the same ID can legitimately be sent more than once, in
                     // which case the acks could no longer be told apart
@@ -984,11 +1184,9 @@ public abstract class DistributedFrontierService extends AbstractFrontierService
                     // before the item goes out as the ack can come back at any point
                     inprocesscache.put(token, pending);
 
-                    StreamObserver<URLItem> forwarder = null;
                     try {
-                        // get the stream observer for the node in charge of the partition
-                        // and give it the value to process
-                        forwarder = observercache.getUnchecked(partition);
+                        // give the value to the stream observer for the node in charge of
+                        // the partition
                         forwarder.onNext(URLItem.newBuilder(value).setID(token).build());
                     } catch (Exception e) {
                         LOG.error(

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardingBackpressureTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardingBackpressureTest.java
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service.cluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import crawlercommons.urlfrontier.URLFrontierGrpc;
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.QueueWithinCrawl;
+import crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ServerCallStreamObserver;
+import io.grpc.stub.StreamObserver;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+/**
+ * Pacing of the putURLs stream node A opens onto node B (issue #208). An owner which stops draining
+ * must push back on the clients of A rather than have its items accumulate in the outbound buffers
+ * of A, so the amount buffered is bounded by the transport and not by what the clients send.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ForwardingBackpressureTest {
+
+    private static final int PORT_A = 7313;
+    private static final int PORT_B = 7314;
+    private static final List<String> NODES = List.of("localhost:" + PORT_A, "localhost:" + PORT_B);
+    private static final String PATH_A = "./target/rocksdb-backpressure-a";
+
+    /** long enough to ride out a hiccup, short enough for a test to wait for it */
+    private static final int READY_TIMEOUT_MS = 2000;
+
+    /** big items so that the flow control window of the connection fills within the burst */
+    private static final int URL_PADDING = 16 * 1024;
+
+    static DistributedFrontierService serviceA;
+    static Server serverA;
+    static Server serverB;
+    static ManagedChannel channelA;
+    static StallingOwner owner;
+
+    /** Node B: acks everything, or stops reading its stream altogether. */
+    private static final class StallingOwner extends URLFrontierGrpc.URLFrontierImplBase {
+
+        volatile boolean stalling = false;
+
+        final AtomicInteger received = new AtomicInteger();
+
+        @Override
+        public StreamObserver<URLItem> putURLs(StreamObserver<AckMessage> responseObserver) {
+            if (stalling) {
+                // never request a message and never ack one: the items node A writes stay
+                // on the wire until the flow control window is full, which is what makes
+                // its stream unwritable
+                ((ServerCallStreamObserver<AckMessage>) responseObserver).disableAutoRequest();
+                return new StreamObserver<>() {
+                    @Override
+                    public void onNext(URLItem value) {}
+
+                    @Override
+                    public void onError(Throwable t) {}
+
+                    @Override
+                    public void onCompleted() {}
+                };
+            }
+            return new StreamObserver<>() {
+                @Override
+                public void onNext(URLItem value) {
+                    received.incrementAndGet();
+                    responseObserver.onNext(
+                            AckMessage.newBuilder()
+                                    .setID(value.getID())
+                                    .setStatus(AckMessage.Status.OK)
+                                    .build());
+                }
+
+                @Override
+                public void onError(Throwable t) {}
+
+                @Override
+                public void onCompleted() {
+                    responseObserver.onCompleted();
+                }
+            };
+        }
+    }
+
+    @BeforeAll
+    static void setup() throws IOException {
+        FileUtils.deleteQuietly(new File(PATH_A));
+        Map<String, String> conf = new HashMap<>();
+        conf.put("rocksdb.path", PATH_A);
+        conf.put("nodes", String.join(",", NODES));
+        conf.put("forward.ready.timeout.ms", Integer.toString(READY_TIMEOUT_MS));
+        serviceA = new ShardedRocksDBService(conf, "localhost", PORT_A);
+        owner = new StallingOwner();
+        serverA = ServerBuilder.forPort(PORT_A).addService(serviceA).build().start();
+        serverB = ServerBuilder.forPort(PORT_B).addService(owner).build().start();
+        channelA = ManagedChannelBuilder.forTarget("localhost:" + PORT_A).usePlaintext().build();
+    }
+
+    @AfterAll
+    static void teardown() throws Exception {
+        if (channelA != null) {
+            channelA.shutdownNow();
+            channelA.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        for (Server server : new Server[] {serverA, serverB}) {
+            if (server == null || server.isTerminated()) {
+                continue;
+            }
+            server.shutdownNow();
+            server.awaitTermination(5, TimeUnit.SECONDS);
+        }
+        try {
+            if (serviceA != null) {
+                serviceA.close();
+            }
+        } finally {
+            FileUtils.deleteQuietly(new File(PATH_A));
+        }
+    }
+
+    /** Finds a key owned by node B, distinct per label. */
+    private static String keyOwnedByB(String label) {
+        for (int i = 0; i < 10_000; i++) {
+            String key = label + "-" + i + ".test";
+            if (DistributedFrontierService.partitionFor(QueueWithinCrawl.get(key, "DEFAULT"), NODES)
+                    == 1) {
+                return key;
+            }
+        }
+        throw new IllegalStateException("no key found for node B");
+    }
+
+    /** Opens a client stream onto node A, collecting the acks it sends back. */
+    private static StreamObserver<URLItem> openStream(List<AckMessage> acks, CountDownLatch done) {
+        return URLFrontierGrpc.newStub(channelA)
+                .putURLs(
+                        new StreamObserver<AckMessage>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                acks.add(value);
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                done.countDown();
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                done.countDown();
+                            }
+                        });
+    }
+
+    /** An item owned by node B, padded so that a burst of them fills the connection. */
+    private static URLItem itemFor(String key, int i) {
+        final String padding = "x".repeat(URL_PADDING);
+        URLInfo info =
+                URLInfo.newBuilder()
+                        .setUrl("https://" + key + "/" + i + "?p=" + padding)
+                        .setKey(key)
+                        .setCrawlID("DEFAULT")
+                        .build();
+        return URLItem.newBuilder()
+                .setID(Integer.toString(i))
+                .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                .build();
+    }
+
+    /** Sends items owned by node B through node A and returns the acks, in order. */
+    private static List<AckMessage> forwardThroughA(String key, int items, int timeoutSeconds)
+            throws InterruptedException {
+        final List<AckMessage> acks = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch done = new CountDownLatch(1);
+        StreamObserver<URLItem> input = openStream(acks, done);
+        for (int i = 0; i < items; i++) {
+            input.onNext(itemFor(key, i));
+        }
+        input.onCompleted();
+        assertTrue(
+                done.await(timeoutSeconds, TimeUnit.SECONDS), "putURLs did not complete in time");
+        return acks;
+    }
+
+    private static long failed(List<AckMessage> acks) {
+        return acks.stream().filter(a -> a.getStatus() == AckMessage.Status.FAIL).count();
+    }
+
+    @Test
+    @Order(1)
+    void arespondingOwnerTakesEverything() throws Exception {
+        final String key = keyOwnedByB("responsive");
+        final List<AckMessage> acks = forwardThroughA(key, 200, 30);
+        assertEquals(200, acks.size(), "every item must be acked");
+        assertEquals(0, failed(acks), "nothing may fail while the owner keeps up");
+        assertEquals(200, owner.received.get(), "every item must reach the owner");
+    }
+
+    @Test
+    @Order(2)
+    void aStalledOwnerIsPacedInsteadOfBuffered() throws Exception {
+        // the stream of the previous test is still cached: drop it so that the next item
+        // opens one onto the stalling handler
+        serviceA.discardForwardingStream(1);
+        owner.stalling = true;
+        owner.received.set(0);
+
+        final String key = keyOwnedByB("stalled");
+        final int items = 400;
+
+        final List<AckMessage> acks = Collections.synchronizedList(new ArrayList<>());
+        final CountDownLatch done = new CountDownLatch(1);
+        final StreamObserver<URLItem> input = openStream(acks, done);
+
+        final long start = System.nanoTime();
+        for (int i = 0; i < items; i++) {
+            input.onNext(itemFor(key, i));
+        }
+        input.onCompleted();
+
+        // the burst is answered while the owner is still stalled: whatever made it onto
+        // the wire before the stream became unwritable is not acked back until the
+        // in-process cache expires it a minute later, so the stream cannot complete here
+        awaitQuiescence(acks);
+        final long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+        final long failures = failed(acks);
+        assertEquals(failures, acks.size(), "a stalled owner cannot ack anything back");
+        assertTrue(failures > 0, "a stalled owner must fail items back rather than buffer them");
+
+        // what got through is what the transport accepted before the stream became
+        // unwritable: a bound coming from the connection, not from what the client sent
+        final long accepted = items - failures;
+        assertTrue(
+                accepted < items / 2,
+                "buffering must be bounded by the transport, "
+                        + accepted
+                        + " of "
+                        + items
+                        + " out");
+
+        // the timeout is paid once for the stall, not once per item, so that a wedged
+        // owner cannot hold a client stream hostage
+        assertTrue(
+                elapsedMillis < READY_TIMEOUT_MS * 5L,
+                "the burst took " + elapsedMillis + " ms, one timeout per item");
+
+        // the client is left waiting for the items which did go out, as it would be in
+        // production until they expire; nothing here depends on that happening
+        ((ClientCallStreamObserver<URLItem>) input).cancel("end of test", null);
+        assertTrue(done.await(10, TimeUnit.SECONDS), "the cancelled stream must terminate");
+    }
+
+    /** Waits for the acks to stop coming, which they do once the burst has been answered. */
+    private static void awaitQuiescence(List<AckMessage> acks) throws InterruptedException {
+        final long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(45);
+        int last = -1;
+        int stable = 0;
+        while (System.nanoTime() < deadline) {
+            Thread.sleep(250);
+            final int size = acks.size();
+            stable = size == last ? stable + 1 : 0;
+            last = size;
+            // quiet for longer than a timeout: nothing is still waiting on the stream
+            if (size > 0 && stable * 250 > READY_TIMEOUT_MS) {
+                return;
+            }
+        }
+        throw new AssertionError(
+                "the burst was not answered: " + acks.size() + " acks and still coming");
+    }
+}


### PR DESCRIPTION
Fixes #208.

## The problem

The remote branch of `putURLs` wrote onto the shared per-partition stream without ever consulting the transport, so an owner node which was reachable but not draining had its items accumulate in the netty write queue of the node forwarding to it.

Nothing bounded that. `limitInFlight` is a per-client-stream budget, so the buffering scaled with the number of concurrent `putURLs` streams funnelling into the same partition. Worse, an item could expire from `inprocesscache` — and be `FAIL`-acked to the client — while still sitting in the write queue, and then be delivered to the owner anyway.

Landing #207 also removed the one thing that was incidentally covering part of this: the forwarding streams are now held for the lifetime of the service, so nothing recycles a stream to an owner which has gone quiet.

## The fix

Writes are paced on `ClientCallStreamObserver.isReady()`. A caller waits for the stream to be writable before taking the item on — which is the right thing for a `putURLs` handler thread to do, since it then stops consuming from its own client, whose in-flight budget stops being replenished, and the backpressure reaches the crawler. It is never a transport thread (the server is built without a `directExecutor`), so blocking it holds up that one client stream and nothing else.

The readiness handler can no longer be set once the call has started, so the response observer became a `ClientResponseObserver` and binds the request stream in `beforeStart`.

The wait is bounded by a new `forward.ready.timeout.ms`, defaulting to `forward.deadline.seconds`, after which the item is failed back and `frontier_putURLs_forward_notready_total` is incremented. Two details worth calling out:

- **The timeout is paid once per stall, not once per item.** Otherwise an owner which is wedged rather than merely slow would also hold up whatever the same client stream has for the other nodes, one timeout at a time. Once a wait has timed out the following calls return straight away, until the transport signals readiness again.
- **A timeout does not discard the stream.** It is slow, not broken, and it is shared by every client forwarding to that node.

Readiness is read outside the monitor the transport signals on: gRPC may signal from a thread holding locks of its own, and taking one of ours while it does would put the two in opposite orders. The poll interval bounds the window where a signal lands just before a caller waits for it.

`PacedForwarder` also does the mutual exclusion the `SynchronizedStreamObserver` wrapper provided on this path, and being created before the call it identifies the stream when it ends — which is what the `AtomicReference` added by #207 was there for, so that goes away.

## Tests

New `ForwardingBackpressureTest`, with node B a mock owner that can stop reading its stream altogether:

- a responsive owner takes all 200 items and none fail — this guards the ordinary path through the new code;
- a stalled owner: of 400 padded items only what the connection window accepted goes out, the rest come back `FAIL` within seconds, and the whole burst is bounded by a few timeouts rather than one per item.

The second test fails against master: nothing is answered at all within 45s. Full service suite is green (219 tests).

## Not addressed

The channels are still built without keepalive, so a black-holed connection is now caught only by this timeout and not by the transport. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)