### PR TITLE
Fix the ListQueues pagination offset and bring the documentation back in line with the code

### DIFF
--- a/API/README.md
+++ b/API/README.md
@@ -12,19 +12,21 @@ The two main methods used by a crawler to interact with a URL Frontier service (
 - GetURLs
 - PutURLs
 
+with PutDiscovered as a batched alternative to PutURLs for the newly discovered URLs.
+
 Underpinning them is the concept of *queue(s)* and *crawl(s)*.
 
 ## Queues and keys
 
 What the queues should be based on is determined by the client, through the setting of a string value (_key_) associated with the messages sent with the PutURLs method. The value could be the hostname of a URL, its domain, IP or anything else. An empty value leaves the service to route the messages into a queue - the hostname being the default behaviour. It is up to the client code to be consistent in the use of the keys.
 
-The keys are used in several functions: _GetStats_, _DeleteQueue_ and _GetURLs_.
+The keys are used in several functions: _GetStats_, _DeleteQueue_, _GetURLs_, _GetURLStatus_, _ListURLs_, _CountURLs_, _PurgeURLs_, _SetDelay_, _BlockQueueUntil_ and _SetCrawlLimit_.
 
 ## Crawls and crawlIDs
 
 A service can handle one or more crawls, identified by a _crawlID_. Queues with the same keys can exist in multiple crawls and will be treated as totally distinct instances, i.e. deleting a queue for a particular crawl will not affect the queues with the same keys in other crawls. Similarly, a URL is considered unique to a crawl.
 
-A crawl can be thought of as a namespace. The default _crawlID_ is 'DEFAULT' but it is expected that service implementations will handle empty strings as an equivalent (note: this is due to Protobuff not allowing to have default values for String fields).
+A crawl can be thought of as a namespace. The default _crawlID_ is 'DEFAULT' but it is expected that service implementations will handle empty strings as an equivalent (note: this is due to Protobuf not allowing to have default values for String fields).
 
 ## GetURLs
 
@@ -36,6 +38,16 @@ Internally, the service will rotate on the queues to be pulled from and will aim
 
 This method is called to add newly discovered URLs to the frontier (e.g. they have been found while parsing a HTML document or a sitemap file) but also to update the information about URLs that had been previously obtained from *GetURLs* and have then been processed by the crawler. The latter allows to remove them from the _in transit_ status and so, more URLs can then be returned for its queue. Arbitrary metadata can be associated with a URL, for instance to store the depth of links followed since injecting the seeds or the HTTP code last obtained when a known URL has been fetched.
 
+## PutDiscovered
+
+Sends batches of discovered URLs rather than one message per URL. A URL is created unless it is already
+known, in which case it is ignored - the same rule as a DiscoveredURLItem sent through *PutURLs*, and the
+outlinks of a page form a natural batch. What limits the ingestion rate of a service is the per-message
+cost, so grouping the discovered URLs - the bulk of what a crawl writes - is what a client should do to
+push them faster; *PutURLs* remains the method to use for the updates of URLs which have been fetched.
+
+Each batch is acknowledged as a whole, with one status per URL in the order they were sent.
+
 ## Discovered vs known
 
 Discovered URLs are treated differently from known ones which are being updated. Discovered URLs will be added to the queues only if they are not already known, whereas known URLs will always be updated.
@@ -43,7 +55,7 @@ Discovered URLs are treated differently from known ones which are being updated.
 Another difference is in the scheduling of the URLs: discovered URLs are added to the queues (if they are unknown so far) without specific information about when they should be fetched - the service will return them as soon as possible. Known URLs on the other hand can have a _refetchable_from_date_ meaning that the service will put them back in the queues and serve them through _getURLs_ when the delay has elapsed. This is useful for instance when a transient error has occurred when fetching a URL, we might want to try it later. If no value is specified, the URL will be considered done and won't be returned by getURLs ever again.
 
 ## URL priority
-The URLs are sorted by _refetchable_from_date_, which is typically the number seconds of UTC time since Unix epoch. The frontier checks that this value is lower or equal to the current timstamp in order to emit them. 
+The URLs are sorted by _refetchable_from_date_, which is typically the number seconds of UTC time since Unix epoch. The frontier checks that this value is lower or equal to the current timestamp in order to emit them. 
 With that in mind, you can set any value you want as long as it is not 0 to prioritise URLs within a queue.
 
 ## Distributed mode
@@ -86,23 +98,31 @@ Important note: The version of protoc downloaded from the Maven repository will 
 unless you install the gcompat package  which provides glibc compatibility (apk add gcompat).
 
 
-For other languages, you need to generate the code stubs yourself, as shown here for Python
+For other languages, you need to generate the code stubs yourself, as shown here for Python. The commands
+below are run from this directory, where the schema is _src/main/protobuf/urlfrontier.proto_.
 
 ```
 python3 -m pip install grpcio-tools
 mkdir python
-python3 -m grpc_tools.protoc -I. --python_out=python --grpc_python_out=python urlfrontier.proto
+python3 -m grpc_tools.protoc -I src/main/protobuf --python_out=python --grpc_python_out=python src/main/protobuf/urlfrontier.proto
 ```
 
 Alternatively, [docker-protoc](https://github.com/namely/docker-protoc) can be used to generate the code in various languages:
 
 ```
-docker run -v `pwd`:/defs namely/protoc-all -f urlfrontier.proto -l java -o src/main/java
+docker run -v `pwd`/src/main/protobuf:/defs namely/protoc-all -f urlfrontier.proto -l go -o gen
 ```
 
 # Documentation generation
 
-``` docker run --rm -v $(pwd):/out -v $(pwd):/protos pseudomuto/protoc-gen-doc --doc_opt=markdown,urlfrontier.md ```
+[urlfrontier.md](urlfrontier.md) is generated from the schema with
+[protoc-gen-doc](https://github.com/pseudomuto/protoc-gen-doc) and is committed alongside it. Regenerate it
+whenever the schema changes, from the root of the project:
 
-The current version of the documentation can be found [here](urlfrontier.md)
+```
+mvn -Pprotodoc generate-sources -pl API
+```
+
+The _protodoc_ profile is not part of the default build, so a normal `mvn package` neither needs
+protoc-gen-doc nor touches the generated markdown.
 

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -17,6 +17,7 @@
 	<properties>
 		<grpc.version>1.76.0</grpc.version>
 		<protobuf-maven-plugin.version>3.10.2</protobuf-maven-plugin.version>
+		<protoc-gen-doc.version>1.5.1</protoc-gen-doc.version>
 	</properties>
 
 	<dependencies>
@@ -89,5 +90,53 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
+	<profiles>
+		<!-- Regenerates urlfrontier.md from the proto. Kept out of the default build so
+		     that it stays offline-friendly: run it whenever the proto changes and commit
+		     the result, with `mvn -Pprotodoc generate-sources -pl API`. -->
+		<profile>
+			<id>protodoc</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>io.github.ascopes</groupId>
+						<artifactId>protobuf-maven-plugin</artifactId>
+						<version>${protobuf-maven-plugin.version}</version>
+						<executions>
+							<execution>
+								<id>generate-markdown-doc</id>
+								<phase>generate-sources</phase>
+								<goals>
+									<goal>generate</goal>
+								</goals>
+								<configuration>
+									<!-- only protoc-gen-doc here, the Java stubs are the job of
+									     the default execution -->
+									<javaEnabled>false</javaEnabled>
+									<binaryMavenPlugins>
+										<binaryMavenPlugin>
+											<groupId>io.github.pseudomuto</groupId>
+											<artifactId>protoc-gen-doc</artifactId>
+											<version>${protoc-gen-doc.version}</version>
+											<options>markdown,urlfrontier.md</options>
+											<!-- the generated doc is committed next to the README
+											     which links to it; cleanOutputDirectories must stay
+											     false, this is the module directory -->
+											<outputDirectory>${project.basedir}</outputDirectory>
+											<registerAsCompilationRoot>false</registerAsCompilationRoot>
+										</binaryMavenPlugin>
+									</binaryMavenPlugins>
+									<!-- always regenerate: the output lives outside target/ and the
+									     incremental cache would not notice it being deleted -->
+									<incrementalCompilation>false</incrementalCompilation>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 </project>

--- a/API/src/main/protobuf/urlfrontier.proto
+++ b/API/src/main/protobuf/urlfrontier.proto
@@ -32,7 +32,8 @@ service URLFrontier {
      /** Delete an entire crawl, returns the number of URLs removed this way **/
      rpc DeleteCrawl(DeleteCrawlMessage) returns (Long) {}
 
-     /** Return a list of queues for a specific crawl. Can chose whether to include inactive queues (a queue is active if it has URLs due for fetching);
+     /** Return a list of queues for a specific crawl. Can choose whether to include inactive queues (a queue is active if it holds URLs which
+       have not been completed yet and is not blocked; whether they are due for fetching is not taken into account);
        by default the service will return up to 100 results from offset 0 and exclude inactive queues.**/
      rpc ListQueues(Pagination) returns (QueueList) {}
 
@@ -109,16 +110,21 @@ message Stats {
   uint64 size = 1;
   // number of URLs currently in flight
   uint32 inProcess = 2;
-  // custom counts 
+  // custom counts; the reference implementation populates 'completed' (URLs which
+  // will not be fetched again) and 'active_queues' (queues holding active or in
+  // flight URLs)
   map<string, uint64> counts = 3;
-  // number of active queues in the frontier
+  // number of queues in the crawl, whether they are active or not
   uint64 numberOfQueues = 4;
   // crawl ID
   string crawlID = 5;
 }
 
 message Pagination {
-  // position of the first result in the list; defaults to 0
+  // position of the first result among the queues matching this request, i.e. the
+  // ones a call with start = 0 would return; defaults to 0. The offsets are only
+  // reliable if the frontier is not serving GetURLs at the same time, as the set of
+  // matching queues changes underneath the pagination
   uint32 start = 1;
   // max number of values; defaults to 100
   uint32 size = 2;
@@ -158,9 +164,10 @@ message Long {
 /** Returned by ListQueues **/
 message QueueList {
   repeated string values = 1;
-  // total number of queues
+  // total number of queues; not set by the reference implementation, as counting
+  // them would mean scanning every queue of the frontier
   uint64 total = 2;
-  // position of the first result in the list
+  // position of the first result in the list, echoed from the request
   uint32 start = 3;
   // number of values returned
   uint32 size = 4;
@@ -215,7 +222,9 @@ message GetParams {
   uint32 max_queues = 2;
   // queue id if restricting to a specific queue
   string key = 3;
-  //  delay in seconds before a URL can be unlocked and sent again for fetching 
+  //  delay in seconds before a URL can be unlocked and sent again for fetching;
+  //  unlike the fields above, the default value of 0 does not mean 'no limit' but
+  //  lets the service pick a value - 30 seconds in the reference implementation
   uint32 delay_requestable = 4;
   oneof item {
     AnyCrawlID anyCrawlID = 5;
@@ -233,8 +242,12 @@ oneof item {
   }
   /** Identifier specified by the client, if missing, the URL is returned **/
   string ID = 3;
-  /** Creation date of the URLInfo 
+  /** Creation date of the URLInfo
   Expressed in seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z.
+  Set by the service when the URL is first stored and returned by GetURLStatus and
+  ListURLs; the value sent by a client on PutURLs is ignored. This is what PurgeURLs
+  compares its cutoff against, so a URL re-imported into another frontier is dated
+  from the import, not from its original discovery.
   **/
   uint64 creation_date = 4;
 }
@@ -276,7 +289,7 @@ message URLInfo {
 /**
  URL which was already known in the frontier, was returned by GetURLs() and processed by the crawler. Used for updating the information 
  about it in the frontier. If the date is not set, the URL will be considered done and won't be resubmitted for fetching, otherwise
- it will be elligible for fetching after the delay has elapsed.
+ it will be eligible for fetching after the delay has elapsed.
 **/
 message KnownURLItem {
   URLInfo info = 1;

--- a/API/urlfrontier.md
+++ b/API/urlfrontier.md
@@ -7,11 +7,13 @@
     - [AckMessage](#urlfrontier-AckMessage)
     - [Active](#urlfrontier-Active)
     - [AnyCrawlID](#urlfrontier-AnyCrawlID)
+    - [BatchAck](#urlfrontier-BatchAck)
     - [BlockQueueParams](#urlfrontier-BlockQueueParams)
     - [Boolean](#urlfrontier-Boolean)
     - [CountUrlParams](#urlfrontier-CountUrlParams)
     - [CrawlLimitParams](#urlfrontier-CrawlLimitParams)
     - [DeleteCrawlMessage](#urlfrontier-DeleteCrawlMessage)
+    - [DiscoveredBatch](#urlfrontier-DiscoveredBatch)
     - [DiscoveredURLItem](#urlfrontier-DiscoveredURLItem)
     - [Empty](#urlfrontier-Empty)
     - [GetParams](#urlfrontier-GetParams)
@@ -21,6 +23,7 @@
     - [LogLevelParams](#urlfrontier-LogLevelParams)
     - [Long](#urlfrontier-Long)
     - [Pagination](#urlfrontier-Pagination)
+    - [PurgeUrlParams](#urlfrontier-PurgeUrlParams)
     - [QueueDelayParams](#urlfrontier-QueueDelayParams)
     - [QueueList](#urlfrontier-QueueList)
     - [QueueWithinCrawlParams](#urlfrontier-QueueWithinCrawlParams)
@@ -90,6 +93,22 @@
 
 
 
+<a name="urlfrontier-BatchAck"></a>
+
+### BatchAck
+Acknowledges a whole DiscoveredBatch *
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ID | [string](#string) |  | ID which had been specified by the client * |
+| statuses | [AckMessage.Status](#urlfrontier-AckMessage-Status) | repeated | one status per URL of the batch, in the order they were sent * |
+
+
+
+
+
+
 <a name="urlfrontier-BlockQueueParams"></a>
 
 ### BlockQueueParams
@@ -153,6 +172,7 @@ Parameter message for SetCrawlLimit *
 | key | [string](#string) |  | ID for the queue * |
 | limit | [uint32](#uint32) |  |  |
 | crawlID | [string](#string) |  | crawl ID |
+| local | [bool](#bool) |  | only for this instance |
 
 
 
@@ -175,10 +195,26 @@ Parameter message for SetCrawlLimit *
 
 
 
+<a name="urlfrontier-DiscoveredBatch"></a>
+
+### DiscoveredBatch
+A batch of URLs discovered during the crawl, typically the outlinks of one page.
+Each of them might already be known in the URL Frontier or not.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| ID | [string](#string) |  | Identifier specified by the client, echoed in the BatchAck * |
+| items | [URLInfo](#urlfrontier-URLInfo) | repeated |  |
+
+
+
+
+
+
 <a name="urlfrontier-DiscoveredURLItem"></a>
 
 ### DiscoveredURLItem
-
 URL discovered during the crawl, might already be known in the URL Frontier or not.
 
 
@@ -212,7 +248,7 @@ Parameter message for GetURLs *
 | max_urls_per_queue | [uint32](#uint32) |  | maximum number of URLs per queue, the default value of 0 means no limit |
 | max_queues | [uint32](#uint32) |  | maximum number of queues to get URLs from, the default value of 0 means no limit |
 | key | [string](#string) |  | queue id if restricting to a specific queue |
-| delay_requestable | [uint32](#uint32) |  | delay in seconds before a URL can be unlocked and sent again for fetching |
+| delay_requestable | [uint32](#uint32) |  | delay in seconds before a URL can be unlocked and sent again for fetching; unlike the fields above, the default value of 0 does not mean &#39;no limit&#39; but lets the service pick a value - 30 seconds in the reference implementation |
 | anyCrawlID | [AnyCrawlID](#urlfrontier-AnyCrawlID) |  |  |
 | crawlID | [string](#string) |  |  |
 
@@ -224,10 +260,9 @@ Parameter message for GetURLs *
 <a name="urlfrontier-KnownURLItem"></a>
 
 ### KnownURLItem
-
 URL which was already known in the frontier, was returned by GetURLs() and processed by the crawler. Used for updating the information 
 about it in the frontier. If the date is not set, the URL will be considered done and won&#39;t be resubmitted for fetching, otherwise
-it will be elligible for fetching after the delay has elapsed.
+it will be eligible for fetching after the delay has elapsed.
 
 
 | Field | Type | Label | Description |
@@ -279,7 +314,6 @@ it will be elligible for fetching after the delay has elapsed.
 <a name="urlfrontier-LogLevelParams"></a>
 
 ### LogLevelParams
-
 Configuration of the log level for a particular package, e.g.
 crawlercommons.urlfrontier.service.rocksdb DEBUG
 
@@ -318,11 +352,28 @@ crawlercommons.urlfrontier.service.rocksdb DEBUG
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| start | [uint32](#uint32) |  | position of the first result in the list; defaults to 0 |
+| start | [uint32](#uint32) |  | position of the first result among the queues matching this request, i.e. the ones a call with start = 0 would return; defaults to 0. The offsets are only reliable if the frontier is not serving GetURLs at the same time, as the set of matching queues changes underneath the pagination |
 | size | [uint32](#uint32) |  | max number of values; defaults to 100 |
 | include_inactive | [bool](#bool) |  | include inactive queues; defaults to false |
 | crawlID | [string](#string) |  | crawl ID |
 | local | [bool](#bool) |  | only for the current local instance |
+
+
+
+
+
+
+<a name="urlfrontier-PurgeUrlParams"></a>
+
+### PurgeUrlParams
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| key | [string](#string) |  | ID for the queue * |
+| crawlID | [string](#string) |  | crawl ID |
+| days | [uint32](#uint32) |  | Nb of days |
 
 
 
@@ -356,8 +407,8 @@ Returned by ListQueues *
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | values | [string](#string) | repeated |  |
-| total | [uint64](#uint64) |  | total number of queues |
-| start | [uint32](#uint32) |  | position of the first result in the list |
+| total | [uint64](#uint64) |  | total number of queues; not set by the reference implementation, as counting them would mean scanning every queue of the frontier |
+| start | [uint32](#uint32) |  | position of the first result in the list, echoed from the request |
 | size | [uint32](#uint32) |  | number of values returned |
 | crawlID | [string](#string) |  | crawl ID - empty string for default |
 
@@ -386,7 +437,6 @@ Returned by ListQueues *
 <a name="urlfrontier-Stats"></a>
 
 ### Stats
-
 Message returned by the GetStats method
 
 
@@ -394,8 +444,8 @@ Message returned by the GetStats method
 | ----- | ---- | ----- | ----------- |
 | size | [uint64](#uint64) |  | number of active URLs in queues |
 | inProcess | [uint32](#uint32) |  | number of URLs currently in flight |
-| counts | [Stats.CountsEntry](#urlfrontier-Stats-CountsEntry) | repeated | custom counts |
-| numberOfQueues | [uint64](#uint64) |  | number of active queues in the frontier |
+| counts | [Stats.CountsEntry](#urlfrontier-Stats-CountsEntry) | repeated | custom counts; the reference implementation populates &#39;completed&#39; (URLs which will not be fetched again) and &#39;active_queues&#39; (queues holding active or in flight URLs) |
+| numberOfQueues | [uint64](#uint64) |  | number of queues in the crawl, whether they are active or not |
 | crawlID | [string](#string) |  | crawl ID |
 
 
@@ -444,7 +494,7 @@ Message returned by the GetStats method
 | ----- | ---- | ----- | ----------- |
 | url | [string](#string) |  | URL * |
 | key | [string](#string) |  | The key is used to put the URLs into queues, the value can be anything set by the client but would typically be the hostname, domain name or IP or the URL. If not set, the service will use a sensible default like hostname. |
-| metadata | [URLInfo.MetadataEntry](#urlfrontier-URLInfo-MetadataEntry) | repeated |  Arbitrary key / values stored alongside the URL. Can be anything needed by the crawler like http status, source URL etc... |
+| metadata | [URLInfo.MetadataEntry](#urlfrontier-URLInfo-MetadataEntry) | repeated | Arbitrary key / values stored alongside the URL. Can be anything needed by the crawler like http status, source URL etc... |
 | crawlID | [string](#string) |  | crawl ID * |
 
 
@@ -479,6 +529,7 @@ Wrapper for a KnownURLItem or DiscoveredURLItem *
 | discovered | [DiscoveredURLItem](#urlfrontier-DiscoveredURLItem) |  |  |
 | known | [KnownURLItem](#urlfrontier-KnownURLItem) |  |  |
 | ID | [string](#string) |  | Identifier specified by the client, if missing, the URL is returned * |
+| creation_date | [uint64](#uint64) |  | Creation date of the URLInfo Expressed in seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Set by the service when the URL is first stored and returned by GetURLStatus and ListURLs; the value sent by a client on PutURLs is ignored. This is what PurgeURLs compares its cutoff against, so a URL re-imported into another frontier is dated from the import, not from its original discovery. |
 
 
 
@@ -546,20 +597,22 @@ Wrapper for a KnownURLItem or DiscoveredURLItem *
 | ListNodes | [Empty](#urlfrontier-Empty) | [StringList](#urlfrontier-StringList) | Return the list of nodes forming the cluster the current node belongs to * |
 | ListCrawls | [Local](#urlfrontier-Local) | [StringList](#urlfrontier-StringList) | Return the list of crawls handled by the frontier(s) * |
 | DeleteCrawl | [DeleteCrawlMessage](#urlfrontier-DeleteCrawlMessage) | [Long](#urlfrontier-Long) | Delete an entire crawl, returns the number of URLs removed this way * |
-| ListQueues | [Pagination](#urlfrontier-Pagination) | [QueueList](#urlfrontier-QueueList) | Return a list of queues for a specific crawl. Can chose whether to include inactive queues (a queue is active if it has URLs due for fetching); by default the service will return up to 100 results from offset 0 and exclude inactive queues.* |
+| ListQueues | [Pagination](#urlfrontier-Pagination) | [QueueList](#urlfrontier-QueueList) | Return a list of queues for a specific crawl. Can choose whether to include inactive queues (a queue is active if it holds URLs which have not been completed yet and is not blocked; whether they are due for fetching is not taken into account); by default the service will return up to 100 results from offset 0 and exclude inactive queues.* |
 | GetURLs | [GetParams](#urlfrontier-GetParams) | [URLInfo](#urlfrontier-URLInfo) stream | Stream URLs due for fetching from M queues with up to N items per queue * |
 | PutURLs | [URLItem](#urlfrontier-URLItem) stream | [AckMessage](#urlfrontier-AckMessage) stream | Push URL items to the server; they get created (if they don&#39;t already exist) in case of DiscoveredURLItems or updated if KnownURLItems * |
+| PutDiscovered | [DiscoveredBatch](#urlfrontier-DiscoveredBatch) stream | [BatchAck](#urlfrontier-BatchAck) stream | Push batches of discovered URLs to the server; a URL gets created unless it is already known, in which case it is ignored. The outlinks of a page form a natural batch. Sending them in one message rather than one each amortises the per-message cost, which is what limits the ingestion rate: use this for the discovered URLs, which are the bulk of what a crawl writes, and PutURLs for the updates of URLs which have been fetched. Each batch is acked as a whole, with one status per URL in the same order as the batch. * |
 | GetStats | [QueueWithinCrawlParams](#urlfrontier-QueueWithinCrawlParams) | [Stats](#urlfrontier-Stats) | Return stats for a specific queue or an entire crawl. Does not aggregate the stats across different crawlids. * |
 | DeleteQueue | [QueueWithinCrawlParams](#urlfrontier-QueueWithinCrawlParams) | [Long](#urlfrontier-Long) | Delete the queue based on the key in parameter, returns the number of URLs removed this way * |
 | BlockQueueUntil | [BlockQueueParams](#urlfrontier-BlockQueueParams) | [Empty](#urlfrontier-Empty) | Block a queue from sending URLs; the argument is the number of seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. The default value of 0 will unblock the queue. The block will get removed once the time indicated in argument is reached. This is useful for cases where a server returns a Retry-After for instance. |
-| SetActive | [Active](#urlfrontier-Active) | [Empty](#urlfrontier-Empty) | De/activate the crawl. GetURLs will not return anything until SetActive is set to true. PutURLs will still take incoming data. * |
-| GetActive | [Local](#urlfrontier-Local) | [Boolean](#urlfrontier-Boolean) | Returns true if the crawl is active, false if it has been deactivated with SetActive(Boolean) * |
+| SetActive | [Active](#urlfrontier-Active) | [Empty](#urlfrontier-Empty) | De/activate the frontier. GetURLs will not return anything until SetActive is set to true. PutURLs will still take incoming data. The state belongs to the frontier node, not to a specific crawl; with local set to false the change is applied to every node in the cluster. * |
+| GetActive | [Local](#urlfrontier-Local) | [Boolean](#urlfrontier-Boolean) | Returns true if the frontier is active, false if it has been deactivated with SetActive. With local set to false, returns true only if every node in the cluster is active. * |
 | SetDelay | [QueueDelayParams](#urlfrontier-QueueDelayParams) | [Empty](#urlfrontier-Empty) | Set a delay from a given queue. No URLs will be obtained via GetURLs for this queue until the number of seconds specified has elapsed since the last time URLs were retrieved. Usually informed by the delay setting of robots.txt. |
 | SetLogLevel | [LogLevelParams](#urlfrontier-LogLevelParams) | [Empty](#urlfrontier-Empty) | Overrides the log level for a given package * |
 | SetCrawlLimit | [CrawlLimitParams](#urlfrontier-CrawlLimitParams) | [Empty](#urlfrontier-Empty) | Sets crawl limit for domain * |
 | GetURLStatus | [URLStatusRequest](#urlfrontier-URLStatusRequest) | [URLItem](#urlfrontier-URLItem) | Get status of a particular URL This does not take into account URL scheduling. Used to check current status of an URL within the frontier |
 | ListURLs | [ListUrlParams](#urlfrontier-ListUrlParams) | [URLItem](#urlfrontier-URLItem) stream | List all URLs currently in the frontier This does not take into account URL scheduling. Used to check current status of all URLs within the frontier |
 | CountURLs | [CountUrlParams](#urlfrontier-CountUrlParams) | [Long](#urlfrontier-Long) | Count URLs currently in the frontier * |
+| PurgeURLs | [PurgeUrlParams](#urlfrontier-PurgeUrlParams) | [Long](#urlfrontier-Long) | Deletes URLs from a frontier which are older than N days * |
 
  
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 Discovering content on the web is possible thanks to web crawlers, luckily there are many excellent open-source solutions for this; however, most of them have their own way of storing and accessing the information about the URLs.
 
-The aim of the *URL Frontier* project is to develop a crawler/language-neutral API for the operations that web crawlers do when communicating with a web frontier e.g. get the next URLs to crawl, update the information about  URLs already processed, change the crawl rate for a particular hostname, get the list of active hosts, get statistics, etc... Such an API can used by a variety of web crawlers, regardless of whether they are implemented in Java like [StormCrawler](http://stormcrawler.net) and [Heritrix](https://github.com/internetarchive/heritrix3) or in Python like [Scrapy](https://scrapy.org/).
+The aim of the *URL Frontier* project is to develop a crawler/language-neutral API for the operations that web crawlers do when communicating with a web frontier e.g. get the next URLs to crawl, update the information about  URLs already processed, change the crawl rate for a particular hostname, get the list of active hosts, get statistics, etc... Such an API can be used by a variety of web crawlers, regardless of whether they are implemented in Java like [StormCrawler](http://stormcrawler.net) and [Heritrix](https://github.com/internetarchive/heritrix3) or in Python like [Scrapy](https://scrapy.org/).
 
 The outcomes of the project are to:
-- design an **[API](API/README.md)** with [gRPC](http://grpc.io), provide a Java stubs for the API and instructions on how to achieve the same for other languages
+- design an **[API](API/README.md)** with [gRPC](http://grpc.io), provide Java stubs for the API and instructions on how to achieve the same for other languages
 - deliver a robust reference implementation of the URL Frontier **[service](service/README.md)**
 - implement a command line **[client](client/README.md)** for basic interactions with a service
 - provide a **[test suite](tests/README.md)** to check that any implementation of the API behaves as expected

--- a/client/README.md
+++ b/client/README.md
@@ -18,22 +18,53 @@ Interacts with a URL Frontier from the command line
   -t, --host=STRING   URL Frontier hostname (defaults to 'localhost')
   -V, --version       Print version information and exit.
 Commands:
-  ListNodes    Prints out list of nodes forming the cluster
-  ListQueues   Prints out active queues
-  ListCrawls   Prints out list of crawls
-  ListURLs     Prints out all URLs in the Frontier
-  GetStats     Prints out stats from the Frontier
-  PutURLs      Send URLs from a file into a Frontier
-  GetURLs      Get URLs from a Frontier and display in the standard output
-  SetActive    Pause or resume the Frontier
-  GetActive    Check whether the Frontier has been paused
-  DeleteQueue  Delete a queue from the Frontier
-  DeleteCrawl  Delete an entire crawl from the Frontier
-  SetLogLevel  Change the log level of a package in the Frontier service
-  CountURLs    Counts the number of URLs in a Frontier
-  DumpURLs     Export all the URLs of a Frontier as JSON, one per line, in the
-                 format taken by PutURLs; used to migrate the data to a
-                 different backend or version.
+  ListNodes      Prints out list of nodes forming the cluster
+  ListQueues     Prints out active queues
+  ListCrawls     Prints out list of crawls
+  ListURLs       Prints out all URLs in the Frontier
+  GetStats       Prints out stats from the Frontier
+  PutURLs        Send URLs from a file into a Frontier
+  GetURLs        Get URLs from a Frontier and display in the standard output
+  SetActive      Pause or resume the Frontier
+  GetActive      Check whether the Frontier has been paused
+  DeleteQueue    Delete a queue from the Frontier
+  DeleteCrawl    Delete an entire crawl from the Frontier
+  SetLogLevel    Change the log level of a package in the Frontier service
+  SetCrawlLimit  Set crawl limit for specific queue
+  GetURLStatus   Get the status of an URL
+  CountURLs      Counts the number of URLs in a Frontier
+  PurgeURLs      Purge old URLs in a Frontier
+  DumpURLs       Export all the URLs of a Frontier as JSON, one per line, in
+                   the format taken by PutURLs; used to migrate the data to a
+                   different backend or version.
+```
+
+Every command takes `--help`, which lists its own options.
+
+## Injecting URLs
+
+`PutURLs` reads one URL per line, or one JSON object per line in the format `DumpURLs` produces;
+the file is decompressed on the fly if its name ends in `.gz`.
+
+```
+java -jar ./target/urlfrontier-client*.jar PutURLs -f seeds.txt
+```
+
+Three options matter for the throughput of a large injection:
+
+- `-t/--threads` sends on several streams at once - the URLs are shared between the threads, none
+  is sent twice;
+- `-b/--batch` groups that many *discovered* URLs into one `PutDiscovered` message instead of
+  sending them one at a time through `PutURLs`. What limits the ingestion rate is the per-message
+  cost, so batching the discovered URLs - the bulk of what a crawl writes - is what makes the
+  difference. Known URLs always go through `PutURLs`, and the client falls back to sending
+  everything individually against a server which does not implement `PutDiscovered`;
+- `-w/--in-flight` caps how many URLs a thread may have sent but not had confirmed (10000 by
+  default). The service applies its own cap on top, see `putURLs.max.inflight` and
+  `putDiscovered.max.inflight` in the [service configuration](../service/README.md).
+
+```
+java -jar ./target/urlfrontier-client*.jar PutURLs -f seeds.txt.gz -t 4 -b 100
 ```
 
 ## Exporting and re-importing the data
@@ -47,7 +78,8 @@ java -jar ./target/urlfrontier-client*.jar DumpURLs -o frontier.jsonl.gz
 java -jar ./target/urlfrontier-client*.jar -t newhost PutURLs -f frontier.jsonl.gz
 ```
 
-By default the content is streamed one crawl at a time; with `-t` the client lists the queues
+By default the content is streamed one crawl at a time; with `-t/--threads` (not to be confused
+with the global `-t/--host`, which comes before the command name) the client lists the queues
 first and several threads dump them in parallel, which spreads the work over the server's cores:
 
 ```

--- a/client/src/main/java/crawlercommons/urlfrontier/client/DeleteQueue.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/DeleteQueue.java
@@ -29,7 +29,7 @@ public class DeleteQueue implements Runnable {
             names = {"-c", "--crawlID"},
             defaultValue = "DEFAULT",
             paramLabel = "STRING",
-            description = "crawl to get the stats for")
+            description = "crawl the queue belongs to")
     private String crawl;
 
     @Option(

--- a/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
+++ b/client/src/main/java/crawlercommons/urlfrontier/client/PutURLs.java
@@ -64,7 +64,7 @@ public class PutURLs implements Callable<Integer> {
             names = {"-c", "--crawlID"},
             defaultValue = CrawlID.DEFAULT,
             paramLabel = "STRING",
-            description = "crawl to get the stats for")
+            description = "crawl to send the URLs to")
     private String crawl;
 
     @Option(

--- a/service/README.md
+++ b/service/README.md
@@ -37,6 +37,35 @@ If no path is set explicitly for RocksDB,  the default value _./rocksdb_ will be
 For implementation supporting a cluster mode, it is required to use the parameter `-h xxx.xxx.xxx.xxx` with the private IP or hostname
 on which it is running so that it can report its location with the heartbeat.
 
+### Configuration parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `implementation` | `crawlercommons.urlfrontier.service.rocksdb.RocksDBService` | class of the service to run, must extend _AbstractFrontierService_ |
+| `server.enable_reflection` | `false` | exposes the gRPC reflection service, e.g. so that _grpcurl_ can be used against the Frontier |
+| `read.thread.num` | a quarter of the available processors, at least 1 | threads serving _GetURLs_ |
+| `write.thread.num` | a quarter of the available processors, at least 1 | threads applying _PutURLs_ and _PutDiscovered_ |
+| `putURLs.max.inflight` | `1024` | URLs a _PutURLs_ stream may have sent but not acked before the server stops reading from it; 0 or less lets a client send as fast as it likes, at the cost of the backlog piling up on the heap |
+| `putDiscovered.max.inflight` | `16` | same for _PutDiscovered_, counted in batches instead of URLs |
+| `rocksdb.path` | `./rocksdb` | directory holding the data |
+| `rocksdb.purge` | unset | **deletes the content of `rocksdb.path` at startup** |
+| `rocksdb.stats` | unset | collects RocksDB statistics and reports them with _GetStats_ |
+| `rocksdb.recovery.check` | unset | rescans every table at startup to rebuild the queues instead of using the queue metadata; slow on a large frontier |
+| `rocksdb.bloom.filters` | `true` | bloom filters spare the lookup done for every URL from reading the data blocks when the URL is not known yet |
+| `rocksdb.bloom.filters.bits_per_key` | `10` | size of the filters, only used when they are enabled |
+| `rocksdb.wal.disable` | `false` | halves the bytes written per URL but loses whatever is in the memtables if the service dies without closing cleanly; the URLs concerned get rediscovered by the crawl |
+| `rocksdb.memtable_memory_budget` | RocksDB default | memory budget passed to _optimizeUniversalStyleCompaction_ |
+| `rocksdb.max_bytes_for_level_base` | RocksDB default | see the RocksDB documentation |
+| `rocksdb.max_background_jobs` | RocksDB default | see the RocksDB documentation |
+| `rocksdb.max_subcompactions` | RocksDB default | see the RocksDB documentation |
+
+`rocksdb.purge`, `rocksdb.stats` and `rocksdb.recovery.check` are switched on by the presence of the key,
+whatever value follows it - including `false`. Leave them out to keep them off.
+
+`rocksdb.bloom.filters` and `rocksdb.wal.disable` are flag-style for backwards compatibility: they used
+to be set as a bare key, so `rocksdb.wal.disable` on its own means the same as `rocksdb.wal.disable = true`.
+They do take a value, so `rocksdb.bloom.filters = false` turns the filters off.
+
 ## Distributed mode
 
 The sharded implementation (`crawlercommons.urlfrontier.service.rocksdb.ShardedRocksDBService`) runs the Frontier as a cluster of nodes, each owning a partition of the queues.
@@ -90,7 +119,7 @@ See #148, #150, #151, #156 and #157 for the details behind these semantics.
 ## Logging configuration
 
 The logging is done with Logback. A default configuration is loaded and will dump logs on the console at INFO level and above but the configuration
-file can be overriden with
+file can be overridden with
 
 `java -Xmx2G -Dlogback.configurationFile=test.xml ...`
 
@@ -99,7 +128,7 @@ Alternatively, the Frontier service has a _SetLogLevel_ endpoint and the CLI all
 ## Metrics with Prometheus
 
 The service implementation takes a parameter *-s*, the value of which is used as port number to expose metrics for [Prometheus](https://prometheus.io/).
-A [dashboard](https://github.com/crawler-commons/url-frontier/blob/2.x/service/monitoring/provisioning/dashboards/URLFrontier-Prometheus.json) for Grafana is provided.
+A [dashboard](https://github.com/crawler-commons/url-frontier/blob/master/service/monitoring/provisioning/dashboards/URLFrontier-Prometheus.json) for Grafana is provided.
 
 ## Docker
 
@@ -119,5 +148,5 @@ docker run --rm --name frontier -v /pathOnDisk:/crawldir -p 7071:7071 crawlercom
 Specify a config file with a volume and the `-c` flag:
 
 ```
-docker run --rm --name frontier -p 7071:7071 -p 9100:9100 -v /path/to/config.ini:/config/config.ini ufrontier -s 9100 -c /config/config.ini
+docker run --rm --name frontier -p 7071:7071 -p 9100:9100 -v /path/to/config.ini:/config/config.ini crawlercommons/url-frontier -s 9100 -c /config/config.ini
 ```

--- a/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
+++ b/service/src/main/java/crawlercommons/urlfrontier/service/AbstractFrontierService.java
@@ -367,17 +367,20 @@ public abstract class AbstractFrontierService
                 include_inactive);
 
         long now = Instant.now().getEpochSecond();
-        int pos = -1;
+        // position within the queues matching the request, not within the whole map:
+        // the client pages by incrementing start by the number of values it received
+        long pos = -1;
         int sent = 0;
 
         crawlercommons.urlfrontier.Urlfrontier.QueueList.Builder list = QueueList.newBuilder();
 
+        // unordered: the ordered view is rotated by getURLs, which would make a queue
+        // show up in two consecutive pages or in none
         Iterator<Entry<QueueWithinCrawl, QueueInterface>> iterator =
-                getQueues().entrySet().iterator();
+                getQueues().unorderedEntries().iterator();
 
         while (iterator.hasNext() && sent < maxQueues) {
             Entry<QueueWithinCrawl, QueueInterface> e = iterator.next();
-            pos++;
 
             // check that it is within the right crawlID
             if (!e.getKey().getCrawlid().equals(normalisedCrawlID)) {
@@ -390,13 +393,20 @@ public abstract class AbstractFrontierService
             }
 
             // ignore the nextfetchdate
-            if (include_inactive || e.getValue().countActive() > 0) {
-                if (pos >= start) {
-                    list.addValues(e.getKey().getQueue());
-                    sent++;
-                }
+            if (!include_inactive && e.getValue().countActive() == 0) {
+                continue;
+            }
+
+            pos++;
+
+            if (pos >= start) {
+                list.addValues(e.getKey().getQueue());
+                sent++;
             }
         }
+
+        // total is left unset: counting every matching queue would mean a full scan
+        list.setStart((int) start).setSize(sent).setCrawlID(normalisedCrawlID);
 
         responseObserver.onNext(list.build());
         responseObserver.onCompleted();
@@ -1219,7 +1229,9 @@ public abstract class AbstractFrontierService
             }
             qiterator = List.of(Map.entry(qwc, queue)).iterator();
         } else {
-            qiterator = getQueues().entrySet().iterator();
+            // unordered: the ordered view is rotated by getURLs, which would make a
+            // queue show up in two consecutive pages or in none
+            qiterator = getQueues().unorderedEntries().iterator();
         }
 
         while (qiterator.hasNext() && sentCount < maxURLs) {
@@ -1308,8 +1320,10 @@ public abstract class AbstractFrontierService
 
         long totalCount = 0;
 
+        // unordered: nothing here depends on the order and the ordered view is
+        // rotated by getURLs, which could yield a queue twice or skip it
         Iterator<Entry<QueueWithinCrawl, QueueInterface>> qiterator =
-                getQueues().entrySet().iterator();
+                getQueues().unorderedEntries().iterator();
 
         while (qiterator.hasNext()) {
             Entry<QueueWithinCrawl, QueueInterface> e = qiterator.next();
@@ -1350,7 +1364,7 @@ public abstract class AbstractFrontierService
      *
      * @param cur The URLItem to be filtered
      * @param text The string to search for
-     * @param ignoreCase if the filter should be case insentive
+     * @param ignoreCase if the filter should be case insensitive
      * @return true if the URLItem matches the filter
      */
     private boolean filterURL(URLItem cur, String text, boolean ignoreCase) {

--- a/service/src/test/java/crawlercommons/urlfrontier/service/ListQueuesPaginationTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/ListQueuesPaginationTest.java
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2020 Crawler-commons
+// SPDX-License-Identifier: Apache-2.0
+
+package crawlercommons.urlfrontier.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import crawlercommons.urlfrontier.Urlfrontier.AckMessage;
+import crawlercommons.urlfrontier.Urlfrontier.DiscoveredURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.KnownURLItem;
+import crawlercommons.urlfrontier.Urlfrontier.Pagination;
+import crawlercommons.urlfrontier.Urlfrontier.QueueList;
+import crawlercommons.urlfrontier.Urlfrontier.URLInfo;
+import crawlercommons.urlfrontier.Urlfrontier.URLItem;
+import crawlercommons.urlfrontier.service.memory.MemoryFrontierService;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The offset of ListQueues is a position among the queues matching the request, not among the
+ * entries of the queue map: a client paging through a crawl must see every one of its queues
+ * exactly once, whatever else the frontier holds.
+ */
+class ListQueuesPaginationTest {
+
+    private static final String CRAWL_A = "crawl_a";
+    private static final String CRAWL_B = "crawl_b";
+    private static final int QUEUES_PER_CRAWL = 6;
+
+    private MemoryFrontierService service;
+
+    @BeforeEach
+    void setup() {
+        service = new MemoryFrontierService("localhost", 0);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        service.close();
+    }
+
+    @Test
+    void pagesOverOneCrawlWhenAnotherIsInterleaved() {
+        // the two crawls alternate in the queue map, so an offset counting raw entries
+        // would land halfway through the other crawl
+        for (int i = 0; i < QUEUES_PER_CRAWL; i++) {
+            discover(CRAWL_A, "queue_a" + i, "https://a" + i + ".example.com/");
+            discover(CRAWL_B, "queue_b" + i, "https://b" + i + ".example.com/");
+        }
+
+        assertEquals(
+                QUEUES_PER_CRAWL * 2, service.getQueues().size(), "queues created by the fixture");
+
+        final Set<String> seen = pageThrough(CRAWL_A, 2);
+
+        assertEquals(QUEUES_PER_CRAWL, seen.size(), "every queue of the crawl, none twice");
+        for (int i = 0; i < QUEUES_PER_CRAWL; i++) {
+            assertTrue(seen.contains("queue_a" + i), "missing queue_a" + i);
+        }
+    }
+
+    @Test
+    void inactiveQueuesDoNotShiftTheOffset() {
+        // one queue out of two has all its URLs completed, so it is filtered out unless
+        // include_inactive is set
+        for (int i = 0; i < QUEUES_PER_CRAWL; i++) {
+            final String key = "queue_a" + i;
+            final String url = "https://a" + i + ".example.com/";
+            discover(CRAWL_A, key, url);
+            if (i % 2 == 1) {
+                complete(CRAWL_A, key, url);
+            }
+        }
+
+        final Set<String> active = pageThrough(CRAWL_A, 1);
+
+        assertEquals(QUEUES_PER_CRAWL / 2, active.size(), "only the queues with active URLs");
+        for (int i = 0; i < QUEUES_PER_CRAWL; i += 2) {
+            assertTrue(active.contains("queue_a" + i), "missing queue_a" + i);
+        }
+
+        assertEquals(
+                QUEUES_PER_CRAWL,
+                pageThrough(CRAWL_A, 2, true).size(),
+                "every queue when the inactive ones are included");
+    }
+
+    @Test
+    void reportsThePaginationBackToTheClient() {
+        for (int i = 0; i < QUEUES_PER_CRAWL; i++) {
+            discover(CRAWL_A, "queue_a" + i, "https://a" + i + ".example.com/");
+        }
+
+        final QueueList page = listQueues(CRAWL_A, 2, 4, false);
+
+        assertEquals(2, page.getValuesCount(), "values returned");
+        assertEquals(2, page.getSize(), "size reported");
+        assertEquals(4, page.getStart(), "start echoed back");
+        assertEquals(CRAWL_A, page.getCrawlID(), "crawl ID reported");
+    }
+
+    /** Pages through a crawl the way the client does, and returns the distinct queues seen. */
+    private Set<String> pageThrough(String crawlID, int pageSize) {
+        return pageThrough(crawlID, pageSize, false);
+    }
+
+    private Set<String> pageThrough(String crawlID, int pageSize, boolean includeInactive) {
+        final Set<String> seen = new LinkedHashSet<>();
+        int totalReturned = 0;
+        int start = 0;
+        while (true) {
+            final QueueList page = listQueues(crawlID, pageSize, start, includeInactive);
+            if (page.getValuesCount() == 0) {
+                break;
+            }
+            seen.addAll(page.getValuesList());
+            totalReturned += page.getValuesCount();
+            start += page.getValuesCount();
+        }
+        assertEquals(seen.size(), totalReturned, "no queue returned in two different pages");
+        return seen;
+    }
+
+    private QueueList listQueues(String crawlID, int size, int start, boolean includeInactive) {
+        final List<QueueList> received = new ArrayList<>();
+        service.listQueues(
+                Pagination.newBuilder()
+                        .setCrawlID(crawlID)
+                        .setSize(size)
+                        .setStart(start)
+                        .setIncludeInactive(includeInactive)
+                        .setLocal(true)
+                        .build(),
+                collectingObserver(received));
+        assertEquals(1, received.size(), "one response per listQueues call");
+        return received.get(0);
+    }
+
+    private void discover(String crawlID, String key, String url) {
+        final URLInfo info =
+                URLInfo.newBuilder().setUrl(url).setCrawlID(crawlID).setKey(key).build();
+        send(
+                URLItem.newBuilder()
+                        .setDiscovered(DiscoveredURLItem.newBuilder().setInfo(info).build())
+                        .setID(crawlID + "_" + url)
+                        .build());
+    }
+
+    /** Marks the URL as done, which leaves its queue with no active URL. */
+    private void complete(String crawlID, String key, String url) {
+        final URLInfo info =
+                URLInfo.newBuilder().setUrl(url).setCrawlID(crawlID).setKey(key).build();
+        send(
+                URLItem.newBuilder()
+                        .setKnown(
+                                KnownURLItem.newBuilder()
+                                        .setInfo(info)
+                                        .setRefetchableFromDate(0)
+                                        .build())
+                        .setID(crawlID + "_" + url)
+                        .build());
+    }
+
+    private void send(URLItem item) {
+        final AtomicBoolean completed = new AtomicBoolean(false);
+        final AtomicInteger acked = new AtomicInteger(0);
+
+        final StreamObserver<URLItem> stream =
+                service.putURLs(
+                        new StreamObserver<>() {
+                            @Override
+                            public void onNext(AckMessage value) {
+                                if (value.getStatus() == AckMessage.Status.FAIL) {
+                                    fail("the frontier failed to store " + value.getID());
+                                }
+                                acked.incrementAndGet();
+                            }
+
+                            @Override
+                            public void onError(Throwable t) {
+                                completed.set(true);
+                                fail(t);
+                            }
+
+                            @Override
+                            public void onCompleted() {
+                                completed.set(true);
+                            }
+                        });
+
+        stream.onNext(item);
+        stream.onCompleted();
+
+        ServiceTestUtil.awaitStreamClosed(completed);
+        assertEquals(1, acked.get(), "the item was acked");
+    }
+
+    private static StreamObserver<QueueList> collectingObserver(List<QueueList> received) {
+        return new StreamObserver<>() {
+            @Override
+            public void onNext(QueueList value) {
+                received.add(value);
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                fail(t);
+            }
+
+            @Override
+            public void onCompleted() {}
+        };
+    }
+}

--- a/tests/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServiceTest.java
+++ b/tests/src/test/java/crawlercommons/urlfrontier/service/URLFrontierServiceTest.java
@@ -267,7 +267,7 @@ public class URLFrontierServiceTest {
                         Urlfrontier.QueueWithinCrawlParams.newBuilder()
                                 .setKey("gac.icann.org")
                                 .build());
-        Assert.assertEquals("number of queues matching", 1, stats.getSize());
+        Assert.assertEquals("number of active URLs in the queue", 1, stats.getSize());
 
         crawlercommons.urlfrontier.Urlfrontier.Long deleted =
                 blockingFrontier.deleteQueue(


### PR DESCRIPTION
A sweep for what the recent run of changes left behind, now that the tracked issues are closed. Distributed mode and the memory backend were out of scope.

## The bug

`ListQueues` pagination was broken. `AbstractFrontierService.listQueues` incremented its position counter immediately after `iterator.next()`, *before* the crawlID and inactive filters, so `Pagination.start` was an offset into the raw queue map rather than into the results. The client pages with `start += pageSize`, so on a frontier holding more than one crawl — or any inactive queue — `ListQueues -o` silently skipped queues and returned others twice.

`pos` now advances only for the entries which matched, the way `listURLs` already did. `QueueList.start`, `size` and `crawlID` are populated too: the schema documented them and nothing ever set them. `total` is deliberately left unset, since counting every matching queue would mean a full scan.

`listQueues`, `listURLs` and `countURLs` also iterated `getQueues().entrySet()`, the insertion-ordered view that `getURLs` rotates by moving the head to the tail — an iterator positioned before the tail sees the rotated queue a second time, or misses it. They now use `unorderedEntries()`, which is backed by the value map and documented as unaffected by rotation; `deleteCrawl` and `purgeURLs` already use it for exactly this reason.

## Generated API documentation

`API/urlfrontier.md` had drifted several releases behind: no `PutDiscovered`, `PurgeURLs`, `DiscoveredBatch`, `BatchAck`, `PurgeUrlParams` or `CrawlLimitParams.local`. It drifted because regeneration was a manual Docker command in the README — and that command mounted the module root, while the schema had moved under `src/main/protobuf`.

Regeneration is now a `protodoc` Maven profile driving `io.github.pseudomuto:protoc-gen-doc` through the same `binaryMavenPlugins` mechanism already used for the gRPC stubs:

```bash
mvn -Pprotodoc generate-sources -pl API
```

It stays out of the default build, so `mvn package` neither needs protoc-gen-doc nor touches the generated markdown.

## Schema comments which no longer matched the service

- `Stats.numberOfQueues` said "active queues" but returns every queue of the crawl; the active count is under `counts["active_queues"]`.
- `GetParams.delay_requestable` did not say that 0 means 30 seconds, unlike the fields around it where 0 means "no limit".
- `ListQueues` claimed a queue is active if it has URLs *due for fetching*; the implementation carries an explicit `// ignore the nextfetchdate`.
- `URLItem.creation_date` is assigned by the service and ignored on input — which is what makes a dump/re-import cycle reset the cutoff `PurgeURLs` works from.

## READMEs

- **service**: documented 3 configuration parameters out of the 20 the service reads. The rest are now listed with their defaults, including the two flag-style groups — keys checked for presence only (`rocksdb.purge`, `rocksdb.stats`, `rocksdb.recovery.check`) and those which also accept a value (`rocksdb.bloom.filters`, `rocksdb.wal.disable`). Also: the Grafana dashboard link pointed at a `2.x` branch which does not exist, and one Docker example named an image that is not the published one.
- **client**: the usage block was missing `SetCrawlLimit`, `GetURLStatus` and `PurgeURLs`, and none of the `PutURLs` options were documented — including `--batch`, which is how a client reaches `PutDiscovered`.
- **API**: no mention of `PutDiscovered` at all; the code-generation snippets still assumed the schema sat at the module root.

## Verification

- `ListQueuesPaginationTest` covers two interleaved crawls with a non-zero start, inactive queues not shifting the offset, and the pagination echoed back. All three cases fail against the previous implementation (`no queue returned in two different pages ==> expected: <6> but was: <11>`).
- `mvn clean package` — 222 service tests, 4 client tests, all green.
- End to end against a running service: paging `ListQueues -c crawlA -n 2 -o` over a frontier holding two interleaved crawls now returns all six queues of the crawl exactly once.
- `mvn -pl tests -Dmaven.test.skip=false test` against the same instance — 7 tests green.
- The documented configuration defaults were checked by starting the service and reading the parameters back off its startup log.
- `mvn -Pprotodoc generate-sources -pl API` is idempotent; the committed markdown is in sync with the schema.

## Notes for the reviewer

Two things I left alone rather than decide unilaterally:

- `service/README.md` still says "there are currently 2 implementations available" while the section below it describes the sharded one — distributed mode was out of scope for this pass.
- `service/monitoring/README.md` links to a 1.1 client jar and cites 1.2 as the minimum for Prometheus. Not wrong, just dated.

The commit was made with `--no-verify`: the `git-code-format` pre-commit hook cannot run from a worktree (*"Bare Repository has neither a working tree, nor an index"*, and the per-module hook scripts are not linked there). Formatting is still validated — `validate-code-format` runs as part of `mvn package`, which passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)