### PR TITLE
Fix the multi-arch Docker release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM maven:3-eclipse-temurin-17 AS build
+# The shaded jar is platform-independent (no native classifiers; rocksdbjni and
+# grpc-netty-shaded ship the natives for every arch), so the build runs once on
+# the builder's own platform instead of once per target under emulation.
+FROM --platform=$BUILDPLATFORM maven:3-eclipse-temurin-17 AS build
 
 RUN useradd -m urlfrontier
 

--- a/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardDeadlineTest.java
+++ b/service/src/test/java/crawlercommons/urlfrontier/service/cluster/ForwardDeadlineTest.java
@@ -93,8 +93,14 @@ class ForwardDeadlineTest {
         }
 
         @Override
-        public void close() throws IOException {
-            socket.close();
+        public void close() {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                // closing the listening socket while the accept thread is parked in a
+                // native accept() can fail to signal that thread (seen under emulation);
+                // the socket is closing either way and the thread is a daemon
+            }
             synchronized (accepted) {
                 for (Socket s : accepted) {
                     try {


### PR DESCRIPTION
The 2.6 [Dockerhub Deployment run](https://github.com/crawler-commons/url-frontier/actions/runs/32255308240) failed, so no 2.6 image was pushed. Two independent problems.

## 1. `ForwardDeadlineTest` teardown

```
#33 332.9 java.io.IOException: Thread signal failed
#33 332.9   at ...ForwardDeadlineTest$BlackHole.close(ForwardDeadlineTest.java:97)
#33 332.9   at ...ForwardDeadlineTest.teardown(ForwardDeadlineTest.java:143)
```

All seven `@Test` methods passed — the failure was in `@AfterAll`. `BlackHole.close()` closed the listening `ServerSocket` while the `blackhole-accept` daemon thread was parked in a native `accept()`. The JDK's `NioSocketImpl` close path wakes that thread with `pthread_kill`, which QEMU user-mode emulation does not deliver reliably, and the resulting `IOException` failed the whole class.

The two accepted-socket closes immediately below already swallow `IOException` as best-effort teardown (*"closing on teardown"*); the `ServerSocket` close had simply been left unguarded. It now does the same, and `close()` no longer declares `IOException`.

## 2. The build stage ran once per target platform

`dockerhub.yml` builds `linux/amd64,linux/arm64` and the Dockerfile runs the full suite, so the tests ran a second time under emulation:

| Stage | Platform | `ForwardDeadlineTest` | Suite |
|---|---|---|---|
| `#26` | linux/amd64 (native) | 7 tests, 0 errors, 14.78s | ~60s |
| `#33` | linux/arm64 (QEMU) | **1 error**, 18.18s | ~330s |

This is why `maven.yml` (native amd64) has always been green.

The shaded jar is platform-independent — no `<classifier>` or `os-maven-plugin` anywhere in the poms, and both `rocksdbjni` and `grpc-netty-shaded` carry natives for every architecture — so the build stage is pinned to `$BUILDPLATFORM` and runs once on the runner. The runtime stage stays per-target, so the manifest is still genuinely multi-arch. Tests still gate the image, just once and natively.

## Verification

- Built the **unfixed** tree for `linux/arm64` → reproduces the CI stack trace exactly, same line numbers, exit 1.
- Same harness with only the guarded close → `Tests run: 7, Failures: 0, Errors: 0`, `BUILD SUCCESS`. So change 1 fixes it independently of change 2.
- `docker buildx build --platform linux/amd64,linux/arm64` → stage list contains only `[linux/amd64 build …]`; no arm64 build stage remains. One `mvn` run, `DONE 91.5s`.
- Both images start (`--help` banner); the arm64 image reports `arm64 linux`, confirming the amd64-built jar runs there.
- Native `mvn -pl service test -Dtest=ForwardDeadlineTest` passes; `validate-code-format` clean.

## Note

`dockerhub.yml` triggers on `release: published`, so 2.6 will not rebuild on its own — @jnioche is handling the tag move / new release once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)